### PR TITLE
REP-5277 Parallelize persistence of rechecks.

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -90,6 +90,10 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 		}
 	}
 
+	verifier.logger.Debug().
+		Int("count", len(docIDs)).
+		Msg("Persisting rechecks for change events.")
+
 	return verifier.insertRecheckDocs(ctx, dbNames, collNames, docIDs, dataSizes)
 }
 

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -2,6 +2,7 @@ package verifier
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/types"
@@ -63,6 +64,10 @@ func (verifier *Verifier) InsertFailedCompareRecheckDocs(
 // This will split the given slice into *roughly* the given number of chunks.
 // It may end up being more or fewer, but it should be pretty close.
 func splitToChunks[T any, Slice ~[]T](elements Slice, numChunks int) []Slice {
+	if numChunks < 1 {
+		panic(fmt.Sprintf("numChunks (%v) should be >=1", numChunks))
+	}
+
 	elsPerChunk := len(elements) / numChunks
 
 	if elsPerChunk == 0 {

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -47,6 +47,10 @@ func (verifier *Verifier) InsertFailedCompareRecheckDocs(
 		collNames[i] = collName
 	}
 
+	verifier.logger.Debug().
+		Int("count", len(documentIDs)).
+		Msg("Persisting rechecks for mismatched or missing documents.")
+
 	return verifier.insertRecheckDocs(
 		context.Background(),
 		dbNames,


### PR DESCRIPTION
We receive events and enqueue rechecks in the same thread. When there are 1,000s of rechecks to enqueue at once, though, we need faster throughput than a single thread will allow.

This changeset fixes that by parallelizing the enqueueing of rechecks.