### PR TITLE
REP-5201 Fix change stream iteration.

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -120,7 +120,8 @@ func (verifier *Verifier) iterateChangeStream(ctx context.Context, cs *mongo.Cha
 		var changeStreamEnded bool
 
 		select {
-		// if the context is cancelled return immmediately
+
+		// If the context is canceled, return immmediately.
 		case <-ctx.Done():
 			return
 


### PR DESCRIPTION
PR #30 added persistence of the change stream’s resume token but mishandled some of the refactoring by making every change stream iteration loop read all events.

This restores the intended logic: check for context cancellation or the end of the change stream after each event.