### PR TITLE
REP-2460 Dereference pointers when showing index discrepancies.

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -912,7 +912,7 @@ func compareIndexSpecifications(srcSpec *mongo.IndexSpecification, dstSpec *mong
 			Cluster:   ClusterTarget,
 			ID:        dstSpec.Name,
 			Field:     "ExpireAfterSeconds",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.ExpireAfterSeconds, dstSpec.ExpireAfterSeconds)})
+			Details:   Mismatch + fmt.Sprintf(" : src: %s, dst: %s", nilableToString(srcSpec.ExpireAfterSeconds), nilableToString(dstSpec.ExpireAfterSeconds))})
 	}
 
 	if !reflect.DeepEqual(srcSpec.Sparse, dstSpec.Sparse) {
@@ -921,7 +921,7 @@ func compareIndexSpecifications(srcSpec *mongo.IndexSpecification, dstSpec *mong
 			Cluster:   ClusterTarget,
 			ID:        dstSpec.Name,
 			Field:     "Sparse",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Sparse, dstSpec.Sparse)})
+			Details:   Mismatch + fmt.Sprintf(" : src: %s, dst: %s", nilableToString(srcSpec.Sparse), nilableToString(dstSpec.Sparse))})
 	}
 
 	if !reflect.DeepEqual(srcSpec.Unique, dstSpec.Unique) {
@@ -930,7 +930,7 @@ func compareIndexSpecifications(srcSpec *mongo.IndexSpecification, dstSpec *mong
 			Cluster:   ClusterTarget,
 			ID:        dstSpec.Name,
 			Field:     "Unique",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Unique, dstSpec.Unique)})
+			Details:   Mismatch + fmt.Sprintf(" : src: %s, dst: %s", nilableToString(srcSpec.Unique), nilableToString(dstSpec.Unique))})
 	}
 
 	if !reflect.DeepEqual(srcSpec.Clustered, dstSpec.Clustered) {
@@ -939,9 +939,17 @@ func compareIndexSpecifications(srcSpec *mongo.IndexSpecification, dstSpec *mong
 			Cluster:   ClusterTarget,
 			ID:        dstSpec.Name,
 			Field:     "Clustered",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Clustered, dstSpec.Clustered)})
+			Details:   Mismatch + fmt.Sprintf(" : src: %s, dst: %s", nilableToString(srcSpec.Clustered), nilableToString(dstSpec.Clustered))})
 	}
 	return results
+}
+
+func nilableToString[T any](ptr *T) string {
+	if ptr == nil {
+		return "(unset)"
+	}
+
+	return fmt.Sprintf("%v", *ptr)
 }
 
 func (verifier *Verifier) ProcessCollectionVerificationTask(ctx context.Context, workerNum int, task *VerificationTask) {

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1106,6 +1106,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "KeysDocument", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 
 	// Shortening the key mattes
@@ -1121,6 +1122,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "KeysDocument", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 
 	var expireAfterSeconds30, expireAfterSeconds0_1, expireAfterSeconds0_2 int32
@@ -1162,6 +1164,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testIndex", result.ID)
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 		diffFields = append(diffFields, result.Field)
 	}
 	assert.ElementsMatch(t, []string{"Sparse", "Unique", "ExpireAfterSeconds", "Clustered"}, diffFields)
@@ -1175,6 +1178,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "ExpireAfterSeconds", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 
 	fullIndexSpec3 = fullIndexSpec2
@@ -1186,6 +1190,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "Sparse", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 
 	fullIndexSpec3 = fullIndexSpec2
@@ -1197,6 +1202,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "Unique", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 
 	fullIndexSpec3 = fullIndexSpec2
@@ -1208,6 +1214,7 @@ func TestVerifierCompareIndexSpecs(t *testing.T) {
 		assert.Equal(t, "testDB.testIndex", result.NameSpace)
 		assert.Equal(t, "Clustered", result.Field)
 		assert.Regexp(t, regexp.MustCompile("^"+Mismatch), result.Details)
+		assert.NotRegexp(t, regexp.MustCompile("0x"), result.Details)
 	}
 }
 


### PR DESCRIPTION
Previously we’d show messages like `Mismatch : src: 0xc0a8a7ca7e` when index properties mismatched. This fixes that.