### PR TITLE
REP-4496: Legacy migration-verifer should use primary readpref

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ migration-verifier … --srcNamespace foo.bar --srcNamespace foo.baz --dstNamesp
 
 will result in the mapping `foo.bar <-> foo.bar1, foo.baz <-> bar.bar2`
 
-By default, the verifier will read from all nodes (primary and secondary).  This can be changed with option “`--readPreference <preference>`” where `<preference>` can be “`primary`”, “`secondary`”, “`primaryPreferred`”, “`secondaryPreferred`”, or “`nearest`” (same as default).  
+By default, the verifier will read from all nodes (primary and secondary).  This can be changed with option “`--readPreference <preference>`” where `<preference>` can be “`primary`” (same as default), “`secondary`”, “`primaryPreferred`”, “`secondaryPreferred`”, or “`nearest`”.  
 
 To set a port, use `--serverPort <port number>`. The default is 27020.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ migration-verifier … --srcNamespace foo.bar --srcNamespace foo.baz --dstNamesp
 
 will result in the mapping `foo.bar <-> foo.bar1, foo.baz <-> bar.bar2`
 
-By default, the verifier will read from all nodes (primary and secondary).  This can be changed with option “`--readPreference <preference>`” where `<preference>` can be “`primary`” (same as default), “`secondary`”, “`primaryPreferred`”, “`secondaryPreferred`”, or “`nearest`”.  
+By default, the verifier will read from the primary node.  This can be changed with option “`--readPreference <preference>`” where `<preference>` can be “`primary`” (same as default), “`secondary`”, “`primaryPreferred`”, “`secondaryPreferred`”, or “`nearest`”.  
 
 To set a port, use `--serverPort <port number>`. The default is 27020.
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -188,7 +188,7 @@ func NewVerifier(settings VerifierSettings) *Verifier {
 	return &Verifier{
 		phase:                 Idle,
 		numWorkers:            NumWorkers,
-		readPreference:        readpref.Nearest(),
+		readPreference:        readpref.Primary(),
 		partitionSizeInBytes:  400 * 1024 * 1024,
 		failureDisplaySize:    DefaultFailureDisplaySize,
 		changeStreamEnderChan: make(chan struct{}),

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -120,7 +120,7 @@ func main() {
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:  readPreference,
-			Value: "nearest",
+			Value: "primary",
 			Usage: "Read preference for reading data from clusters. " +
 				"May be 'primary', 'secondary', 'primaryPreferred', 'secondaryPreferred', or 'nearest'",
 		}),


### PR DESCRIPTION
We have seen issues with nearest read preference (e.g. [REP-4294](https://jira.mongodb.org/browse/REP-4294), [SERVER-87673](https://jira.mongodb.org/browse/SERVER-87673)). The defensive thing to do will be to set primary read pref by enforcing usage of primary read preference in the verifier.