### PR TITLE
Reduce memory usage of the migration verifier

### DIFF
--- a/internal/documentmap/documentmap.go
+++ b/internal/documentmap/documentmap.go
@@ -199,8 +199,8 @@ func (m *Map) getMapKey(doc *bson.Raw) MapKey {
 	var keyBuffer bytes.Buffer
 	for _, keyName := range m.fieldNames {
 		value := doc.Lookup(keyName)
-		keyBuffer.WriteString(string(value.Type))
-		keyBuffer.WriteString(string(value.Value))
+		keyBuffer.WriteByte(byte(value.Type))
+		keyBuffer.Write(value.Value)
 	}
 
 	return MapKey(keyBuffer.String())

--- a/internal/documentmap/documentmap.go
+++ b/internal/documentmap/documentmap.go
@@ -199,6 +199,7 @@ func (m *Map) getMapKey(doc *bson.Raw) MapKey {
 	var keyBuffer bytes.Buffer
 	for _, keyName := range m.fieldNames {
 		value := doc.Lookup(keyName)
+		keyBuffer.Grow(1 + len(value.Value))
 		keyBuffer.WriteByte(byte(value.Type))
 		keyBuffer.Write(value.Value)
 	}

--- a/internal/documentmap/documentmap.go
+++ b/internal/documentmap/documentmap.go
@@ -115,14 +115,14 @@ func (m *Map) ImportFromCursor(ctx context.Context, cursor *mongo.Cursor) error 
 		nDocumentsReturned++
 		bytesReturned += (int64)(len(cursor.Current))
 
-		m.addDocument(cursor.Current)
+		m.copyAndAddDocument(cursor.Current)
 	}
 	m.logger.Debug().Msgf("Find returned %d documents containing %d bytes", nDocumentsReturned, bytesReturned)
 
 	return nil
 }
 
-func (m *Map) addDocument(rawDoc bson.Raw) {
+func (m *Map) copyAndAddDocument(rawDoc bson.Raw) {
 	rawDocCopy := make(bson.Raw, len(rawDoc))
 	copy(rawDocCopy, rawDoc)
 

--- a/internal/documentmap/documentmap.go
+++ b/internal/documentmap/documentmap.go
@@ -28,7 +28,9 @@ package documentmap
 // to try to duplicate that here.)
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/10gen/migration-verifier/internal/logger"
@@ -103,7 +105,7 @@ func (m *Map) ImportFromCursor(ctx context.Context, cursor *mongo.Cursor) error 
 	for cursor.Next(ctx) {
 		err := cursor.Err()
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			if errors.Is(err, mongo.ErrNoDocuments) {
 				break
 			}
 
@@ -111,15 +113,9 @@ func (m *Map) ImportFromCursor(ctx context.Context, cursor *mongo.Cursor) error 
 		}
 
 		nDocumentsReturned++
+		bytesReturned += (int64)(len(cursor.Current))
 
-		var rawDoc bson.Raw
-		err = cursor.Decode(&rawDoc)
-		if err != nil {
-			return err
-		}
-		bytesReturned += (int64)(len(rawDoc))
-
-		m.addDocument(rawDoc)
+		m.addDocument(cursor.Current)
 	}
 	m.logger.Debug().Msgf("Find returned %d documents containing %d bytes", nDocumentsReturned, bytesReturned)
 
@@ -200,11 +196,12 @@ func (m *Map) TotalDocsBytes() types.ByteCount {
 
 // called in tests as well as internally
 func (m *Map) getMapKey(doc *bson.Raw) MapKey {
-	key := MapKey("")
+	var keyBuffer bytes.Buffer
 	for _, keyName := range m.fieldNames {
 		value := doc.Lookup(keyName)
-		key += MapKey(value.Type) + MapKey(value.Value)
+		keyBuffer.WriteString(string(value.Type))
+		keyBuffer.WriteString(string(value.Value))
 	}
 
-	return key
+	return MapKey(keyBuffer.String())
 }


### PR DESCRIPTION
Generation 0 heap pprof file has shown high memory usage by the `ImportFromCursor` function itself. This PR attempts to improve the memory usage of the migration verifier by:

- removing an extra BSON decode step before storing a document to a doc map in `ImportFromCursor`
- using a byte buffer when constructing map keys in `getMapKey` 