### PR TITLE
REP-5330 Fix deep index comparison.

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -905,12 +905,10 @@ func (verifier *Verifier) doIndexSpecsMatch(ctx context.Context, srcSpec bson.Ra
 		ctx,
 		mongo.Pipeline{
 			{{"$documents", []bson.D{
-				{{"spec", srcSpec}},
-			}}},
-
-			// Add the destination spec.
-			{{"$addFields", bson.D{
-				{"dstSpec", dstSpec},
+				{
+					{"spec", bson.D{{"$literal", srcSpec}}},
+					{"dstSpec", bson.D{{"$literal", dstSpec}}},
+				},
 			}}},
 
 			{{"$unset", lo.Reduce(

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1021,6 +1021,19 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexSpecs() {
 		},
 
 		{
+			label: "simple deep",
+			src: bson.D{
+				{"name", "testIndex"},
+				{"key", bson.M{"$foo.bar": 123}},
+			},
+			dst: bson.D{
+				{"name", "testIndex"},
+				{"key", bson.M{"$foo.bar": 123}},
+			},
+			shouldMatch: true,
+		},
+
+		{
 			label: "ignore `ns` field",
 			src: bson.D{
 				{"name", "testIndex"},

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1021,19 +1021,6 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexSpecs() {
 		},
 
 		{
-			label: "simple deep",
-			src: bson.D{
-				{"name", "testIndex"},
-				{"key", bson.M{"$foo.bar": 123}},
-			},
-			dst: bson.D{
-				{"name", "testIndex"},
-				{"key", bson.M{"$foo.bar": 123}},
-			},
-			shouldMatch: true,
-		},
-
-		{
 			label: "ignore `ns` field",
 			src: bson.D{
 				{"name", "testIndex"},
@@ -1056,6 +1043,19 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexSpecs() {
 			dst: bson.D{
 				{"name", "testIndex"},
 				{"key", bson.M{"foo": float64(123)}},
+			},
+			shouldMatch: true,
+		},
+
+		{
+			label: "ignore number types, deep",
+			src: bson.D{
+				{"name", "testIndex"},
+				{"key", bson.M{"foo.bar": float64(123)}},
+			},
+			dst: bson.D{
+				{"name", "testIndex"},
+				{"key", bson.M{"foo.bar": 123}},
 			},
 			shouldMatch: true,
 		},


### PR DESCRIPTION
This adds a $literal around the documents inserted into the $documents aggregation to allow for number-type discrepancies in index specifications. See the test case added here for why this is needed.