### PR TITLE
REP-3431 Create partitions using _ids of filtered documents 

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -401,9 +401,7 @@ func GetDocumentCountAfterFiltering(ctx context.Context, logger *logger.Logger, 
 	if len(filter) > 0 {
 		pipeline = append(pipeline, bson.D{{"$match", filter}})
 	}
-	pipeline = append(pipeline, []bson.D{
-		{{"$count", "numFilteredDocs"}},
-	}...)
+	pipeline = append(pipeline, bson.D{{"$count", "numFilteredDocs"}})
 
 	currCollName, err := retryer.RunForUUIDAndTransientErrors(ctx, logger, collName, func(ri *retry.Info, collectionName string) error {
 		ri.Log(logger.Logger, "count", "source", srcDB.Name(), collectionName, "Counting filtered documents.")
@@ -421,7 +419,7 @@ func GetDocumentCountAfterFiltering(ctx context.Context, logger *logger.Logger, 
 		defer cursor.Close(ctx)
 		if cursor.Next(ctx) {
 			if err := cursor.Decode(&value); err != nil {
-				return errors.Wrapf(err, "failed to decode $count response for source namespace %s.%s after filter (%+v)", srcDB.Name(), collName, filter)
+				return errors.Wrapf(err, "failed to decode $count response (%+v) for source namespace %s.%s after filter (%+v)", cursor.Current, srcDB.Name(), collName, filter)
 			}
 		}
 		return nil

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -754,7 +754,7 @@ func (verifier *Verifier) partitionAndInspectNamespace(ctx context.Context, name
 	replicator1 := partitions.Replicator{ID: "verifier"}
 	replicators := []partitions.Replicator{replicator1}
 	partitionList, srcDocs, srcBytes, err := partitions.PartitionCollectionWithSize(
-		ctx, namespaceAndUUID, retryer, verifier.srcClient, replicators, verifier.logger, verifier.partitionSizeInBytes)
+		ctx, namespaceAndUUID, retryer, verifier.srcClient, replicators, verifier.logger, verifier.partitionSizeInBytes, verifier.globalFilter)
 	if err != nil {
 		return nil, nil, 0, 0, err
 	}


### PR DESCRIPTION
This PR adds a filter to the partition logic so that partition bounds are created by randomly sampling filtered documents. Number of partitions is calculated by multiplying a ratio of filtered documents with the entire-collection num of partitions. Since sampling of partition bounds will use filtered documents, they will be more evenly distributed across partitions. A more reasonable number of partitions will also be created if only a small subset of documents out of a collection are to be included in the filter. If the partitioning-after-filtering approach takes too long (timeout error), it will fall back to partitioning without filtering.