### PR TITLE
Add support for entire database namespaces

### DIFF
--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -285,6 +285,19 @@ func (verifier *Verifier) CreateInitialTasks() error {
 			verifier.logger.Error().Msgf("%s", err)
 			return err
 		}
+		// Check for database names and append their collections
+		if NamespacesContainsDBName(verifier.srcNamespaces) {
+			namespaces, dbs := ParseDBNamespaces(verifier.srcNamespaces)
+
+			dbNamespaces, err := ListUserCollectionsForDBs(context.Background(), verifier.logger, verifier.srcClient, true /* include views */, dbs)
+			if err != nil {
+				verifier.logger.Error().Msgf("Failed to parse database namespaces: %s", err)
+				return err
+			}
+
+			verifier.srcNamespaces = append(namespaces, dbNamespaces...)
+			verifier.SetNamespaceMap()
+		}
 	}
 	isPrimary, err := verifier.CheckIsPrimary()
 	if err != nil {

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -37,8 +37,14 @@ func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *
 	}
 	logger.Debug().Msgf("All user databases: %+v", dbNames)
 
+	return ListUserCollectionsForDBs(ctx, logger, client, includeViews, dbNames)
+}
+
+func ListUserCollectionsForDBs(ctx context.Context, logger *logger.Logger, client *mongo.Client, includeViews bool,
+	databases []string) ([]string, error) {
+
 	collectionNamespaces := []string{}
-	for _, dbName := range dbNames {
+	for _, dbName := range databases {
 		db := client.Database(dbName)
 		filter := bson.D{{"name", bson.D{{"$nin", bson.A{ExcludedSystemCollRegex}}}}}
 		if !includeViews {

--- a/internal/verifier/util.go
+++ b/internal/verifier/util.go
@@ -154,3 +154,27 @@ func GetLastOpTimeAndSyncShardClusterTime(
 	t, i := rawOperationTime.Timestamp()
 	return &primitive.Timestamp{T: t, I: i}, nil
 }
+
+func NamespacesContainsDBName(namespaces []string) bool {
+	for _, namespace := range namespaces {
+		if strings.Index(namespace, ".") < 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func ParseDBNamespaces(namespaces []string) ([]string, []string) {
+	databases := []string{}
+	parsedNamespaces := []string{}
+	// strip database names from namespaces - db collections will be appended to the namespaces
+	for _, name := range namespaces {
+		db, coll := SplitNamespace(name)
+		if coll == "" {
+			databases = append(databases, db)
+		} else {
+			parsedNamespaces = append(parsedNamespaces, name)
+		}
+	}
+	return parsedNamespaces, databases
+}


### PR DESCRIPTION
For our usecase, we are doing migrations of entire DBs and would like to provide a DB name as a namespace and have the migration-verifier check all collections of the DB.


Here are the high level changes:
- Extracted a function to find all namespaces for a database from ListAllUserCollections in `list_namespaces.go`
- I've added some logic to the parsing of the --srcNamespace flag to detect database names in `check.go`
    - for each database found, use the new function to get all the collections in that DB and append it to the slice of srcNamespace
- added some util functions to help parse namespaces for DB names
