### PR TITLE
Clarify reporting of change events in progress logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ The migration-verifier is also rather resource-hungry. To mitigate this, try lim
 
 - The verifier, during its first generation, may report a confusing “Mismatches found” but then report 0 problems. This is a reporting bug in mongosync; if you see it, check the documents in `migration_verification_metadata.verification_tasks` for generation 1 (not generation 0).
 
+- The verifier conflates “missing” documents with change events: if it finds a document missing and receives a change event for another document, the verifier records those together in its metadata. As a result, the verifier’s reporting can cause confusion: what its log calls “missing or changed” documents aren’t, in fact, necessarily failures; they’re just pending recheck.
+
 # Limitations
 
 - The verifier’s iterative process can handle data changes while it is running, until you hit the writesOff endpoint.  However, it cannot handle DDL commands.  If the verifier receives a DDL change stream event (drop, dropDatabase, rename), the verification will fail.  If an untracked DDL event (create, createIndexes, dropIndexes, modify) occurs, the verifier may miss the change.


### PR DESCRIPTION
3 things cause migration-verifier to recheck a document:
1. document is mismatched between source & destination
2. document is missing on source or destination
3. document changed on source and needs a recheck

Unfortunately, the verifier’s metadata persists 2 and 3 together, such that the verifier’s progress logs can’t differentiate them. The current progress logs, though, report them all as “missing”, which can confuse users.

This changeset updates the logging verbiage to be clearer that the “missing documents” totals are really “missing or changed documents”.