### PR TITLE
Add a timeout when reading cursor, and fail immediately.

### DIFF
--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -190,9 +190,6 @@ func (verifier *Verifier) compareDocsFromChannels(
 				)
 			case doc, alive := <-dstChannel:
 				if !alive {
-					verifier.logger.Debug().
-						Interface("task", task.PrimaryKey).
-						Msg("Destination reader closed.")
 					dstClosed = true
 					break
 				}


### PR DESCRIPTION
In certain cases reads from the source or destination seem to hang. This changeset makes two changes to address that:
1. A timer is added to detect hung reads. It is hard-coded at 10 minutes, which seems conservative enough.
2. The comparer thread fails immediately if it finds a failure from the source. Previously it would read from the destination if the source failed. (This _could_ be the case of the apparent hangs, but how that could be seems unclear.)