### PR TITLE
Read documents in parallel

### DIFF
--- a/internal/reportutils/reportutils.go
+++ b/internal/reportutils/reportutils.go
@@ -183,5 +183,6 @@ func FindBestUnit[T num16Plus](count T) DataUnit {
 // FmtBytes is a convenience that combines BytesToUnit with FindBestUnit.
 // Use it to format a single count of bytes.
 func FmtBytes[T num16Plus](count T) string {
-	return BytesToUnit(count, FindBestUnit(count))
+	unit := FindBestUnit(count)
+	return BytesToUnit(count, unit) + " " + string(unit)
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -146,7 +146,7 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 		err = nil
 	}
 
-	if err != nil {
+	if err == nil {
 		verifier.logger.Debug().
 			Int("generation", generation).
 			Msgf("Check finished.")
@@ -432,11 +432,6 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			duration := verifier.workerSleepDelayMillis * time.Millisecond
 
 			if duration > 0 {
-				verifier.logger.Debug().
-					Int("workerNum", workerNum).
-					Stringer("duration", duration).
-					Msg("No tasks found. Sleeping.")
-
 				time.Sleep(duration)
 			}
 
@@ -453,6 +448,8 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 		switch task.Type {
 		case verificationTaskVerifyCollection:
 			err := verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
+			verifier.workerTracker.Unset(workerNum)
+
 			if err != nil {
 				return err
 			}
@@ -464,6 +461,8 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			}
 		case verificationTaskVerifyDocuments:
 			err := verifier.ProcessVerifyTask(ctx, workerNum, task)
+			verifier.workerTracker.Unset(workerNum)
+
 			if err != nil {
 				return err
 			}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -574,7 +574,7 @@ func TestVerifierCompareDocs(t *testing.T) {
 				{{"_id", id}, {"sharded", 123}},
 			},
 			compareFn: func(t *testing.T, mismatchedIds []VerificationResult) {
-				assert.Empty(t, mismatchedIds)
+				assert.Empty(t, mismatchedIds, "should be no problems")
 			},
 		},
 	}
@@ -1491,7 +1491,7 @@ func (suite *IntegrationTestSuite) TestVerifierWithFilter() {
 	status := waitForTasks()
 	suite.Require().Greater(status.CompletedTasks, 1)
 	suite.Require().Greater(status.TotalTasks, 1)
-	suite.Require().Equal(status.FailedTasks, 0)
+	suite.Require().Zero(status.FailedTasks, "there should be no failed tasks")
 
 	// Insert another document that is not in the filter.
 	// This should trigger a recheck despite being outside the filter.


### PR DESCRIPTION
This tweaks the document comparison from REP-5230 (PR #34) so that, instead of reading source and destination documents in series, they are read in parallel. This should improve comparison speed.

This copies syncmap and syncslice from mongosync.