### PR TITLE
REP-5283 Report change event document sizes accurately.

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -108,7 +108,7 @@ func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
 	if len(verifier.srcNamespaces) == 0 {
 		pipeline = []bson.D{{{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
 	} else {
-		filter := []bson.D{}
+		filter := bson.A{}
 		for _, ns := range verifier.srcNamespaces {
 			db, coll := SplitNamespace(ns)
 			filter = append(filter, bson.D{{"ns", bson.D{{"db", db}, {"coll", coll}}}})

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -102,6 +102,13 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 	return verifier.insertRecheckDocs(ctx, dbNames, collNames, docIDs, dataSizes)
 }
 
+// GetChangeStreamFilter returns an aggregation pipeline that filters
+// namespaces as per configuration.
+//
+// NB: Ideally we could make the change stream give $bsonSize(fullDocument)
+// and omit fullDocument, but $bsonSize was new in MongoDB 4.4, and we still
+// want to verify migrations from 4.2. fullDocument is unlikely to be a
+// bottleneck anyway.
 func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
 	if len(verifier.srcNamespaces) == 0 {
 		return []bson.D{{bson.E{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -19,12 +19,12 @@ const fauxDocSizeForDeleteEvents = 1024
 
 // ParsedEvent contains the fields of an event that we have parsed from 'bson.Raw'.
 type ParsedEvent struct {
-	ID          interface{}          `bson:"_id"`
-	OpType      string               `bson:"operationType"`
-	Ns          *Namespace           `bson:"ns,omitempty"`
-	DocKey      DocKey               `bson:"documentKey,omitempty"`
-	DocSize     *int                 `bson:"fullDocument,omitempty"`
-	ClusterTime *primitive.Timestamp `bson:"clusterTime,omitEmpty"`
+	ID           interface{}          `bson:"_id"`
+	OpType       string               `bson:"operationType"`
+	Ns           *Namespace           `bson:"ns,omitempty"`
+	DocKey       DocKey               `bson:"documentKey,omitempty"`
+	FullDocument bson.Raw             `bson:"fullDocument,omitempty"`
+	ClusterTime  *primitive.Timestamp `bson:"clusterTime,omitEmpty"`
 }
 
 func (pe *ParsedEvent) String() string {
@@ -82,13 +82,13 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 			collNames[i] = changeEvent.Ns.Coll
 			docIDs[i] = changeEvent.DocKey.ID
 
-			if changeEvent.DocSize == nil {
+			if changeEvent.FullDocument == nil {
 				// This happens for deletes and for some updates.
 				// The document is probably, but not necessarily, deleted.
 				dataSizes[i] = fauxDocSizeForDeleteEvents
 			} else {
 				// This happens for inserts, replaces, and most updates.
-				dataSizes[i] = *changeEvent.DocSize
+				dataSizes[i] = len(changeEvent.FullDocument)
 			}
 		default:
 			return UnknownEventError{Event: &changeEvent}
@@ -103,52 +103,16 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 }
 
 func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
-	var pipeline mongo.Pipeline
-
 	if len(verifier.srcNamespaces) == 0 {
-		pipeline = []bson.D{{bson.E{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
-	} else {
-		filter := bson.A{}
-		for _, ns := range verifier.srcNamespaces {
-			db, coll := SplitNamespace(ns)
-			filter = append(filter, bson.D{{"ns", bson.D{{"db", db}, {"coll", coll}}}})
-		}
-		stage := bson.D{{"$match", bson.D{{"$or", filter}}}}
-		pipeline = []bson.D{stage}
+		return []bson.D{{bson.E{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
 	}
-
-	return append(
-		pipeline,
-		[]bson.D{
-
-			// Add a documentSize field.
-			{
-				{"$addFields", bson.D{
-					{"documentSize", bson.D{
-						{"$cond", bson.D{
-							{"if", bson.D{
-								{"$ne", bson.A{
-									"missing",
-									bson.D{{"$type", "$fullDocument"}},
-								}},
-							}}, // fullDocument exists
-							{"then", bson.D{{"$bsonSize", "$fullDocument"}}},
-							{"else", "$$REMOVE"},
-						}},
-					}},
-				}},
-			},
-
-			// Remove the fullDocument field since a) we don't use it, and
-			// b) it's big.
-			{
-				{"$project", bson.D{
-					{"fullDocument", 0},
-				}},
-			},
-		}...,
-	)
-
+	filter := bson.A{}
+	for _, ns := range verifier.srcNamespaces {
+		db, coll := SplitNamespace(ns)
+		filter = append(filter, bson.D{{"ns", bson.D{{"db", db}, {"coll", coll}}}})
+	}
+	stage := bson.D{{"$match", bson.D{{"$or", filter}}}}
+	return []bson.D{stage}
 }
 
 func (verifier *Verifier) iterateChangeStream(ctx context.Context, cs *mongo.ChangeStream) {

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -106,7 +106,7 @@ func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
 	var pipeline mongo.Pipeline
 
 	if len(verifier.srcNamespaces) == 0 {
-		pipeline = []bson.D{{{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
+		pipeline = []bson.D{{bson.E{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
 	} else {
 		filter := bson.A{}
 		for _, ns := range verifier.srcNamespaces {

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -106,7 +106,7 @@ func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
 	var pipeline mongo.Pipeline
 
 	if len(verifier.srcNamespaces) == 0 {
-		pipeline = []bson.D{{bson.E{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
+		pipeline = []bson.D{{{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
 	} else {
 		filter := bson.A{}
 		for _, ns := range verifier.srcNamespaces {

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -108,7 +108,7 @@ func (verifier *Verifier) GetChangeStreamFilter() []bson.D {
 	if len(verifier.srcNamespaces) == 0 {
 		pipeline = []bson.D{{{"$match", bson.D{{"ns.db", bson.D{{"$ne", verifier.metaDBName}}}}}}}
 	} else {
-		filter := bson.A{}
+		filter := []bson.D{}
 		for _, ns := range verifier.srcNamespaces {
 			db, coll := SplitNamespace(ns)
 			filter = append(filter, bson.D{{"ns", bson.D{{"db", db}, {"coll", coll}}}})

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/10gen/migration-verifier/internal/testutil"
 	"github.com/10gen/migration-verifier/internal/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -49,7 +48,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 			DB:   "the",
 			Coll: "namespace",
 		},
-		FullDocument: testutil.MustMarshal(bson.D{{"foo", 1}}),
+		DocSize: func() *int { v := 123; return &v }(),
 	}
 
 	err := verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event})
@@ -65,7 +64,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 					CollectionName: "namespace",
 					DocumentID:     "theDocID",
 				},
-				DataSize: len(event.FullDocument),
+				DataSize: *event.DocSize,
 			},
 		},
 		recheckDocs,

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/10gen/migration-verifier/internal/testutil"
 	"github.com/10gen/migration-verifier/internal/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -48,6 +49,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 			DB:   "the",
 			Coll: "namespace",
 		},
+		FullDocument: testutil.MustMarshal(bson.D{{"foo", 1}}),
 	}
 
 	err := verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event})
@@ -63,7 +65,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 					CollectionName: "namespace",
 					DocumentID:     "theDocID",
 				},
-				DataSize: maxBSONObjSize,
+				DataSize: len(event.FullDocument),
 			},
 		},
 		recheckDocs,

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/10gen/migration-verifier/internal/testutil"
 	"github.com/10gen/migration-verifier/internal/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -48,7 +49,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 			DB:   "the",
 			Coll: "namespace",
 		},
-		DocSize: func() *int { v := 123; return &v }(),
+		FullDocument: testutil.MustMarshal(bson.D{{"foo", 1}}),
 	}
 
 	err := verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event})
@@ -64,7 +65,7 @@ func (suite *MultiMetaVersionTestSuite) TestFailedCompareThenReplace() {
 					CollectionName: "namespace",
 					DocumentID:     "theDocID",
 				},
-				DataSize: *event.DocSize,
+				DataSize: len(event.FullDocument),
 			},
 		},
 		recheckDocs,


### PR DESCRIPTION
Previously all change events’ document sizes were recorded “pessimistically” as 16 MiB. This helped to avoid OOMs. It came at a cost, though: when the recheck queue is converted to recheck tasks, those tasks are sized so as to approximate the configured partition size. Thus, if the partition size was 400 MiB (the default), only 25 change events could fit into a recheck task. If there are 250,000 pending rechecks—not unfeasible for a large, busy data set after generation 0—that’s 10,000 tasks to create and perform, which is inefficient.

PR #34 all but eliminates the OOMs, which undercuts that “pessimism”’s benefit. It makes more sense now to allow for the possibility of large recheck tasks in order to minimize the number of tasks. Moreover, we can get pretty good confidence about document sizes from change events anyway:
- Insert & replace events always include the `fullDocument`.
- Update events can be configured to include the current `fullDocument`.
- Delete events refer to a document that probably no longer exists, so we can safely estimate its size to be “small”.

This changeset, then:
1. configures the change stream to include `fullDocument` in update events, and
2. records document sizes from the change event.