### PR TITLE
REP-4197: fix collectionUUID not supported error for 5.0 versions

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -347,8 +347,6 @@ func GetSizeAndDocumentCount(ctx context.Context, logger *logger.Logger, retryer
 
 		cursor, driverErr := srcDB.RunCommandCursor(ctx, request)
 		if driverErr != nil {
-			merr := mongo.CommandError{}
-			errors.As(driverErr, &merr)
 			return driverErr
 		}
 

--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -347,6 +347,8 @@ func GetSizeAndDocumentCount(ctx context.Context, logger *logger.Logger, retryer
 
 		cursor, driverErr := srcDB.RunCommandCursor(ctx, request)
 		if driverErr != nil {
+			merr := mongo.CommandError{}
+			errors.As(driverErr, &merr)
 			return driverErr
 		}
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -181,12 +181,18 @@ func (r *Retryer) runRetryLoop(
 			continue
 		}
 
+		isPreV50CollectionUUIDNotSupportErr := func(err error) bool {
+			return util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID")
+		}
+		isV50CollectionUUIDNotSupportErr := func(err error) bool {
+			return util.HasServerErrorMessage(err, "collectionUUID is not supported")
+		}
+
 		// If this is the first time we've come across a failure to parse
 		// collection UUID, try again with the UUID elided (if the caller used
 		// RequestWithUUID).
 		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs &&
-			(util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID")) || // This error is returned in pre 5.0 server
-			util.HasServerErrorMessage(err, "collectionUUID is not supported") { // The error is returned in the v5.0 server
+			(isPreV50CollectionUUIDNotSupportErr(err) || isV50CollectionUUIDNotSupportErr(err)) {
 			logger.Debug().Msg("Server does not support UUIDs in 'aggregate'. Will retry without UUID.")
 			ri.attemptNumber++
 			r.aggregateDisallowsUUIDs = true

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -184,7 +184,9 @@ func (r *Retryer) runRetryLoop(
 		// If this is the first time we've come across a failure to parse
 		// collection UUID, try again with the UUID elided (if the caller used
 		// RequestWithUUID).
-		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs && util.HasServerErrorMessage(err, "collectionUUID") {
+		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs &&
+			(util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID")) || // This error is returned in pre 5.0 server
+			util.HasServerErrorMessage(err, "collectionUUID is not supported") { // The error is returned in the v5.0 server
 			logger.Debug().Msg("Server does not support UUIDs in 'aggregate'. Will retry without UUID.")
 			ri.attemptNumber++
 			r.aggregateDisallowsUUIDs = true

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -184,9 +184,9 @@ func (r *Retryer) runRetryLoop(
 		// If this is the first time we've come across a failure to parse
 		// collection UUID, try again with the UUID elided (if the caller used
 		// RequestWithUUID).
-		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs && util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID") {
-			logger.Debug().Msg("Server version (< 5.0) does not support UUIDs in 'aggregate'. Will retry without UUID.")
-			r.aggregateDisallowsUUIDs = true
+		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs && util.HasServerErrorMessage(err, "collectionUUID") {
+			logger.Debug().Msg("Server does not support UUIDs in 'aggregate'. Will retry without UUID.")
+			ri.attemptNumber++
 			continue
 		}
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -187,6 +187,7 @@ func (r *Retryer) runRetryLoop(
 		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs && util.HasServerErrorMessage(err, "collectionUUID") {
 			logger.Debug().Msg("Server does not support UUIDs in 'aggregate'. Will retry without UUID.")
 			ri.attemptNumber++
+			r.aggregateDisallowsUUIDs = true
 			continue
 		}
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -181,9 +181,13 @@ func (r *Retryer) runRetryLoop(
 			continue
 		}
 
+		// isPreV50CollectionUUIDNotSupportErr is the helper function to check the error returned from MongoDB pre-V5.0
+		// because of collectionUUID not supported.
 		isPreV50CollectionUUIDNotSupportErr := func(err error) bool {
 			return util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID")
 		}
+		// isV50CollectionUUIDNotSupportErr is the helper function to check the error returned from MongoDB V5.0
+		// because of collectionUUID not supported.
 		isV50CollectionUUIDNotSupportErr := func(err error) bool {
 			return util.HasServerErrorMessage(err, "collectionUUID is not supported")
 		}

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -285,6 +285,7 @@ func (suite *UnitTestSuite) TestRetryerWithEmptyCollectionName() {
 	suite.Equal("", name)
 }
 
+// Test fix for REP-4197
 func (suite *UnitTestSuite) TestRetryerWithUUIDNotSupportedError() {
 	retryer := New(0)
 
@@ -296,7 +297,11 @@ func (suite *UnitTestSuite) TestRetryerWithUUIDNotSupportedError() {
 	}
 	f := func(ri *Info, _ string) error {
 		attemptNumber = ri.attemptNumber
-		return cmdErr
+		if attemptNumber == 0 {
+			return cmdErr
+		} else {
+			return nil
+		}
 	}
 
 	r := retryer.SetRetryOnUUIDNotSupported()
@@ -304,6 +309,6 @@ func (suite *UnitTestSuite) TestRetryerWithUUIDNotSupportedError() {
 	_, err := r.RunForUUIDAndTransientErrors(suite.Context(), suite.Logger(), "bar", f)
 	// The aggregateDisallowsUUIDs will be set to True in the retry
 	suite.True(r.aggregateDisallowsUUIDs)
-	suite.Equal(cmdErr, err)
+	suite.Nil(err)
 	suite.Equal(1, attemptNumber)
 }

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -292,8 +292,6 @@ func (suite *UnitTestSuite) TestV50RetryerWithUUIDNotSupportedError() {
 	attemptNumber := 0
 	cmdErr := mongo.CommandError{
 		Message: "(Location4928902) collectionUUID is not supported on a mongos",
-		Name:    "FailedToParseError",
-		Code:    9,
 	}
 	f := func(ri *Info, _ string) error {
 		attemptNumber = ri.attemptNumber


### PR DESCRIPTION
In v5.0, the error "collectionUUID is not supported on a mongos" in the collstats command is not retried because the error is a "FailedToParse" error. I added the retry condition for the collectionUUID error in v5.0.