### PR TITLE
REP-2943 / REP-2944: Add `filter` parameter to `/check` endpoint and enable query filtering 

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Document filtering can be enabled by passing a `filter` parameter in the `check`
 ```
 curl -H "Content-Type: application/json" -X POST -d '{{"filter": {"inFilter": {"$ne": false}}}}' http://127.0.0.1:27020/api/v1/check
 ```
+If a checking is started with the above filter, the table below summarizes the verifier's behavior: 
+
+| Source Document                                   | Destination Document                              | Verifier's Behavior                         |
+|---------------------------------------------------|---------------------------------------------------|---------------------------------------------|
+| `{"_id": <id>, "inFilter": true, "diff": "src"}`  | `{"_id": <id>, "inFilter": true, "diff": "dst"}`  | ❗ (Finds a document with differing content) |
+| `{"_id": <id>, "inFilter": false, "diff": "src"}` | `{"_id": <id>, "inFilter": false, "diff": "dst"}` | ✅ (Skips a document)                        |
+| `{"_id": <id>, "inFilter": true, "diff": "src"}`  | `{"_id": <id>, "inFilter": false, "diff": "dst"}` | ❗ (Finds a document missing on Destination) |
+| `{"_id": <id>, "inFilter": false, "diff": "src"}` | `{"_id": <id>, "inFilter": true, "diff": "dst"}`  | ❗ (Finds a document missing on Source)      |
 
 # Checking Failures
 

--- a/internal/partitions/partition.go
+++ b/internal/partitions/partition.go
@@ -190,16 +190,16 @@ func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates []bson
 func (p *Partition) filterWithNoTypeBracketing() bson.D {
 	// We use $expr to avoid type bracketing and allow comparison of different _id types,
 	// and $literal to avoid MQL injection from an _id's value.
-	return bson.D{{"$and", bson.A{
+	return bson.D{{"$and", []bson.D{
 		// All _id values >= lower bound.
-		bson.D{{"$expr", bson.D{
+		{{"$expr", bson.D{
 			{"$gte", bson.A{
 				"$_id",
 				bson.D{{"$literal", p.Key.Lower}},
 			}},
 		}}},
 		// All _id values <= upper bound.
-		bson.D{{"$expr", bson.D{
+		{{"$expr", bson.D{
 			{"$lte", bson.A{
 				"$_id",
 				bson.D{{"$literal", p.Upper}},
@@ -212,10 +212,10 @@ func (p *Partition) filterWithNoTypeBracketing() bson.D {
 // partition.  This filter will not properly handle mixed-type _ids -- if the upper and lower
 // bounds are of different types (except minkey/maxkey), nothing will be returned.
 func (p *Partition) filterWithTypeBracketing() bson.D {
-	return bson.D{{"$and", bson.A{
+	return bson.D{{"$and", []bson.D{
 		// All _id values >= lower bound.
-		bson.D{{"_id", bson.D{{"$gte", p.Key.Lower}}}},
+		{{"_id", bson.D{{"$gte", p.Key.Lower}}}},
 		// All _id values <= upper bound.
-		bson.D{{"_id", bson.D{{"$lte", p.Upper}}}},
+		{{"_id", bson.D{{"$lte", p.Upper}}}},
 	}}}
 }

--- a/internal/partitions/partition.go
+++ b/internal/partitions/partition.go
@@ -137,7 +137,7 @@ func (p *Partition) FindCmd(
 // (e.g. use the partitions on the source to read the destination for verification)
 // If the passed-in buildinfo indicates a mongodb version < 5.0, type bracketing is not used.
 // filterAndPredicates is a slice of filter criteria that's used to construct the "filter" field in the find option.
-func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates []bson.D) bson.D {
+func (p *Partition) GetFindOptions(buildInfo *bson.M, filterAndPredicates bson.A) bson.D {
 	if p == nil {
 		if len(filterAndPredicates) > 0 {
 			return bson.D{{"filter", bson.D{{"$and", filterAndPredicates}}}}

--- a/internal/partitions/partition_test.go
+++ b/internal/partitions/partition_test.go
@@ -131,8 +131,8 @@ func makeTestPartition() (Partition, bson.D) {
 }
 
 func makeExpectedFilter(lower, upper interface{}) bson.D {
-	return bson.D{{"$and", []bson.D{
-		{{"$and", []bson.D{
+	return bson.D{{"$and", bson.A{
+		bson.D{{"$and", []bson.D{
 			// All _id values >= lower bound.
 			{{"$expr", bson.D{
 				{"$gte", bson.A{
@@ -152,8 +152,8 @@ func makeExpectedFilter(lower, upper interface{}) bson.D {
 }
 
 func makeExpectedFilterWithTypeBracketing(lower, upper interface{}) bson.D {
-	return bson.D{{"$and", []bson.D{
-		{{"$and", []bson.D{
+	return bson.D{{"$and", bson.A{
+		bson.D{{"$and", []bson.D{
 			// All _id values >= lower bound.
 			{{"_id", bson.D{{"$gte", lower}}}},
 			// All _id values <= upper bound.

--- a/internal/partitions/partition_test.go
+++ b/internal/partitions/partition_test.go
@@ -131,17 +131,17 @@ func makeTestPartition() (Partition, bson.D) {
 }
 
 func makeExpectedFilter(lower, upper interface{}) bson.D {
-	return bson.D{{"$and", bson.A{
-		bson.D{{"$and", []bson.D{
+	return bson.D{{"$and", []bson.D{
+		{{"$and", []bson.D{
 			// All _id values >= lower bound.
-			bson.D{{"$expr", bson.D{
+			{{"$expr", bson.D{
 				{"$gte", bson.A{
 					"$_id",
 					bson.D{{"$literal", lower}},
 				}},
 			}}},
 			// All _id values <= upper bound.
-			bson.D{{"$expr", bson.D{
+			{{"$expr", bson.D{
 				{"$lte", bson.A{
 					"$_id",
 					bson.D{{"$literal", upper}},
@@ -152,12 +152,12 @@ func makeExpectedFilter(lower, upper interface{}) bson.D {
 }
 
 func makeExpectedFilterWithTypeBracketing(lower, upper interface{}) bson.D {
-	return bson.D{{"$and", bson.A{
-		bson.D{{"$and", []bson.D{
+	return bson.D{{"$and", []bson.D{
+		{{"$and", []bson.D{
 			// All _id values >= lower bound.
-			bson.D{{"_id", bson.D{{"$gte", lower}}}},
+			{{"_id", bson.D{{"$gte", lower}}}},
 			// All _id values <= upper bound.
-			bson.D{{"_id", bson.D{{"$lte", upper}}}},
+			{{"_id", bson.D{{"$lte", upper}}}},
 		}}},
 	}}}
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -33,9 +33,9 @@ var verificationStatusCheckInterval time.Duration = 15 * time.Second
 // testChan is a pair of channels for coordinating generations in tests.
 // testChan[0] is a channel signalled when when a generation is complete
 // testChan[1] is a channel signalled when Check should continue with the next generation.
-func (verifier *Verifier) Check(ctx context.Context) {
+func (verifier *Verifier) Check(ctx context.Context, filter bson.D) {
 	go func() {
-		err := verifier.CheckDriver(ctx, nil)
+		err := verifier.CheckDriver(ctx, filter)
 		if err != nil {
 			verifier.logger.Fatal().Err(err).Msgf("Fatal error in generation %d", verifier.generation)
 		}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -33,7 +33,7 @@ var verificationStatusCheckInterval time.Duration = 15 * time.Second
 // testChan is a pair of channels for coordinating generations in tests.
 // testChan[0] is a channel signalled when when a generation is complete
 // testChan[1] is a channel signalled when Check should continue with the next generation.
-func (verifier *Verifier) Check(ctx context.Context, filter bson.D) {
+func (verifier *Verifier) Check(ctx context.Context, filter map[string]any) {
 	go func() {
 		err := verifier.CheckDriver(ctx, filter)
 		if err != nil {
@@ -122,7 +122,7 @@ func (verifier *Verifier) CheckWorker(ctx context.Context) error {
 	return nil
 }
 
-func (verifier *Verifier) CheckDriver(ctx context.Context, filter bson.D, testChan ...chan struct{}) error {
+func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any, testChan ...chan struct{}) error {
 	verifier.mux.Lock()
 	if verifier.running {
 		verifier.mux.Unlock()

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -645,7 +645,7 @@ func (verifier *Verifier) ProcessVerifyTask(workerNum int, task *VerificationTas
 					dataSizes = append(dataSizes, v.dataSize)
 				}
 				// Update ids of the failed task so that only ids from mismatches are reported.
-				// Ids of checked documents are discarded and hidden from report if they passed verification.
+				// Ids of matching documents are discarded and hidden from the mismatching documents report.
 				task.Ids = ids
 				err := verifier.InsertFailedCompareRecheckDocs(task.QueryFilter.Namespace, ids, dataSizes)
 				if err != nil {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -399,7 +399,7 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 
 func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates []bson.D) []bson.D {
 	if verifier.globalFilter == nil {
-		verifier.logger.Debug().Str("filter", fmt.Sprintf("%v", verifier.globalFilter)).Msg("No filter to append")
+		verifier.logger.Debug().Msg("No filter to append; globalFilter is nil")
 		return predicates
 	}
 	verifier.logger.Debug().Str("filter", fmt.Sprintf("%v", verifier.globalFilter)).Msg("Appending filter to find query")

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -135,7 +135,7 @@ type Verifier struct {
 	// A user-defined $match-compatible document-level query filter.
 	// The filter is applied to all namespaces in both initial checking and iterative checking.
 	// The verifier only checks documents within the filter.
-	globalFilter bson.D
+	globalFilter map[string]any
 }
 
 // VerificationStatus holds the Verification Status
@@ -397,7 +397,7 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 	return verifier.generation, verifier.lastGeneration
 }
 
-func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates []bson.D) []bson.D {
+func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A) bson.A {
 	if verifier.globalFilter == nil {
 		verifier.logger.Debug().Msg("No filter to append; globalFilter is nil")
 		return predicates
@@ -410,7 +410,7 @@ func (verifier *Verifier) getDocumentsCursor(ctx context.Context, collection *mo
 	startAtTs *primitive.Timestamp, task *VerificationTask) (*mongo.Cursor, error) {
 	var findOptions bson.D
 	runCommandOptions := options.RunCmd()
-	var andPredicates []bson.D
+	var andPredicates bson.A
 
 	if len(task.Ids) > 0 {
 		andPredicates = append(andPredicates, bson.D{{"_id", bson.M{"$in": task.Ids}}})

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -210,7 +210,7 @@ func (suite *MultiDataVersionTestSuite) TestVerifierFetchDocuments() {
 	expectTwoCommonDocs(srcDocumentMap, dstDocumentMap)
 
 	// Test fetchDocuments for ids with a global filter.
-	verifier.globalFilter = bson.D{{"num", bson.D{{"$lt", 100}}}}
+	verifier.globalFilter = map[string]any{"num": map[string]any{"$lt": 100}}
 	srcDocumentMap, dstDocumentMap, err = verifier.fetchDocuments(task)
 	suite.Require().NoError(err)
 	expectOneCommonDoc(srcDocumentMap, dstDocumentMap)
@@ -220,7 +220,7 @@ func (suite *MultiDataVersionTestSuite) TestVerifierFetchDocuments() {
 		Ns:       &partitions.Namespace{DB: "keyhole", Coll: "dealers"},
 		IsCapped: false,
 	}
-	verifier.globalFilter = bson.D{{"num", bson.D{{"$lt", 100}}}}
+	verifier.globalFilter = map[string]any{"num": map[string]any{"$lt": 100}}
 	srcDocumentMap, dstDocumentMap, err = verifier.fetchDocuments(task)
 	suite.Require().NoError(err)
 	expectOneCommonDoc(srcDocumentMap, dstDocumentMap)
@@ -1432,7 +1432,7 @@ func (suite *MultiDataVersionTestSuite) TestGenerationalRechecking() {
 func (suite *MultiDataVersionTestSuite) TestVerifierWithFilter() {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
-	filter := bson.D{{"inFilter", bson.D{{"$ne", false}}}}
+	filter := map[string]any{"inFilter": map[string]any{"$ne": false}}
 	verifier := buildVerifier(suite.T(), suite.srcMongoInstance, suite.dstMongoInstance, suite.metaMongoInstance)
 	verifier.SetSrcNamespaces([]string{"testDb1.testColl1"})
 	verifier.SetDstNamespaces([]string{"testDb2.testColl3"})

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1428,3 +1428,97 @@ func (suite *MultiDataVersionTestSuite) TestGenerationalRechecking() {
 	// there should be a failure from the src insert
 	suite.Require().Equal(VerificationStatus{TotalTasks: 1, FailedTasks: 1}, *status)
 }
+
+func (suite *MultiDataVersionTestSuite) TestVerifierWithFilter() {
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+
+	filter := bson.D{{"inFilter", bson.D{{"$ne", false}}}}
+	verifier := buildVerifier(suite.T(), suite.srcMongoInstance, suite.dstMongoInstance, suite.metaMongoInstance)
+	verifier.SetSrcNamespaces([]string{"testDb1.testColl1"})
+	verifier.SetDstNamespaces([]string{"testDb2.testColl3"})
+	verifier.SetNamespaceMap()
+	verifier.SetIgnoreBSONFieldOrder(true)
+
+	ctx := context.Background()
+
+	srcColl := suite.srcMongoClient.Database("testDb1").Collection("testColl1")
+	dstColl := suite.dstMongoClient.Database("testDb2").Collection("testColl3")
+
+	// Documents {_id: 1} should match, {_id: 2} should be ignored because it's not in the filter.
+	_, err := srcColl.InsertOne(ctx, bson.M{"_id": 1, "x": 42, "inFilter": true})
+	suite.Require().NoError(err)
+	_, err = srcColl.InsertOne(ctx, bson.M{"_id": 2, "x": 53, "inFilter": false})
+	suite.Require().NoError(err)
+	_, err = dstColl.InsertOne(ctx, bson.M{"_id": 1, "x": 42, "inFilter": true})
+	suite.Require().NoError(err)
+
+	checkDoneChan := make(chan struct{})
+	checkContinueChan := make(chan struct{})
+	go func() {
+		err := verifier.CheckDriver(ctx, filter, checkDoneChan, checkContinueChan)
+		suite.Require().NoError(err)
+	}()
+
+	waitForTasks := func() *VerificationStatus {
+		status, err := verifier.GetVerificationStatus()
+		suite.Require().NoError(err)
+
+		for status.TotalTasks == 0 && verifier.generation < 10 {
+			suite.T().Logf("TotalTasks is 0 (generation=%d); waiting another generation …", verifier.generation)
+			checkContinueChan <- struct{}{}
+			<-checkDoneChan
+			status, err = verifier.GetVerificationStatus()
+			suite.Require().NoError(err)
+		}
+		return status
+	}
+
+	// Wait for one generation to finish.
+	<-checkDoneChan
+	status := waitForTasks()
+	suite.Require().Equal(VerificationStatus{TotalTasks: 2, FailedTasks: 0, CompletedTasks: 2}, *status)
+
+	// Insert another document that is not in the filter.
+	_, err = srcColl.InsertOne(ctx, bson.M{"_id": 3, "x": 43, "inFilter": false})
+	suite.Require().NoError(err)
+
+	// Tell check to start the next generation.
+	checkContinueChan <- struct{}{}
+
+	// Wait for generation to finish.
+	<-checkDoneChan
+	status = waitForTasks()
+	// There should be no failures, since the inserted document is not in the filter.
+	suite.Require().Equal(VerificationStatus{TotalTasks: 1, CompletedTasks: 1}, *status)
+
+	// Now insert in the source, this should come up next generation.
+	_, err = srcColl.InsertOne(ctx, bson.M{"_id": 4, "x": 44, "inFilter": true})
+	suite.Require().NoError(err)
+
+	// Tell check to start the next generation.
+	checkContinueChan <- struct{}{}
+
+	// Wait for one generation to finish.
+	<-checkDoneChan
+	status = waitForTasks()
+
+	// There should be a failure from the src insert of a document in the filter.
+	suite.Require().Equal(VerificationStatus{TotalTasks: 1, FailedTasks: 1}, *status)
+
+	// Now patch up the destination.
+	_, err = dstColl.InsertOne(ctx, bson.M{"_id": 4, "x": 44, "inFilter": true})
+	suite.Require().NoError(err)
+
+	// Continue.
+	checkContinueChan <- struct{}{}
+
+	// Wait for it to finish again, this should be a clean run.
+	<-checkDoneChan
+	status = waitForTasks()
+
+	// There should be no failures now, since they are equivalent at this point in time.
+	suite.Require().Equal(VerificationStatus{TotalTasks: 1, CompletedTasks: 1}, *status)
+
+	// Turn writes off.
+	verifier.WritesOff(ctx)
+}

--- a/internal/verifier/web_server.go
+++ b/internal/verifier/web_server.go
@@ -197,13 +197,13 @@ func parseJsonMap(jsonMap map[string]any) (bson.D, error) {
 
 	raw, err := bson.Marshal(jsonMap)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to marshal json to bson.Raw")
 	}
 
 	var doc bson.D
 	err = bson.Unmarshal(raw, &doc)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to unmarshal bson.Raw filter to bson.D")
 	}
 
 	return doc, nil

--- a/internal/verifier/web_server_test.go
+++ b/internal/verifier/web_server_test.go
@@ -2,6 +2,7 @@ package verifier
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/stretchr/testify/suite"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 // WebServerTestSuite uses a mock verifier to test webserver endpoints.
@@ -20,14 +20,14 @@ type WebServerTestSuite struct {
 }
 
 type MockVerifier struct {
-	filter bson.D
+	filter map[string]any
 }
 
 func NewMockVerifier() *MockVerifier {
 	return &MockVerifier{}
 }
 
-func (verifier *MockVerifier) Check(ctx context.Context, filter bson.D) {
+func (verifier *MockVerifier) Check(ctx context.Context, filter map[string]any) {
 	verifier.filter = filter
 }
 func (verifier *MockVerifier) WritesOff(ctx context.Context) {}
@@ -57,7 +57,7 @@ func (suite *WebServerTestSuite) TestCheckEndPoint() {
 
 	router.ServeHTTP(w, req)
 	suite.Require().Equal(200, w.Code)
-	suite.Require().Equal(suite.mockVerifier.filter, bson.D{{"i", bson.D{{"$gt", int64(10)}}}})
+	suite.Require().Equal(map[string]any{"i": map[string]any{"$gt": json.Number("10")}}, suite.mockVerifier.filter)
 
 	invalidJSONInput1 := `{
 		"filter": "A string, not JSON."

--- a/internal/verifier/web_server_test.go
+++ b/internal/verifier/web_server_test.go
@@ -58,6 +58,28 @@ func (suite *WebServerTestSuite) TestCheckEndPoint() {
 	router.ServeHTTP(w, req)
 	suite.Require().Equal(200, w.Code)
 	suite.Require().Equal(suite.mockVerifier.filter, bson.D{{"i", bson.D{{"$gt", int64(10)}}}})
+
+	invalidJSONInput1 := `{
+		"filter": "A string, not JSON."
+	}`
+	w = httptest.NewRecorder()
+	req, err = http.NewRequest("POST", "/api/v1/check", strings.NewReader(invalidJSONInput1))
+	suite.Require().NoError(err)
+
+	router.ServeHTTP(w, req)
+	suite.Require().Equal(400, w.Code)
+	suite.Require().Contains(w.Body.String(), "error")
+
+	invalidJSONInput2 := `{
+		"filter": {
+	}`
+	w = httptest.NewRecorder()
+	req, err = http.NewRequest("POST", "/api/v1/check", strings.NewReader(invalidJSONInput2))
+	suite.Require().NoError(err)
+
+	router.ServeHTTP(w, req)
+	suite.Require().Equal(400, w.Code)
+	suite.Require().Contains(w.Body.String(), "error")
 }
 
 func TestWebServer(t *testing.T) {

--- a/internal/verifier/web_server_test.go
+++ b/internal/verifier/web_server_test.go
@@ -1,0 +1,46 @@
+package verifier
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type WebServerTestSuite struct {
+	suite.Suite
+	webServer *WebServer
+}
+
+func NewWebServerSuite() *WebServerTestSuite {
+	verifier := NewVerifier(VerifierSettings{})
+
+	return &WebServerTestSuite{
+		webServer: NewWebServer(27020, verifier, verifier.logger),
+	}
+}
+
+func (suite *WebServerTestSuite) TestCheckEndPoint() {
+	input := `{
+		"queryFilter": "{\"_id\": 0}"
+	}`
+	var checkRequest CheckRequest
+	suite.Require().NoError(json.Unmarshal([]byte(input), &checkRequest), "json should decode")
+	suite.Require().Equal(
+		CheckRequest{
+			Filter: "{\"_id\": 0}",
+		},
+		checkRequest,
+		"queryFilter should unmarshal correctly",
+	)
+
+	filter, err := unmarshalJsonStringToDocument(checkRequest.Filter)
+	suite.Require().NoError(err)
+	suite.Require().Equal(bson.D{{"_id", int32(0)}}, filter)
+}
+
+func TestWebServer(t *testing.T) {
+	testSuite := NewWebServerSuite()
+	suite.Run(t, testSuite)
+}


### PR DESCRIPTION
The `/check` endpoint takes a JSON filter. The verifier parses the JSON filter to `map[string]any`. The verifier starts a change stream without query filtering. The verifier generates a recheck document for a change event of a filtered document, but the document should be filtered out during fetching and thus not compared by the verifier. 