### PR TITLE
REP-3423 Migration-verifier should retry on Location28799 error while sampling documents

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -430,7 +430,8 @@ func getMidIDBounds(ctx context.Context, logger *logger.Logger, retryer *retry.R
 
 	// Get a cursor for the $sample and $bucketAuto aggregation.
 	var midIDBounds []interface{}
-	currCollName, err := retryer.RunForUUIDAndTransientErrors(ctx, logger, collName, func(ri *retry.Info, collName string) error {
+	agRetryer := retryer.WithErrorCodes(util.SampleTooManyDuplicates)
+	currCollName, err := agRetryer.RunForUUIDAndTransientErrors(ctx, logger, collName, func(ri *retry.Info, collName string) error {
 		ri.Log(logger.Logger, "aggregate", "source", srcDB.Name(), collName, "Retrieving mid _id partition bounds using $sample.")
 		cursor, cmdErr :=
 			srcDB.RunCommandCursor(ctx, retryer.RequestWithUUID(bson.D{

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -20,7 +20,8 @@ import (
 // `ErrorCode` newtype, but that requires a more invasive change to everything
 // that uses error codes.
 const (
-	LockFailed int = 107
+	LockFailed              int = 107
+	SampleTooManyDuplicates int = 28799
 )
 
 //

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -398,7 +398,7 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 }
 
 func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A) bson.A {
-	if verifier.globalFilter == nil {
+	if len(verifier.globalFilter) == 0 {
 		verifier.logger.Debug().Msg("No filter to append; globalFilter is nil")
 		return predicates
 	}


### PR DESCRIPTION
This PR adds `Location28799` error and make it retryable if running a pipeline with `$sample` stage.