### PR TITLE
REP-5324 Normalize error handling.

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -59,12 +59,12 @@ func (r *Retryer) RunForUUIDAndTransientErrors(
 //
 // RunForUUIDErrorOnly returns the collection's current name in all cases.
 func (r *Retryer) RunForUUIDErrorOnly(
-	logger *logger.Logger, expectedCollName string, f func(*Info, string) error,
+	ctx context.Context, logger *logger.Logger, expectedCollName string, f func(*Info, string) error,
 ) (string, error) {
 	// Since we're not actually sleeping when checking for UUID/name mismatch
 	// errors, we don't need to provide a real context to handle
 	// cancellations.
-	return r.runRetryLoop(context.Background(), logger, expectedCollName, f, false, true)
+	return r.runRetryLoop(ctx, logger, expectedCollName, f, false, true)
 }
 
 // RunForTransientErrorsOnly retries f() for transient errors only, and

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -26,7 +26,7 @@ func (suite *UnitTestSuite) TestRetryer() {
 		suite.NoError(err)
 		suite.Equal(0, attemptNumber)
 
-		_, err = retryer.RunForUUIDErrorOnly(logger, "foo", f)
+		_, err = retryer.RunForUUIDErrorOnly(suite.Context(), logger, "foo", f)
 		suite.NoError(err)
 		suite.Equal(0, attemptNumber)
 
@@ -92,7 +92,7 @@ func (suite *UnitTestSuite) TestRetryer() {
 			}
 			return nil
 		}
-		_, err := retryer.RunForUUIDErrorOnly(logger, "bar", f)
+		_, err := retryer.RunForUUIDErrorOnly(suite.Context(), logger, "bar", f)
 		suite.NoError(err)
 		suite.Equal(attemptLimit/2, attemptNumber)
 	})
@@ -109,7 +109,7 @@ func (suite *UnitTestSuite) TestRetryer() {
 				Raw:  bson.Raw(raw),
 			}
 		}
-		_, err := retryer.RunForUUIDErrorOnly(logger, "bar", f)
+		_, err := retryer.RunForUUIDErrorOnly(suite.Context(), logger, "bar", f)
 		suite.NoError(err)
 		// We only did one retry because the actual collection name matched the
 		// previous attempt.
@@ -130,7 +130,7 @@ func (suite *UnitTestSuite) TestRetryerDurationLimitIsZero() {
 		return cmdErr
 	}
 
-	_, err := retryer.RunForUUIDErrorOnly(suite.Logger(), "bar", f)
+	_, err := retryer.RunForUUIDErrorOnly(suite.Context(), suite.Logger(), "bar", f)
 	suite.Equal(cmdErr, err)
 	suite.Equal(0, attemptNumber)
 }
@@ -280,7 +280,7 @@ func (suite *UnitTestSuite) TestRetryerWithEmptyCollectionName() {
 		return nil
 	}
 
-	name, err := retryer.RunForUUIDErrorOnly(suite.Logger(), "", f)
+	name, err := retryer.RunForUUIDErrorOnly(suite.Context(), suite.Logger(), "", f)
 	suite.NoError(err)
 	suite.Equal("", name)
 }

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -55,7 +55,7 @@ func (suite *IntegrationTestSuite) TestChangeStreamResumability() {
 
 	func() {
 		verifier1 := suite.BuildVerifier()
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(suite.Context())
 		defer cancel()
 		err := verifier1.StartChangeStream(ctx)
 		suite.Require().NoError(err)
@@ -147,8 +147,7 @@ func (suite *IntegrationTestSuite) fetchVerifierRechecks(ctx context.Context, ve
 
 func (suite *IntegrationTestSuite) TestStartAtTimeNoChanges() {
 	verifier := suite.BuildVerifier()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := suite.Context()
 	sess, err := suite.srcMongoClient.StartSession()
 	suite.Require().NoError(err)
 	sctx := mongo.NewSessionContext(ctx, sess)
@@ -167,8 +166,7 @@ func (suite *IntegrationTestSuite) TestStartAtTimeNoChanges() {
 
 func (suite *IntegrationTestSuite) TestStartAtTimeWithChanges() {
 	verifier := suite.BuildVerifier()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := suite.Context()
 	sess, err := suite.srcMongoClient.StartSession()
 	suite.Require().NoError(err)
 	sctx := mongo.NewSessionContext(ctx, sess)
@@ -220,8 +218,7 @@ func (suite *IntegrationTestSuite) TestStartAtTimeWithChanges() {
 
 func (suite *IntegrationTestSuite) TestNoStartAtTime() {
 	verifier := suite.BuildVerifier()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := suite.Context()
 	sess, err := suite.srcMongoClient.StartSession()
 	suite.Require().NoError(err)
 	sctx := mongo.NewSessionContext(ctx, sess)

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -139,6 +139,10 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 	err := eg.Wait()
 
 	if succeeded {
+		if !errors.Is(err, context.Canceled) {
+			panic("success should mean that err is context.Canceled, not: " + err.Error())
+		}
+
 		err = nil
 	}
 

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -346,9 +346,11 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 			verifier.dstNamespaces = verifier.srcNamespaces
 		}
 		if len(verifier.srcNamespaces) != len(verifier.dstNamespaces) {
-			err := errors.Errorf("Different number of source and destination namespaces")
-			verifier.logger.Error().Msgf("%s", err)
-			return err
+			return errors.Errorf(
+				"source has %d namespace(s), but destination has %d (they must match)",
+				len(verifier.srcNamespaces),
+				len(verifier.dstNamespaces),
+			)
 		}
 	}
 	isPrimary, err := verifier.CheckIsPrimary()
@@ -368,8 +370,11 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 	for _, src := range verifier.srcNamespaces {
 		_, err := verifier.InsertCollectionVerificationTask(ctx, src)
 		if err != nil {
-			verifier.logger.Error().Msgf("Failed to insert collection verification task: %s", err)
-			return err
+			return errors.Wrapf(
+				err,
+				"failed to insert collection verification task for namespace %#q",
+				src,
+			)
 		}
 	}
 

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -127,11 +127,10 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 			if verificationStatus.AddedTasks > 0 || verificationStatus.ProcessingTasks > 0 {
 				waitForTaskCreation++
 				time.Sleep(verifier.verificationStatusCheckInterval)
-				continue
 			} else {
 				verifier.PrintVerificationSummary(ctx, GenerationComplete)
 				succeeded = true
-				canceler(errors.New("ok"))
+				canceler(errors.Errorf("generation %d succeeded", generation))
 				return nil
 			}
 		}
@@ -438,12 +437,7 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			}
 
 			continue
-			/*
-				} else if errors.Is(err, context.Canceled) {
-					return nil
-			*/
 		} else if err != nil {
-
 			return errors.Wrap(
 				err,
 				"failed to seek next task",
@@ -467,6 +461,8 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			if err != nil {
 				return err
 			}
+		default:
+			panic("Unknown verification task type: " + task.Type)
 		}
 	}
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -353,7 +353,7 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 			)
 		}
 	}
-	isPrimary, err := verifier.CheckIsPrimary()
+	isPrimary, err := verifier.CheckIsPrimary(ctx)
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 
 	verifier.gen0PendingCollectionTasks.Store(int32(len(verifier.srcNamespaces)))
 
-	err = verifier.UpdatePrimaryTaskComplete()
+	err = verifier.UpdatePrimaryTaskComplete(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/verifier/clustertime_test.go
+++ b/internal/verifier/clustertime_test.go
@@ -1,15 +1,13 @@
 package verifier
 
 import (
-	"context"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func (suite *IntegrationTestSuite) TestGetNewClusterTime() {
-	ctx := context.Background()
+	ctx := suite.Context()
 	logger, _ := getLoggerAndWriter("stdout")
 
 	sess, err := suite.srcMongoClient.StartSession()

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1142,7 +1142,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 	}
 
 	insertFailedCollection := func() error {
-		_, err := verifier.InsertFailedCollectionVerificationTask(srcNs)
+		_, err := verifier.InsertFailedCollectionVerificationTask(ctx, srcNs)
 		return errors.Wrapf(
 			err,
 			"failed to persist metadata mismatch for collection %#q",
@@ -1236,7 +1236,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		task.SourceByteCount = bytesCount
 
 		for _, partition := range partitions {
-			_, err := verifier.InsertPartitionVerificationTask(partition, shardKeys, dstNs)
+			_, err := verifier.InsertPartitionVerificationTask(ctx, partition, shardKeys, dstNs)
 			if err != nil {
 				return errors.Wrapf(
 					err,

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1219,7 +1219,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		task.Status = verificationTaskMetadataMismatch
 	}
 
-	// We’ve confirmed that the collection metadata (including indices and shard keys)
+	// We’ve confirmed that the collection metadata (including indices)
 	// matches between soruce & destination. Now we can partition the collection.
 
 	if task.Generation == 0 {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -980,21 +980,6 @@ func (verifier *Verifier) ProcessCollectionVerificationTask(
 	)
 }
 
-func (verifier *Verifier) markCollectionFailed(workerNum int, task *VerificationTask, cluster string, namespace string, err error) {
-	task.Status = verificationTaskFailed
-	verifier.logger.Error().
-		Int("workerNum", workerNum).
-		Interface("task", task.PrimaryKey).
-		Str("namespace", namespace).
-		Err(err).
-		Msg("Failed to read collection metadata.")
-
-	task.FailedDocs = append(task.FailedDocs, VerificationResult{
-		NameSpace: namespace,
-		Cluster:   cluster,
-		Details:   Failed + fmt.Sprintf(" %v", err)})
-}
-
 func getIndexesMap(
 	ctx context.Context,
 	coll *mongo.Collection,

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -671,7 +671,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.sameView",
 			To:        "testDb.sameView"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskCompleted, task.Status)
 	suite.Nil(task.FailedDocs)
 
@@ -685,7 +687,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.wrongColl",
 			To:        "testDb.wrongColl"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(task.FailedDocs[0].Field, "Options.viewOn")
@@ -703,7 +707,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.wrongPipeline",
 			To:        "testDb.wrongPipeline"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(task.FailedDocs[0].Field, "Options.pipeline")
@@ -726,7 +732,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.missingOptionsSrc",
 			To:        "testDb.missingOptionsSrc"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(task.FailedDocs[0].Field, "Options.collation")
@@ -744,7 +752,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.missingOptionsDst",
 			To:        "testDb.missingOptionsDst"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(task.FailedDocs[0].Field, "Options.collation")
@@ -762,7 +772,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.differentOptions",
 			To:        "testDb.differentOptions"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(task.FailedDocs[0].Field, "Options.collation")
@@ -783,7 +795,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testColl"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	suite.Equal(1, len(task.FailedDocs))
 	suite.Equal(task.FailedDocs[0].Details, Missing)
@@ -798,7 +812,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testCollTo"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	suite.Equal(1, len(task.FailedDocs))
 	suite.Equal(task.FailedDocs[0].Details, Missing)
@@ -813,7 +829,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.destOnlyColl",
 			To:        "testDb.destOnlyColl"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	suite.Equal(1, len(task.FailedDocs))
 	suite.Equal(task.FailedDocs[0].Details, Missing)
@@ -830,7 +848,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.viewOnSrc",
 			To:        "testDb.viewOnSrc"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	suite.Equal(1, len(task.FailedDocs))
 	suite.Equal(task.FailedDocs[0].Field, "Type")
@@ -847,7 +867,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.cappedOnDst",
 			To:        "testDb.cappedOnDst"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskFailed, task.Status)
 	// Capped and size should differ
 	var wrongFields []string
@@ -864,7 +886,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testColl"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskCompleted, task.Status)
 
 	// Neither collection exists success case
@@ -873,7 +897,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testCollDNE",
 			To:        "testDb.testCollDNE"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskCompleted, task.Status)
 }
 
@@ -900,7 +926,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 			To:        "testDb.testColl1",
 		},
 	}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskMetadataMismatch, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(srcIndexNames[1], task.FailedDocs[0].ID)
@@ -926,7 +954,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl2",
 			To:        "testDb.testColl2"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskMetadataMismatch, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal(dstIndexNames[1], task.FailedDocs[0].ID)
@@ -952,7 +982,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl3",
 			To:        "testDb.testColl3"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskMetadataMismatch, task.Status)
 	if suite.Equal(2, len(task.FailedDocs)) {
 		sort.Slice(task.FailedDocs, func(i, j int) bool {
@@ -987,7 +1019,9 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl4",
 			To:        "testDb.testColl4"}}
-	verifier.verifyMetadataAndPartitionCollection(ctx, 1, task)
+	suite.Require().NoError(
+		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
+	)
 	suite.Equal(verificationTaskMetadataMismatch, task.Status)
 	if suite.Equal(1, len(task.FailedDocs)) {
 		suite.Equal("wrong", task.FailedDocs[0].ID)
@@ -1281,16 +1315,19 @@ func (suite *IntegrationTestSuite) TestMetadataMismatchAndPartitioning() {
 }
 
 func (suite *IntegrationTestSuite) TestGenerationalRechecking() {
+	dbname1 := suite.DBNameForTest("1")
+	dbname2 := suite.DBNameForTest("2")
+
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	verifier := suite.BuildVerifier()
-	verifier.SetSrcNamespaces([]string{"testDb1.testColl1"})
-	verifier.SetDstNamespaces([]string{"testDb2.testColl3"})
+	verifier.SetSrcNamespaces([]string{dbname1 + ".testColl1"})
+	verifier.SetDstNamespaces([]string{dbname2 + ".testColl3"})
 	verifier.SetNamespaceMap()
 
 	ctx := suite.Context()
 
-	srcColl := suite.srcMongoClient.Database("testDb1").Collection("testColl1")
-	dstColl := suite.dstMongoClient.Database("testDb2").Collection("testColl3")
+	srcColl := suite.srcMongoClient.Database(dbname1).Collection("testColl1")
+	dstColl := suite.dstMongoClient.Database(dbname2).Collection("testColl3")
 	_, err := srcColl.InsertOne(ctx, bson.M{"_id": 1, "x": 42})
 	suite.Require().NoError(err)
 	_, err = srcColl.InsertOne(ctx, bson.M{"_id": 2, "x": 43})
@@ -1548,6 +1585,7 @@ func (suite *IntegrationTestSuite) TestBackgroundInIndexSpec() {
 
 func (suite *IntegrationTestSuite) TestPartitionWithFilter() {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	dbname := suite.DBNameForTest()
 
 	ctx := suite.Context()
 
@@ -1557,14 +1595,14 @@ func (suite *IntegrationTestSuite) TestPartitionWithFilter() {
 
 	// Set up the verifier for testing.
 	verifier := suite.BuildVerifier()
-	verifier.SetSrcNamespaces([]string{"testDb1.testColl1"})
+	verifier.SetSrcNamespaces([]string{dbname + ".testColl1"})
 	verifier.SetNamespaceMap()
 	verifier.globalFilter = filter
 	// Use a small partition size so that we can test creating multiple partitions.
 	verifier.partitionSizeInBytes = 30
 
 	// Insert documents into the source.
-	srcColl := suite.srcMongoClient.Database("testDb1").Collection("testColl1")
+	srcColl := suite.srcMongoClient.Database(dbname).Collection("testColl1")
 
 	// 30 documents with _ids [0, 30) are in the filter.
 	for i := 0; i < 30; i++ {
@@ -1579,7 +1617,7 @@ func (suite *IntegrationTestSuite) TestPartitionWithFilter() {
 	}
 
 	// Create partitions with the filter.
-	partitions, _, _, _, err := verifier.partitionAndInspectNamespace(ctx, "testDb1.testColl1")
+	partitions, _, _, _, err := verifier.partitionAndInspectNamespace(ctx, dbname+".testColl1")
 	suite.Require().NoError(err)
 
 	// Check that each partition have bounds in the filter.

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -216,10 +216,10 @@ func (suite *IntegrationTestSuite) TestGetNamespaceStatistics_Gen0() {
 	// Now add 2 namespaces. Add them “out of order” to test
 	// that we sort the returned array by Namespace.
 
-	task2, err := verifier.InsertCollectionVerificationTask("mydb.coll2")
+	task2, err := verifier.InsertCollectionVerificationTask(ctx, "mydb.coll2")
 	suite.Require().NoError(err)
 
-	task1, err := verifier.InsertCollectionVerificationTask("mydb.coll1")
+	task1, err := verifier.InsertCollectionVerificationTask(ctx, "mydb.coll1")
 	suite.Require().NoError(err)
 
 	stats, err = verifier.GetNamespaceStatistics(ctx)
@@ -276,6 +276,7 @@ func (suite *IntegrationTestSuite) TestGetNamespaceStatistics_Gen0() {
 	task2parts := [2]*VerificationTask{}
 	for i := range task1parts {
 		task1part, err := verifier.InsertPartitionVerificationTask(
+			ctx,
 			&partitions.Partition{
 				Ns: &partitions.Namespace{DB: "mydb", Coll: "coll1"},
 			},
@@ -287,6 +288,7 @@ func (suite *IntegrationTestSuite) TestGetNamespaceStatistics_Gen0() {
 		task1parts[i] = task1part
 
 		task2part, err := verifier.InsertPartitionVerificationTask(
+			ctx,
 			&partitions.Partition{
 				Ns: &partitions.Namespace{DB: "mydb", Coll: "coll2"},
 			},

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -44,6 +44,7 @@ type RecheckDoc struct {
 
 // InsertFailedCompareRecheckDocs is for inserting RecheckDocs based on failures during Check.
 func (verifier *Verifier) InsertFailedCompareRecheckDocs(
+	ctx context.Context,
 	namespace string, documentIDs []interface{}, dataSizes []int) error {
 	dbName, collName := SplitNamespace(namespace)
 
@@ -59,7 +60,7 @@ func (verifier *Verifier) InsertFailedCompareRecheckDocs(
 		Msg("Persisting rechecks for mismatched or missing documents.")
 
 	return verifier.insertRecheckDocs(
-		context.Background(),
+		ctx,
 		dbNames,
 		collNames,
 		documentIDs,

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -261,6 +261,7 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 		namespace := prevDBName + "." + prevCollName
 
 		err := verifier.InsertDocumentRecheckTask(
+			ctx,
 			idAccum,
 			types.ByteCount(dataSizeAccum),
 			namespace,

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -12,10 +12,11 @@ import (
 
 func (suite *IntegrationTestSuite) TestFailedCompareThenReplace() {
 	verifier := suite.BuildVerifier()
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	suite.Require().NoError(
 		verifier.InsertFailedCompareRecheckDocs(
+			ctx,
 			"the.namespace",
 			[]any{"theDocID"},
 			[]int{1234},

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -89,7 +89,7 @@ func (suite *IntegrationTestSuite) fetchRecheckDocs(ctx context.Context, verifie
 
 func (suite *IntegrationTestSuite) TestLargeIDInsertions() {
 	verifier := suite.BuildVerifier()
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	overlyLarge := 7 * 1024 * 1024 // Three of these exceed our 16MB limit, but two do not
 	id1 := strings.Repeat("a", overlyLarge)
@@ -151,7 +151,7 @@ func (suite *IntegrationTestSuite) TestLargeIDInsertions() {
 func (suite *IntegrationTestSuite) TestLargeDataInsertions() {
 	verifier := suite.BuildVerifier()
 	verifier.partitionSizeInBytes = 1024 * 1024
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	id1 := "a"
 	id2 := "b"
@@ -212,7 +212,7 @@ func (suite *IntegrationTestSuite) TestLargeDataInsertions() {
 
 func (suite *IntegrationTestSuite) TestMultipleNamespaces() {
 	verifier := suite.BuildVerifier()
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	id1 := "a"
 	id2 := "b"
@@ -263,7 +263,7 @@ func (suite *IntegrationTestSuite) TestMultipleNamespaces() {
 
 func (suite *IntegrationTestSuite) TestGenerationalClear() {
 	verifier := suite.BuildVerifier()
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	id1 := "a"
 	id2 := "b"

--- a/internal/verifier/reset_test.go
+++ b/internal/verifier/reset_test.go
@@ -40,7 +40,7 @@ func (suite *IntegrationTestSuite) TestResetPrimaryTask() {
 }
 
 func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
-	ctx := context.Background()
+	ctx := suite.Context()
 
 	verifier := suite.BuildVerifier()
 
@@ -61,7 +61,7 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 	collTask.Status = verificationTaskProcessing
 
 	suite.Require().NoError(
-		verifier.UpdateVerificationTask(collTask),
+		verifier.UpdateVerificationTask(ctx, collTask),
 	)
 
 	// Create three partition tasks with the same namespace as the
@@ -92,7 +92,7 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 
 		task.Status = taskParts.Status
 		suite.Require().NoError(
-			verifier.UpdateVerificationTask(task),
+			verifier.UpdateVerificationTask(ctx, task),
 		)
 	}
 

--- a/internal/verifier/reset_test.go
+++ b/internal/verifier/reset_test.go
@@ -15,7 +15,7 @@ func (suite *IntegrationTestSuite) TestResetPrimaryTask() {
 
 	verifier := suite.BuildVerifier()
 
-	created, err := verifier.CheckIsPrimary()
+	created, err := verifier.CheckIsPrimary(ctx)
 	suite.Require().NoError(err)
 	suite.Require().True(created)
 
@@ -45,11 +45,11 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 	verifier := suite.BuildVerifier()
 
 	// Create a primary task, and set it to complete.
-	created, err := verifier.CheckIsPrimary()
+	created, err := verifier.CheckIsPrimary(ctx)
 	suite.Require().NoError(err)
 	suite.Require().True(created)
 
-	suite.Require().NoError(verifier.UpdatePrimaryTaskComplete())
+	suite.Require().NoError(verifier.UpdatePrimaryTaskComplete(ctx))
 
 	ns1 := "foo.bar"
 	ns2 := "qux.quux"

--- a/internal/verifier/reset_test.go
+++ b/internal/verifier/reset_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 func (suite *IntegrationTestSuite) TestResetPrimaryTask() {
+	ctx := suite.Context()
+
 	verifier := suite.BuildVerifier()
 
 	created, err := verifier.CheckIsPrimary()
 	suite.Require().NoError(err)
 	suite.Require().True(created)
 
-	_, err = verifier.InsertCollectionVerificationTask("foo.bar")
+	_, err = verifier.InsertCollectionVerificationTask(ctx, "foo.bar")
 	suite.Require().NoError(err)
-
-	ctx := context.Background()
 
 	err = verifier.doInMetaTransaction(
 		ctx,
@@ -55,7 +55,7 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 	ns2 := "qux.quux"
 
 	// Create a collection-verification task, and set it to processing.
-	collTask, err := verifier.InsertCollectionVerificationTask(ns1)
+	collTask, err := verifier.InsertCollectionVerificationTask(ctx, ns1)
 	suite.Require().NoError(err)
 
 	collTask.Status = verificationTaskProcessing
@@ -79,6 +79,7 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 		{verificationTaskCompleted, ns2},
 	} {
 		task, err := verifier.InsertPartitionVerificationTask(
+			ctx,
 			&partitions.Partition{
 				Ns: &partitions.Namespace{
 					DB:   strings.Split(taskParts.Namespace, ".")[0],

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -90,6 +90,7 @@ type VerificationRange struct {
 }
 
 func (verifier *Verifier) insertCollectionVerificationTask(
+	ctx context.Context,
 	srcNamespace string,
 	generation int) (*VerificationTask, error) {
 
@@ -120,7 +121,7 @@ func (verifier *Verifier) insertCollectionVerificationTask(
 			To:        dstNamespace,
 		},
 	}
-	_, err := verifier.verificationTaskCollection().InsertOne(context.Background(), verificationTask)
+	_, err := verifier.verificationTaskCollection().InsertOne(ctx, verificationTask)
 	return &verificationTask, err
 }
 
@@ -128,14 +129,14 @@ func (verifier *Verifier) InsertCollectionVerificationTask(
 	ctx context.Context,
 	srcNamespace string,
 ) (*VerificationTask, error) {
-	return verifier.insertCollectionVerificationTask(srcNamespace, verifier.generation)
+	return verifier.insertCollectionVerificationTask(ctx, srcNamespace, verifier.generation)
 }
 
 func (verifier *Verifier) InsertFailedCollectionVerificationTask(
 	ctx context.Context,
 	srcNamespace string,
 ) (*VerificationTask, error) {
-	return verifier.insertCollectionVerificationTask(srcNamespace, verifier.generation+1)
+	return verifier.insertCollectionVerificationTask(ctx, srcNamespace, verifier.generation+1)
 }
 
 func (verifier *Verifier) InsertPartitionVerificationTask(
@@ -157,7 +158,7 @@ func (verifier *Verifier) InsertPartitionVerificationTask(
 			To:        dstNamespace,
 		},
 	}
-	_, err := verifier.verificationTaskCollection().InsertOne(context.Background(), verificationTask)
+	_, err := verifier.verificationTaskCollection().InsertOne(ctx, verificationTask)
 	return &verificationTask, err
 }
 
@@ -247,7 +248,7 @@ func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *Veri
 	return err
 }
 
-func (verifier *Verifier) CheckIsPrimary() (bool, error) {
+func (verifier *Verifier) CheckIsPrimary(ctx context.Context) (bool, error) {
 	ownerSetId := primitive.NewObjectID()
 	filter := bson.M{"type": verificationTaskPrimary}
 	opts := options.Update()
@@ -259,7 +260,7 @@ func (verifier *Verifier) CheckIsPrimary() (bool, error) {
 			"status": verificationTaskAdded,
 		},
 	}
-	result, err := verifier.verificationTaskCollection().UpdateOne(context.Background(), filter, update, opts)
+	result, err := verifier.verificationTaskCollection().UpdateOne(ctx, filter, update, opts)
 	if err != nil {
 		return false, err
 	}
@@ -268,8 +269,7 @@ func (verifier *Verifier) CheckIsPrimary() (bool, error) {
 	return isPrimary, nil
 }
 
-func (verifier *Verifier) UpdatePrimaryTaskComplete() error {
-	var ctx = context.Background()
+func (verifier *Verifier) UpdatePrimaryTaskComplete(ctx context.Context) error {
 	updateFields := bson.M{
 		"$set": bson.M{
 			"status": verificationTaskCompleted,

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -181,7 +181,7 @@ func (verifier *Verifier) InsertDocumentRecheckTask(ids []interface{}, dataSize 
 	return err
 }
 
-func (verifier *Verifier) FindNextVerifyTaskAndUpdate() (*VerificationTask, error) {
+func (verifier *Verifier) FindNextVerifyTaskAndUpdate(ctx context.Context) (*VerificationTask, error) {
 	var verificationTask = VerificationTask{}
 	filter := bson.M{
 		"$and": bson.A{
@@ -209,12 +209,11 @@ func (verifier *Verifier) FindNextVerifyTaskAndUpdate() (*VerificationTask, erro
 	// We want “verifyCollection” tasks before “verify”(-document) ones.
 	opts.SetSort(bson.M{"type": -1})
 
-	err := coll.FindOneAndUpdate(context.Background(), filter, updates, opts).Decode(&verificationTask)
+	err := coll.FindOneAndUpdate(ctx, filter, updates, opts).Decode(&verificationTask)
 	return &verificationTask, err
 }
 
-func (verifier *Verifier) UpdateVerificationTask(task *VerificationTask) error {
-	var ctx = context.Background()
+func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *VerificationTask) error {
 	updateFields := bson.M{
 		"$set": bson.M{
 			"status":                 task.Status,

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -125,17 +125,25 @@ func (verifier *Verifier) insertCollectionVerificationTask(
 }
 
 func (verifier *Verifier) InsertCollectionVerificationTask(
-	srcNamespace string) (*VerificationTask, error) {
+	ctx context.Context,
+	srcNamespace string,
+) (*VerificationTask, error) {
 	return verifier.insertCollectionVerificationTask(srcNamespace, verifier.generation)
 }
 
 func (verifier *Verifier) InsertFailedCollectionVerificationTask(
-	srcNamespace string) (*VerificationTask, error) {
+	ctx context.Context,
+	srcNamespace string,
+) (*VerificationTask, error) {
 	return verifier.insertCollectionVerificationTask(srcNamespace, verifier.generation+1)
 }
 
-func (verifier *Verifier) InsertPartitionVerificationTask(partition *partitions.Partition, shardKeys []string,
-	dstNamespace string) (*VerificationTask, error) {
+func (verifier *Verifier) InsertPartitionVerificationTask(
+	ctx context.Context,
+	partition *partitions.Partition,
+	shardKeys []string,
+	dstNamespace string,
+) (*VerificationTask, error) {
 	srcNamespace := strings.Join([]string{partition.Ns.DB, partition.Ns.Coll}, ".")
 	verificationTask := VerificationTask{
 		PrimaryKey: primitive.NewObjectID(),
@@ -153,7 +161,12 @@ func (verifier *Verifier) InsertPartitionVerificationTask(partition *partitions.
 	return &verificationTask, err
 }
 
-func (verifier *Verifier) InsertDocumentRecheckTask(ids []interface{}, dataSize types.ByteCount, srcNamespace string) error {
+func (verifier *Verifier) InsertDocumentRecheckTask(
+	ctx context.Context,
+	ids []interface{},
+	dataSize types.ByteCount,
+	srcNamespace string,
+) error {
 	dstNamespace := srcNamespace
 	if len(verifier.nsMap) != 0 {
 		var ok bool
@@ -176,7 +189,7 @@ func (verifier *Verifier) InsertDocumentRecheckTask(ids []interface{}, dataSize 
 		SourceDocumentCount: types.DocumentCount(len(ids)),
 		SourceByteCount:     dataSize,
 	}
-	var ctx = context.Background()
+
 	_, err := verifier.verificationTaskCollection().InsertOne(ctx, &verificationTask)
 	return err
 }


### PR DESCRIPTION
## Reviewer note

While this is a regrettably large changeset, most of it is trivial changes like passing a context where previously the function used context.Background().

The check logic contains most of this PR’s “interesting” changes.

-----

In certain cases migration-verifier would log on fatal errors rather than propagating them back up the call stack. This has led to failures to compare documents that were effectively ignored save for being noted in the log. This changeset fixes that so that such exceptional cases will halt the verification.

Broadly speaking, this changeset:
a) brings idiomatic Context propagation in places where context.Background() was used
b) converts Error() logs and “failed” task statuses to returned errors

As of this changeset, any task in “failed” indicates a mismatch rather than a failure to complete the check.

A separate changeset will introduce a retryer to FetchAndCompareDocuments.

Other, specific changes:
- CheckWorker() is rewritten to use an errgroup, which automatically cancels context if a thread fails.
- CheckDriver() now returns errors rather than Error() logging them.
- A few places’ direct checks for ctx.Done() are removed. (They’re superfluous.)
- TestGenerationalRechecking and TestPartitionWithFilter no longer use constant DB names.
- RunForUUIDErrorOnly() now takes a context. (NB: This method is currently unused.)
- Most uses of context.Background() in tests are now suite.Context().
- The unused RecheckTasks is removed from VerificationStatus.