### PR TITLE
REP-2942 Verifier: Add user-defined query filtering to the initial check logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ go.sum
 migration_verifier
 internal/verifier/mongodb_exec/
 verifier_expansion.yml
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ go.sum
 migration_verifier
 internal/verifier/mongodb_exec/
 verifier_expansion.yml
-.idea/

--- a/internal/partitions/partition.go
+++ b/internal/partitions/partition.go
@@ -138,6 +138,9 @@ func (p *Partition) FindCmd(
 // If the passed-in buildinfo indicates a mongodb version < 5.0, type bracketing is not used.
 func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates bson.A) bson.D {
 	if p == nil {
+		if len(filterAndPredicates) > 0 {
+			return bson.D{{"filter", bson.D{{"$and", filterAndPredicates}}}}
+		}
 		return bson.D{}
 	}
 	findOptions := bson.D{}

--- a/internal/partitions/partition.go
+++ b/internal/partitions/partition.go
@@ -136,7 +136,8 @@ func (p *Partition) FindCmd(
 // partition. It is intended to allow the same partitioning to be used on different collections
 // (e.g. use the partitions on the source to read the destination for verification)
 // If the passed-in buildinfo indicates a mongodb version < 5.0, type bracketing is not used.
-func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates bson.A) bson.D {
+// filterAndPredicates is a slice of filter criteria that's used to construct the "filter" field in the find option.
+func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates []bson.D) bson.D {
 	if p == nil {
 		if len(filterAndPredicates) > 0 {
 			return bson.D{{"filter", bson.D{{"$and", filterAndPredicates}}}}

--- a/internal/partitions/partition_test.go
+++ b/internal/partitions/partition_test.go
@@ -132,7 +132,7 @@ func makeTestPartition() (Partition, bson.D) {
 
 func makeExpectedFilter(lower, upper interface{}) bson.D {
 	return bson.D{{"$and", bson.A{
-		bson.D{{"$and", bson.A{
+		bson.D{{"$and", []bson.D{
 			// All _id values >= lower bound.
 			bson.D{{"$expr", bson.D{
 				{"$gte", bson.A{
@@ -153,7 +153,7 @@ func makeExpectedFilter(lower, upper interface{}) bson.D {
 
 func makeExpectedFilterWithTypeBracketing(lower, upper interface{}) bson.D {
 	return bson.D{{"$and", bson.A{
-		bson.D{{"$and", bson.A{
+		bson.D{{"$and", []bson.D{
 			// All _id values >= lower bound.
 			bson.D{{"_id", bson.D{{"$gte", lower}}}},
 			// All _id values <= upper bound.

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -135,7 +135,6 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter bson.D, testCh
 	defer func() {
 		verifier.mux.Lock()
 		verifier.running = false
-		verifier.globalFilter = nil
 		verifier.mux.Unlock()
 	}()
 	var err error

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -397,7 +397,7 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 	return verifier.generation, verifier.lastGeneration
 }
 
-func (verifier *Verifier) maybeAppendGlobalFilter(predicates bson.A) bson.A {
+func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A) bson.A {
 	if verifier.globalFilter == nil {
 		return predicates
 	}
@@ -412,12 +412,12 @@ func (verifier *Verifier) getDocumentsCursor(ctx context.Context, collection *mo
 
 	if len(task.Ids) > 0 {
 		andPredicates = append(andPredicates, bson.D{{"_id", bson.M{"$in": task.Ids}}})
-		andPredicates = verifier.maybeAppendGlobalFilter(andPredicates)
+		andPredicates = verifier.maybeAppendGlobalFilterToPredicates(andPredicates)
 		findOptions = bson.D{
 			bson.E{"filter", bson.D{{"$and", andPredicates}}},
 		}
 	} else {
-		findOptions = task.QueryFilter.Partition.GetFindOptions(buildInfo, verifier.maybeAppendGlobalFilter(andPredicates))
+		findOptions = task.QueryFilter.Partition.GetFindOptions(buildInfo, verifier.maybeAppendGlobalFilterToPredicates(andPredicates))
 	}
 	if verifier.readPreference.Mode() != readpref.PrimaryMode {
 		runCommandOptions = runCommandOptions.SetReadPreference(verifier.readPreference)

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -397,7 +397,7 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 	return verifier.generation, verifier.lastGeneration
 }
 
-func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A) bson.A {
+func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates []bson.D) []bson.D {
 	if verifier.globalFilter == nil {
 		return predicates
 	}
@@ -408,7 +408,7 @@ func (verifier *Verifier) getDocumentsCursor(ctx context.Context, collection *mo
 	startAtTs *primitive.Timestamp, task *VerificationTask) (*mongo.Cursor, error) {
 	var findOptions bson.D
 	runCommandOptions := options.RunCmd()
-	var andPredicates bson.A
+	var andPredicates []bson.D
 
 	if len(task.Ids) > 0 {
 		andPredicates = append(andPredicates, bson.D{{"_id", bson.M{"$in": task.Ids}}})

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -191,17 +191,17 @@ func (suite *MultiDataVersionTestSuite) TestVerifierFetchDocuments() {
 	}
 
 	id := rand.Intn(1000)
-	_, err := verifier.srcClient.Database("keyhole").Collection("dealers").InsertMany(ctx, []interface{}{
+	_, err := verifier.srcClient.Database("keyhole").Collection("dealers").InsertMany(ctx, []any{
 		bson.D{{"_id", id}, {"num", 99}, {"name", "srcTest"}},
 		bson.D{{"_id", id + 1}, {"num", 101}, {"name", "srcTest"}},
 	})
 	suite.Require().NoError(err)
-	_, err = verifier.dstClient.Database("keyhole").Collection("dealers").InsertMany(ctx, []interface{}{
+	_, err = verifier.dstClient.Database("keyhole").Collection("dealers").InsertMany(ctx, []any{
 		bson.D{{"_id", id}, {"num", 99}, {"name", "dstTest"}},
 		bson.D{{"_id", id + 1}, {"num", 101}, {"name", "dstTest"}},
 	})
 	suite.Require().NoError(err)
-	task := &VerificationTask{Ids: []interface{}{id, id + 1}, QueryFilter: basicQueryFilter("keyhole.dealers")}
+	task := &VerificationTask{Ids: []any{id, id + 1}, QueryFilter: basicQueryFilter("keyhole.dealers")}
 
 	// Test fetchDocuments without global filter.
 	verifier.globalFilter = nil

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -55,14 +55,15 @@ const (
 
 // VerificationTask stores source cluster info
 type VerificationTask struct {
-	PrimaryKey  interface{}            `bson:"_id"`
-	Type        verificationTaskType   `bson:"type"`
-	Status      verificationTaskStatus `bson:"status"`
-	Generation  int                    `bson:"generation"`
-	Ids         []interface{}          `bson:"_ids"`
-	ID          int                    `bson:"id"`
-	FailedDocs  []VerificationResult   `bson:"failed_docs,omitempty"`
-	QueryFilter QueryFilter            `bson:"query_filter"          json:"query_filter"`
+	PrimaryKey interface{}            `bson:"_id"`
+	Type       verificationTaskType   `bson:"type"`
+	Status     verificationTaskStatus `bson:"status"`
+	Generation int                    `bson:"generation"`
+	Ids        []interface{}          `bson:"_ids"`
+	// Deprecated: VerificationTask ID field is ignored by the verifier.
+	ID          int                  `bson:"id"`
+	FailedDocs  []VerificationResult `bson:"failed_docs,omitempty"`
+	QueryFilter QueryFilter          `bson:"query_filter"          json:"query_filter"`
 
 	// DocumentCount is set when the verifier is done with the task
 	// (whether we found mismatches or not).

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -159,7 +159,7 @@ func main() {
 			}
 			if cCtx.Bool(checkOnly) {
 				verifier.WritesOff(ctx)
-				return verifier.CheckDriver(ctx)
+				return verifier.CheckDriver(ctx, nil)
 			} else {
 				return verifier.StartServer()
 			}


### PR DESCRIPTION
Added `globalFilter` field to the Verifier for user-defined filter. The filter is applied when fetching documents.