### PR TITLE
Ensure parallelization of rechecks by capping recheck task size.

### DIFF
--- a/internal/reportutils/reportutils.go
+++ b/internal/reportutils/reportutils.go
@@ -15,10 +15,11 @@ import (
 
 const decimalPrecision = 2
 
-// This could include signed ints, but we have no need for now.
-// The bigger requirement is that it exclude uint8.
+// num16Plus is like realNum, but it excludes 8-bit int/uint.
 type num16Plus interface {
-	constraints.Float | ~uint | ~uint16 | ~uint32 | ~uint64
+	constraints.Float |
+		~uint | ~uint16 | ~uint32 | ~uint64 |
+		~int | ~int16 | ~int32 | ~int64
 }
 
 type realNum interface {
@@ -177,4 +178,10 @@ func FindBestUnit[T num16Plus](count T) DataUnit {
 	}
 
 	return biggestUnit
+}
+
+// FmtBytes is a convenience that combines BytesToUnit with FindBestUnit.
+// Use it to format a single count of bytes.
+func FmtBytes[T num16Plus](count T) string {
+	return BytesToUnit(count, FindBestUnit(count))
 }

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -19,11 +19,16 @@ const (
 	recheckQueue                  = "recheckQueue"
 	maxBSONObjSize                = 16 * 1024 * 1024
 	recheckInserterThreadsSoftMax = 100
+	maxIdsPerRecheckTask          = 12 * 1024 * 1024
 )
 
 // RecheckPrimaryKey stores the implicit type of recheck to perform
 // Currently, we only handle document mismatches/change stream updates,
 // so DatabaseName, CollectionName, and DocumentID must always be specified.
+//
+// NB: Order is important here so that, within a given generation,
+// sorting by _id will guarantee that all rechecks for a given
+// namespace appear consecutively.
 type RecheckPrimaryKey struct {
 	Generation     int         `bson:"generation"`
 	DatabaseName   string      `bson:"db"`
@@ -195,11 +200,14 @@ func (verifier *Verifier) getPreviousGenerationWhileLocked() int {
 func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 	prevGeneration := verifier.getPreviousGenerationWhileLocked()
 
+	findFilter := bson.D{{"_id.generation", prevGeneration}}
+
+	verifier.logger.Debug().
+		Int("priorGeneration", prevGeneration).
+		Msgf("Counting prior generation’s enqueued rechecks.")
+
 	recheckColl := verifier.verificationDatabase().Collection(recheckQueue)
-	rechecksCount, err := recheckColl.CountDocuments(
-		ctx,
-		bson.D{{"_id.generation", prevGeneration}},
-	)
+	rechecksCount, err := recheckColl.CountDocuments(ctx, findFilter)
 	if err != nil {
 		return errors.Wrapf(err,
 			"failed to count generation %d’s rechecks",
@@ -220,30 +228,49 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 	// 3) The number of documents exceeds $rechecksCount/$numWorkers. We do
 	//    this to prevent one thread from doing all of the rechecks.
 
-	prevDBName, prevCollName := "", ""
+	var prevDBName, prevCollName string
 	var idAccum []interface{}
 	var idLenAccum int
 	var dataSizeAccum int64
-	const maxIdsSize = 12 * 1024 * 1024
+
 	maxDocsPerTask := rechecksCount / int64(verifier.numWorkers)
 
 	if maxDocsPerTask < int64(verifier.numWorkers) {
 		maxDocsPerTask = int64(verifier.numWorkers)
 	}
 
+	// The sort here is important because the recheck _id is an embedded
+	// document that includes the namespace. Thus, all rechecks for a given
+	// namespace will be consecutive in this query’s result.
 	cursor, err := recheckColl.Find(
-		ctx, bson.D{{"_id.generation", prevGeneration}}, options.Find().SetSort(bson.D{{"_id", 1}}))
+		ctx,
+		findFilter,
+		options.Find().SetSort(bson.D{{"_id", 1}}),
+	)
 	if err != nil {
 		return err
 	}
 	defer cursor.Close(ctx)
 
-	createRecheckTask := func() error {
+	persistBufferedRechecks := func() error {
+		if len(idAccum) == 0 {
+			return nil
+		}
+
 		namespace := prevDBName + "." + prevCollName
 
-		err := verifier.InsertDocumentRecheckTask(idAccum, types.ByteCount(dataSizeAccum), namespace)
+		err := verifier.InsertDocumentRecheckTask(
+			idAccum,
+			types.ByteCount(dataSizeAccum),
+			namespace,
+		)
 		if err != nil {
-			return err
+			return errors.Wrapf(
+				err,
+				"failed to create a %d-document recheck task for collection %#q",
+				len(idAccum),
+				namespace,
+			)
 		}
 
 		verifier.logger.Debug().
@@ -263,27 +290,34 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		idRaw := cursor.Current.Lookup("_id", "docID")
 		idLen := len(idRaw.Value)
 
+		// We persist rechecks if any of these happen:
+		// - the namespace has changed
+		// - we’ve reached the per-task recheck maximum
+		// - the buffered document IDs’ size exceeds the per-task maximum
+		// - the buffered documents exceed the partition size
+		//
 		if doc.PrimaryKey.DatabaseName != prevDBName ||
 			doc.PrimaryKey.CollectionName != prevCollName ||
 			int64(len(idAccum)) > maxDocsPerTask ||
-			idLenAccum >= maxIdsSize ||
+			idLenAccum >= maxIdsPerRecheckTask ||
 			dataSizeAccum >= verifier.partitionSizeInBytes {
 
-			if len(idAccum) > 0 {
-				err := createRecheckTask()
-				if err != nil {
-					return err
-				}
+			err := persistBufferedRechecks()
+			if err != nil {
+				return err
 			}
+
 			prevDBName = doc.PrimaryKey.DatabaseName
 			prevCollName = doc.PrimaryKey.CollectionName
 			idLenAccum = 0
 			dataSizeAccum = 0
-			idAccum = []interface{}{}
+			idAccum = idAccum[:0]
 		}
+
 		idLenAccum += idLen
 		dataSizeAccum += int64(doc.DataSize)
 		idAccum = append(idAccum, doc.PrimaryKey.DocumentID)
@@ -294,11 +328,5 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 		return err
 	}
 
-	if len(idAccum) > 0 {
-		err := createRecheckTask()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return persistBufferedRechecks()
 }

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -153,7 +153,7 @@ func (verifier *Verifier) InsertPartitionVerificationTask(partition *partitions.
 	return &verificationTask, err
 }
 
-func (verifier *Verifier) InsertFailedIdsVerificationTask(ids []interface{}, dataSize types.ByteCount, srcNamespace string) error {
+func (verifier *Verifier) InsertDocumentRecheckTask(ids []interface{}, dataSize types.ByteCount, srcNamespace string) error {
 	dstNamespace := srcNamespace
 	if len(verifier.nsMap) != 0 {
 		var ok bool


### PR DESCRIPTION
Presently the only limit on a recheck task’s size is BSON’s document-size limit (i.e., 16 MiB). Thus, a single task can feasibly include every recheck. If there are millions of rechecks, that means only 1 thread is doing all of them, which increases the likelihood that migration-verifier would fail to keep pace with the source workload.

This changeset addresses this problem by capping the recheck task size according to the number of pending rechecks and the number of workers.