### PR TITLE
REP-2682 Fix failure report with no shown failures.

### DIFF
--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -75,9 +75,9 @@ func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuild
 
 	contentMismatch := 0
 	missing := 0
-	for _, v := range failedTasks {
-		contentMismatch += len(v.FailedDocs)
-		missing += len(v.Ids)
+	for _, task := range failedTasks {
+		contentMismatch += len(task.FailedDocs)
+		missing += len(task.Ids)
 	}
 
 	failureTypesTable.Append([]string{"Documents With Differing Content", fmt.Sprintf("%v", contentMismatch)})
@@ -87,12 +87,12 @@ func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuild
 
 	mismatchedDocsTable := tablewriter.NewWriter(strBuilder)
 	mismatchedDocsTableRows := types.ToNumericTypeOf(0, verifier.failureDisplaySize)
-	mismatchedDocsTable.SetHeader([]string{"ID", "Cluster", "Type", "Field", "Namespace", "Details"})
+	mismatchedDocsTable.SetHeader([]string{"ID", "Cluster", "Field", "Namespace", "Details"})
 
 	printAll := int64(contentMismatch) < (verifier.failureDisplaySize + int64(0.25*float32(verifier.failureDisplaySize)))
 OUTA:
-	for _, v := range failedTasks {
-		for _, f := range v.FailedDocs {
+	for _, task := range failedTasks {
+		for _, f := range task.FailedDocs {
 			if !printAll && mismatchedDocsTableRows >= verifier.failureDisplaySize {
 				break OUTA
 			}
@@ -124,8 +124,8 @@ OUTA:
 
 	printAll = int64(missing) < (verifier.failureDisplaySize + int64(0.25*float32(verifier.failureDisplaySize)))
 OUTB:
-	for _, v := range failedTasks {
-		for _, _id := range v.Ids {
+	for _, task := range failedTasks {
+		for _, _id := range task.Ids {
 			if !printAll && missingDocsTableRows >= verifier.failureDisplaySize {
 				break OUTB
 			}
@@ -133,8 +133,8 @@ OUTB:
 			missingDocsTableRows++
 			missingDocsTable.Append([]string{
 				fmt.Sprintf("%v", _id),
-				fmt.Sprintf("%v", v.QueryFilter.Namespace),
-				fmt.Sprintf("%v", v.QueryFilter.To),
+				fmt.Sprintf("%v", task.QueryFilter.Namespace),
+				fmt.Sprintf("%v", task.QueryFilter.To),
 			})
 		}
 	}

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -59,11 +59,19 @@ type VerificationTask struct {
 	Type       verificationTaskType   `bson:"type"`
 	Status     verificationTaskStatus `bson:"status"`
 	Generation int                    `bson:"generation"`
-	Ids        []interface{}          `bson:"_ids"`
+
+	// For failed tasks, this stores the document IDs missing on
+	// one cluster or the other.
+	Ids []interface{} `bson:"_ids"`
+
 	// Deprecated: VerificationTask ID field is ignored by the verifier.
-	ID          int                  `bson:"id"`
-	FailedDocs  []VerificationResult `bson:"failed_docs,omitempty"`
-	QueryFilter QueryFilter          `bson:"query_filter"          json:"query_filter"`
+	ID int `bson:"id"`
+
+	// For failed tasks, this stores details on documents that exist on
+	// both clusters but don’t match.
+	FailedDocs []VerificationResult `bson:"failed_docs,omitempty"`
+
+	QueryFilter QueryFilter `bson:"query_filter"          json:"query_filter"`
 
 	// DocumentCount is set when the verifier is done with the task
 	// (whether we found mismatches or not).
@@ -213,6 +221,7 @@ func (verifier *Verifier) UpdateVerificationTask(task *VerificationTask) error {
 			"failed_docs":            task.FailedDocs,
 			"source_documents_count": task.SourceDocumentCount,
 			"source_bytes_count":     task.SourceByteCount,
+			"_ids":                   task.Ids,
 		},
 	}
 	result, err := verifier.verificationTaskCollection().UpdateOne(ctx, bson.M{"_id": task.PrimaryKey}, updateFields)


### PR DESCRIPTION
It’s been common with the verifier for generation 0’s report to indicate “Mismatches found” but to show 0 documents that actually do mismatch. This changeset fixes that; specifically:

- UpdateVerificationTask() now persists the task’s Ids.
- ProcessVerifyTask() now populates Ids and FailedDocs as reportDocumentMismatches() expects.

Additionally, some comments are added to aid future maintenance, a few “unhelpful” iteration variables are renamed, and the leftover “Type” column header in the mismatched-documents table is removed.