### PR TITLE
REP-5329 Improve retryer & apply it more consistently.

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -15,6 +15,17 @@ import (
 
 type RetryCallback = func(context.Context, *FuncInfo) error
 
+// Retry is a convenience that creates a retryer and executes it.
+// See RunForTransientErrorsOnly for argument details.
+func Retry(
+	ctx context.Context,
+	logger *logger.Logger,
+	callbacks ...RetryCallback,
+) error {
+	retryer := New(DefaultDurationLimit)
+	return retryer.Run(ctx, logger, callbacks...)
+}
+
 // Run() runs each given callback in parallel. If none of them fail,
 // then no error is returned.
 //

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -346,6 +346,7 @@ func (suite *IntegrationTestSuite) TestCursorKilledResilience() {
 
 	failedTasks, incompleteTasks, err := FetchFailedAndIncompleteTasks(
 		ctx,
+		verifier.logger,
 		verifier.verificationTaskCollection(),
 		verificationTaskVerifyDocuments,
 		verifier.generation,
@@ -395,6 +396,7 @@ func (suite *IntegrationTestSuite) testInsertsBeforeWritesOff(docsCount int) {
 	generation := verifier.generation
 	failedTasks, incompleteTasks, err := FetchFailedAndIncompleteTasks(
 		ctx,
+		verifier.logger,
 		verifier.verificationTaskCollection(),
 		verificationTaskVerifyDocuments,
 		generation,

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/10gen/migration-verifier/internal/logger"
+	"github.com/10gen/migration-verifier/internal/retry"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -34,7 +36,10 @@ func (verifier *Verifier) Check(ctx context.Context, filter map[string]any) {
 	go func() {
 		err := verifier.CheckDriver(ctx, filter)
 		if err != nil {
-			verifier.logger.Fatal().Err(err).Msgf("Fatal error in generation %d", verifier.generation)
+			verifier.logger.Fatal().
+				Int("generation", verifier.generation).
+				Err(err).
+				Msg("Fatal error.")
 		}
 	}()
 	verifier.MaybeStartPeriodicHeapProfileCollection(ctx)
@@ -182,19 +187,31 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 			return err
 		}
 	}
-	err = verifier.AddMetaIndexes(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = verifier.doInMetaTransaction(
+	err = retry.Retry(
 		ctx,
-		func(ctx context.Context, sCtx mongo.SessionContext) error {
-			return verifier.ResetInProgressTasks(sCtx)
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			err = verifier.AddMetaIndexes(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = verifier.doInMetaTransaction(
+				ctx,
+				func(ctx context.Context, sCtx mongo.SessionContext) error {
+					return verifier.ResetInProgressTasks(sCtx)
+				},
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to reset any in-progress tasks")
+			}
+
+			return nil
 		},
 	)
+
 	if err != nil {
-		return errors.Wrap(err, "failed to reset any in-progress tasks")
+		return err
 	}
 
 	verifier.logger.Debug().Msg("Starting Check")
@@ -293,13 +310,23 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 		}
 		verifier.generation++
 		verifier.phase = Recheck
-		err = verifier.GenerateRecheckTasks(ctx)
+
+		// Generation of recheck tasks can partial-fail. The following will
+		// cause a full redo in that case, which is inefficient but simple.
+		// Such failures seem unlikely anyhow.
+		err = retry.Retry(
+			ctx,
+			verifier.logger,
+			func(ctx context.Context, _ *retry.FuncInfo) error {
+				return verifier.GenerateRecheckTasksWhileLocked(ctx)
+			},
+		)
 		if err != nil {
 			verifier.mux.Unlock()
 			return err
 		}
 
-		err = verifier.ClearRecheckDocs(ctx)
+		err = verifier.ClearRecheckDocsWhileLocked(ctx)
 		if err != nil {
 			verifier.logger.Warn().
 				Err(err).
@@ -356,7 +383,7 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 			)
 		}
 	}
-	isPrimary, err := verifier.CheckIsPrimary(ctx)
+	isPrimary, err := verifier.CreatePrimaryTaskIfNeeded(ctx)
 	if err != nil {
 		return err
 	}
@@ -390,30 +417,44 @@ func (verifier *Verifier) CreateInitialTasks(ctx context.Context) error {
 	return nil
 }
 
-func FetchFailedAndIncompleteTasks(ctx context.Context, coll *mongo.Collection, taskType verificationTaskType, generation int) ([]VerificationTask, []VerificationTask, error) {
+func FetchFailedAndIncompleteTasks(
+	ctx context.Context,
+	logger *logger.Logger,
+	coll *mongo.Collection,
+	taskType verificationTaskType,
+	generation int,
+) ([]VerificationTask, []VerificationTask, error) {
 	var FailedTasks, allTasks, IncompleteTasks []VerificationTask
 
-	cur, err := coll.Find(ctx, bson.D{
-		bson.E{Key: "type", Value: taskType},
-		bson.E{Key: "generation", Value: generation},
-	})
-	if err != nil {
-		return FailedTasks, IncompleteTasks, err
-	}
+	err := retry.Retry(
+		ctx,
+		logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			cur, err := coll.Find(ctx, bson.D{
+				bson.E{Key: "type", Value: taskType},
+				bson.E{Key: "generation", Value: generation},
+			})
+			if err != nil {
+				return err
+			}
 
-	err = cur.All(ctx, &allTasks)
-	if err != nil {
-		return FailedTasks, IncompleteTasks, err
-	}
-	for _, t := range allTasks {
-		if failedStatus.Contains(t.Status) {
-			FailedTasks = append(FailedTasks, t)
-		} else if t.Status != verificationTaskCompleted {
-			IncompleteTasks = append(IncompleteTasks, t)
-		}
-	}
+			err = cur.All(ctx, &allTasks)
+			if err != nil {
+				return err
+			}
+			for _, t := range allTasks {
+				if failedStatus.Contains(t.Status) {
+					FailedTasks = append(FailedTasks, t)
+				} else if t.Status != verificationTaskCompleted {
+					IncompleteTasks = append(IncompleteTasks, t)
+				}
+			}
 
-	return FailedTasks, IncompleteTasks, nil
+			return nil
+		},
+	)
+
+	return FailedTasks, IncompleteTasks, err
 }
 
 // work is the logic for an individual worker thread.
@@ -427,8 +468,16 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 		Msg("Worker finished.")
 
 	for {
-		task, err := verifier.FindNextVerifyTaskAndUpdate(ctx)
-		if errors.Is(err, mongo.ErrNoDocuments) {
+		taskOpt, err := verifier.FindNextVerifyTaskAndUpdate(ctx)
+		if err != nil {
+			return errors.Wrap(
+				err,
+				"failed to seek next task",
+			)
+		}
+
+		task, gotTask := taskOpt.Get()
+		if !gotTask {
 			duration := verifier.workerSleepDelayMillis * time.Millisecond
 
 			if duration > 0 {
@@ -436,18 +485,13 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			}
 
 			continue
-		} else if err != nil {
-			return errors.Wrap(
-				err,
-				"failed to seek next task",
-			)
 		}
 
-		verifier.workerTracker.Set(workerNum, *task)
+		verifier.workerTracker.Set(workerNum, task)
 
 		switch task.Type {
 		case verificationTaskVerifyCollection:
-			err := verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
+			err := verifier.ProcessCollectionVerificationTask(ctx, workerNum, &task)
 			verifier.workerTracker.Unset(workerNum)
 
 			if err != nil {
@@ -460,7 +504,7 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 				}
 			}
 		case verificationTaskVerifyDocuments:
-			err := verifier.ProcessVerifyTask(ctx, workerNum, task)
+			err := verifier.ProcessVerifyTask(ctx, workerNum, &task)
 			verifier.workerTracker.Unset(workerNum)
 
 			if err != nil {

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -176,7 +176,7 @@ func (suite *IntegrationTestSuite) TestGetNamespaceStatistics_Recheck() {
 	func() {
 		verifier.mux.Lock()
 		defer func() { verifier.mux.Unlock() }()
-		suite.Require().NoError(verifier.GenerateRecheckTasks(ctx))
+		suite.Require().NoError(verifier.GenerateRecheckTasksWhileLocked(ctx))
 	}()
 
 	stats, err := verifier.GetNamespaceStatistics(ctx)
@@ -433,7 +433,7 @@ func (suite *IntegrationTestSuite) TestFailedVerificationTaskInsertions() {
 		verifier.mux.Lock()
 		defer verifier.mux.Unlock()
 
-		err = verifier.GenerateRecheckTasks(ctx)
+		err = verifier.GenerateRecheckTasksWhileLocked(ctx)
 		suite.Require().NoError(err)
 	}()
 

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -16,10 +16,9 @@ import (
 )
 
 const (
-	recheckQueue                  = "recheckQueue"
-	maxBSONObjSize                = 16 * 1024 * 1024
-	recheckInserterThreadsSoftMax = 100
-	maxIdsPerRecheckTask          = 12 * 1024 * 1024
+	recheckQueue         = "recheckQueue"
+	maxBSONObjSize       = 16 * 1024 * 1024
+	maxIdsPerRecheckTask = 12 * 1024 * 1024
 )
 
 // RecheckPrimaryKey stores the implicit type of recheck to perform
@@ -97,7 +96,7 @@ func (verifier *Verifier) insertRecheckDocs(
 	generation, _ := verifier.getGenerationWhileLocked()
 
 	docIDIndexes := lo.Range(len(documentIDs))
-	indexesPerThread := splitToChunks(docIDIndexes, recheckInserterThreadsSoftMax)
+	indexesPerThread := splitToChunks(docIDIndexes, verifier.numWorkers)
 
 	eg, groupCtx := errgroup.WithContext(ctx)
 
@@ -114,21 +113,18 @@ func (verifier *Verifier) insertRecheckDocs(
 					DocumentID:     documentIDs[i],
 				}
 
-				// The filter must exclude DataSize; otherwise, if a failed comparison
-				// and a change event happen on the same document for the same
-				// generation, the 2nd insert will fail because a) its filter won’t
-				// match anything, and b) it’ll try to insert a new document with the
-				// same _id as the one that the 1st insert already created.
-				filterDoc := bson.D{{"_id", pk}}
-
-				recheckDoc := RecheckDoc{
-					PrimaryKey: pk,
-					DataSize:   dataSizes[i],
-				}
-
 				models[m] = mongo.NewReplaceOneModel().
-					SetFilter(filterDoc).
-					SetReplacement(recheckDoc).
+
+					// The filter must exclude DataSize; otherwise, if a failed comparison
+					// and a change event happen on the same document for the same
+					// generation, the 2nd insert will fail because a) its filter won’t
+					// match anything, and b) it’ll try to insert a new document with the
+					// same _id as the one that the 1st insert already created.
+					SetFilter(bson.D{{"_id", pk}}).
+					SetReplacement(RecheckDoc{
+						PrimaryKey: pk,
+						DataSize:   dataSizes[i],
+					}).
 					SetUpsert(true)
 			}
 
@@ -170,18 +166,29 @@ func (verifier *Verifier) insertRecheckDocs(
 	return nil
 }
 
-// ClearRecheckDocs deletes the previous generation’s recheck
+// ClearRecheckDocsWhileLocked deletes the previous generation’s recheck
 // documents from the verifier’s metadata.
 //
 // The verifier **MUST** be locked when this function is called (or panic).
-func (verifier *Verifier) ClearRecheckDocs(ctx context.Context) error {
+func (verifier *Verifier) ClearRecheckDocsWhileLocked(ctx context.Context) error {
 	prevGeneration := verifier.getPreviousGenerationWhileLocked()
 
-	verifier.logger.Debug().Msgf("Deleting generation %d’s %s documents", prevGeneration, recheckQueue)
+	verifier.logger.Debug().
+		Int("previousGeneration", prevGeneration).
+		Msg("Deleting previous generation's enqueued rechecks.")
 
-	_, err := verifier.verificationDatabase().Collection(recheckQueue).DeleteMany(
-		ctx, bson.D{{"_id.generation", prevGeneration}})
-	return err
+	return retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, i *retry.FuncInfo) error {
+			_, err := verifier.verificationDatabase().Collection(recheckQueue).DeleteMany(
+				ctx,
+				bson.D{{"_id.generation", prevGeneration}},
+			)
+
+			return err
+		},
+	)
 }
 
 func (verifier *Verifier) getPreviousGenerationWhileLocked() int {
@@ -193,12 +200,15 @@ func (verifier *Verifier) getPreviousGenerationWhileLocked() int {
 	return generation - 1
 }
 
-// GenerateRecheckTasks fetches the previous generation’s recheck
+// GenerateRecheckTasksWhileLocked fetches the previous generation’s recheck
 // documents from the verifier’s metadata and creates current-generation
 // document-verification tasks from them.
 //
+// Note that this function DOES NOT retry on failure, so callers should wrap
+// calls to this function in a retryer.
+//
 // The verifier **MUST** be locked when this function is called (or panic).
-func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
+func (verifier *Verifier) GenerateRecheckTasksWhileLocked(ctx context.Context) error {
 	prevGeneration := verifier.getPreviousGenerationWhileLocked()
 
 	findFilter := bson.D{{"_id.generation", prevGeneration}}
@@ -260,7 +270,7 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 
 		namespace := prevDBName + "." + prevCollName
 
-		err := verifier.InsertDocumentRecheckTask(
+		task, err := verifier.InsertDocumentRecheckTask(
 			ctx,
 			idAccum,
 			types.ByteCount(dataSizeAccum),
@@ -276,6 +286,7 @@ func (verifier *Verifier) GenerateRecheckTasks(ctx context.Context) error {
 		}
 
 		verifier.logger.Debug().
+			Interface("task", task.PrimaryKey).
 			Str("namespace", namespace).
 			Int("numDocuments", len(idAccum)).
 			Str("dataSize", reportutils.FmtBytes(dataSizeAccum)).

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -118,7 +118,7 @@ func (suite *IntegrationTestSuite) TestLargeIDInsertions() {
 
 	verifier.generation++
 	verifier.mux.Lock()
-	err = verifier.GenerateRecheckTasks(ctx)
+	err = verifier.GenerateRecheckTasksWhileLocked(ctx)
 	suite.Require().NoError(err)
 	taskColl := suite.metaMongoClient.Database(verifier.metaDBName).Collection(verificationTasksCollection)
 	cursor, err := taskColl.Find(ctx, bson.D{}, options.Find().SetProjection(bson.D{{"_id", 0}}))
@@ -180,7 +180,7 @@ func (suite *IntegrationTestSuite) TestLargeDataInsertions() {
 
 	verifier.generation++
 	verifier.mux.Lock()
-	err = verifier.GenerateRecheckTasks(ctx)
+	err = verifier.GenerateRecheckTasksWhileLocked(ctx)
 	suite.Require().NoError(err)
 	taskColl := suite.metaMongoClient.Database(verifier.metaDBName).Collection(verificationTasksCollection)
 	cursor, err := taskColl.Find(ctx, bson.D{}, options.Find().SetProjection(bson.D{{"_id", 0}}))
@@ -230,7 +230,7 @@ func (suite *IntegrationTestSuite) TestMultipleNamespaces() {
 
 	verifier.generation++
 	verifier.mux.Lock()
-	err = verifier.GenerateRecheckTasks(ctx)
+	err = verifier.GenerateRecheckTasksWhileLocked(ctx)
 	suite.Require().NoError(err)
 	taskColl := suite.metaMongoClient.Database(verifier.metaDBName).Collection(verificationTasksCollection)
 	cursor, err := taskColl.Find(ctx, bson.D{}, options.Find().SetProjection(bson.D{{"_id", 0}}))
@@ -308,21 +308,21 @@ func (suite *IntegrationTestSuite) TestGenerationalClear() {
 	verifier.mux.Lock()
 
 	verifier.generation = 2
-	err = verifier.ClearRecheckDocs(ctx)
+	err = verifier.ClearRecheckDocsWhileLocked(ctx)
 	suite.Require().NoError(err)
 
 	results = suite.fetchRecheckDocs(ctx, verifier)
 	suite.ElementsMatch([]interface{}{d1, d2, d5, d6}, results)
 
 	verifier.generation = 1
-	err = verifier.ClearRecheckDocs(ctx)
+	err = verifier.ClearRecheckDocsWhileLocked(ctx)
 	suite.Require().NoError(err)
 
 	results = suite.fetchRecheckDocs(ctx, verifier)
 	suite.ElementsMatch([]interface{}{d5, d6}, results)
 
 	verifier.generation = 3
-	err = verifier.ClearRecheckDocs(ctx)
+	err = verifier.ClearRecheckDocsWhileLocked(ctx)
 	suite.Require().NoError(err)
 
 	results = suite.fetchRecheckDocs(ctx, verifier)

--- a/internal/verifier/reset_test.go
+++ b/internal/verifier/reset_test.go
@@ -15,7 +15,7 @@ func (suite *IntegrationTestSuite) TestResetPrimaryTask() {
 
 	verifier := suite.BuildVerifier()
 
-	created, err := verifier.CheckIsPrimary(ctx)
+	created, err := verifier.CreatePrimaryTaskIfNeeded(ctx)
 	suite.Require().NoError(err)
 	suite.Require().True(created)
 
@@ -45,7 +45,7 @@ func (suite *IntegrationTestSuite) TestResetNonPrimaryTasks() {
 	verifier := suite.BuildVerifier()
 
 	// Create a primary task, and set it to complete.
-	created, err := verifier.CheckIsPrimary(ctx)
+	created, err := verifier.CreatePrimaryTaskIfNeeded(ctx)
 	suite.Require().NoError(err)
 	suite.Require().True(created)
 

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -30,8 +30,13 @@ const changeEventsTableMaxSize = 10
 func (verifier *Verifier) reportCollectionMetadataMismatches(ctx context.Context, strBuilder *strings.Builder) (bool, bool, error) {
 	generation, _ := verifier.getGeneration()
 
-	failedTasks, incompleteTasks, err :=
-		FetchFailedAndIncompleteTasks(ctx, verifier.verificationTaskCollection(), verificationTaskVerifyCollection, generation)
+	failedTasks, incompleteTasks, err := FetchFailedAndIncompleteTasks(
+		ctx,
+		verifier.logger,
+		verifier.verificationTaskCollection(),
+		verificationTaskVerifyCollection,
+		generation,
+	)
 	if err != nil {
 		return false, false, err
 	}
@@ -59,7 +64,13 @@ func (verifier *Verifier) reportCollectionMetadataMismatches(ctx context.Context
 func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuilder *strings.Builder) (bool, bool, error) {
 	generation, _ := verifier.getGeneration()
 
-	failedTasks, incompleteTasks, err := FetchFailedAndIncompleteTasks(ctx, verifier.verificationTaskCollection(), verificationTaskVerifyDocuments, generation)
+	failedTasks, incompleteTasks, err := FetchFailedAndIncompleteTasks(
+		ctx,
+		verifier.logger,
+		verifier.verificationTaskCollection(),
+		verificationTaskVerifyDocuments,
+		generation,
+	)
 
 	if err != nil {
 		return false, false, err

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -13,9 +13,14 @@ import (
 	"time"
 
 	"github.com/10gen/migration-verifier/internal/partitions"
+	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/types"
+	"github.com/10gen/migration-verifier/mslices"
+	"github.com/10gen/migration-verifier/option"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -121,7 +126,16 @@ func (verifier *Verifier) insertCollectionVerificationTask(
 			To:        dstNamespace,
 		},
 	}
-	_, err := verifier.verificationTaskCollection().InsertOne(ctx, verificationTask)
+
+	err := retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			_, err := verifier.verificationTaskCollection().InsertOne(ctx, verificationTask)
+			return err
+		},
+	)
+
 	return &verificationTask, err
 }
 
@@ -146,7 +160,8 @@ func (verifier *Verifier) InsertPartitionVerificationTask(
 	dstNamespace string,
 ) (*VerificationTask, error) {
 	srcNamespace := strings.Join([]string{partition.Ns.DB, partition.Ns.Coll}, ".")
-	verificationTask := VerificationTask{
+
+	task := VerificationTask{
 		PrimaryKey: primitive.NewObjectID(),
 		Generation: verifier.generation,
 		Status:     verificationTaskAdded,
@@ -158,8 +173,18 @@ func (verifier *Verifier) InsertPartitionVerificationTask(
 			To:        dstNamespace,
 		},
 	}
-	_, err := verifier.verificationTaskCollection().InsertOne(ctx, verificationTask)
-	return &verificationTask, err
+
+	err := retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			_, err := verifier.verificationTaskCollection().InsertOne(ctx, &task)
+
+			return err
+		},
+	)
+
+	return &task, err
 }
 
 func (verifier *Verifier) InsertDocumentRecheckTask(
@@ -167,17 +192,17 @@ func (verifier *Verifier) InsertDocumentRecheckTask(
 	ids []interface{},
 	dataSize types.ByteCount,
 	srcNamespace string,
-) error {
+) (*VerificationTask, error) {
 	dstNamespace := srcNamespace
 	if len(verifier.nsMap) != 0 {
 		var ok bool
 		dstNamespace, ok = verifier.nsMap[srcNamespace]
 		if !ok {
-			return fmt.Errorf("Could not find Namespace %s", srcNamespace)
+			return nil, fmt.Errorf("Could not find Namespace %s", srcNamespace)
 		}
 	}
 
-	verificationTask := VerificationTask{
+	task := VerificationTask{
 		PrimaryKey: primitive.NewObjectID(),
 		Generation: verifier.generation,
 		Ids:        ids,
@@ -191,97 +216,158 @@ func (verifier *Verifier) InsertDocumentRecheckTask(
 		SourceByteCount:     dataSize,
 	}
 
-	_, err := verifier.verificationTaskCollection().InsertOne(ctx, &verificationTask)
-	return err
+	err := retry.Retry(ctx, verifier.logger, func(ctx context.Context, _ *retry.FuncInfo) error {
+		_, err := verifier.verificationTaskCollection().InsertOne(ctx, &task)
+
+		return err
+	})
+
+	return &task, err
 }
 
-func (verifier *Verifier) FindNextVerifyTaskAndUpdate(ctx context.Context) (*VerificationTask, error) {
-	var verificationTask = VerificationTask{}
-	filter := bson.M{
-		"$and": bson.A{
-			bson.M{"generation": verifier.generation},
-			bson.M{"type": bson.M{
-				"$in": bson.A{
-					verificationTaskVerifyDocuments,
-					verificationTaskVerifyCollection,
+func (verifier *Verifier) FindNextVerifyTaskAndUpdate(
+	ctx context.Context,
+) (option.Option[VerificationTask], error) {
+	task := &VerificationTask{}
+
+	err := retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+
+			err := verifier.verificationTaskCollection().FindOneAndUpdate(
+				ctx,
+				bson.M{
+					"$and": []bson.M{
+						{"generation": verifier.generation},
+						{"type": bson.M{
+							"$in": mslices.Of(
+								verificationTaskVerifyDocuments,
+								verificationTaskVerifyCollection,
+							),
+						}},
+						{"status": verificationTaskAdded},
+					},
 				},
-			}},
-			bson.M{"status": verificationTaskAdded},
+				bson.M{
+					"$set": bson.M{
+						"status":     verificationTaskProcessing,
+						"begin_time": time.Now(),
+					},
+				},
+				options.FindOneAndUpdate().
+					SetReturnDocument(options.After).
+
+					// We want “verifyCollection” tasks before “verify”(-document) ones.
+					SetSort(bson.M{"type": -1}),
+			).Decode(task)
+
+			if err != nil {
+				task = nil
+				if errors.Is(err, mongo.ErrNoDocuments) {
+					err = nil
+				}
+			}
+
+			return err
 		},
-	}
+	)
 
-	coll := verifier.verificationTaskCollection()
-	opts := options.FindOneAndUpdate()
-	opts.SetReturnDocument(options.After)
-	updates := bson.M{
-		"$set": bson.M{
-			"status":     verificationTaskProcessing,
-			"begin_time": time.Now(),
-		},
-	}
-
-	// We want “verifyCollection” tasks before “verify”(-document) ones.
-	opts.SetSort(bson.M{"type": -1})
-
-	err := coll.FindOneAndUpdate(ctx, filter, updates, opts).Decode(&verificationTask)
-	return &verificationTask, err
+	return option.FromPointer(task), err
 }
 
 func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *VerificationTask) error {
-	updateFields := bson.M{
-		"$set": bson.M{
-			"status":                 task.Status,
-			"failed_docs":            task.FailedDocs,
-			"source_documents_count": task.SourceDocumentCount,
-			"source_bytes_count":     task.SourceByteCount,
-			"_ids":                   task.Ids,
-		},
-	}
-	result, err := verifier.verificationTaskCollection().UpdateOne(ctx, bson.M{"_id": task.PrimaryKey}, updateFields)
-	if err != nil {
-		return err
-	}
-	if result.MatchedCount == 0 {
-		return TaskError{Code: ErrorUpdateTask, Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey)}
-	}
+	return retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			result, err := verifier.verificationTaskCollection().UpdateOne(
+				ctx,
+				bson.M{"_id": task.PrimaryKey},
+				bson.M{
+					"$set": bson.M{
+						"status":                 task.Status,
+						"failed_docs":            task.FailedDocs,
+						"source_documents_count": task.SourceDocumentCount,
+						"source_bytes_count":     task.SourceByteCount,
+						"_ids":                   task.Ids,
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if result.MatchedCount == 0 {
+				return TaskError{
+					Code:    ErrorUpdateTask,
+					Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey),
+				}
+			}
 
-	return err
+			return err
+		},
+	)
 }
 
-func (verifier *Verifier) CheckIsPrimary(ctx context.Context) (bool, error) {
+func (verifier *Verifier) CreatePrimaryTaskIfNeeded(ctx context.Context) (bool, error) {
 	ownerSetId := primitive.NewObjectID()
-	filter := bson.M{"type": verificationTaskPrimary}
-	opts := options.Update()
-	opts.SetUpsert(true)
-	update := bson.M{
-		"$setOnInsert": bson.M{
-			"_id":    ownerSetId,
-			"type":   verificationTaskPrimary,
-			"status": verificationTaskAdded,
-		},
-	}
-	result, err := verifier.verificationTaskCollection().UpdateOne(ctx, filter, update, opts)
-	if err != nil {
-		return false, err
-	}
 
-	isPrimary := result.UpsertedID == ownerSetId
-	return isPrimary, nil
+	var created bool
+
+	err := retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			result, err := verifier.verificationTaskCollection().UpdateOne(
+				ctx,
+				bson.M{"type": verificationTaskPrimary},
+				bson.M{
+					"$setOnInsert": bson.M{
+						"_id":    ownerSetId,
+						"type":   verificationTaskPrimary,
+						"status": verificationTaskAdded,
+					},
+				},
+				options.Update().SetUpsert(true),
+			)
+			if err != nil {
+				return err
+			}
+
+			created = result.UpsertedID == ownerSetId
+
+			return nil
+		},
+	)
+
+	return created, err
 }
 
 func (verifier *Verifier) UpdatePrimaryTaskComplete(ctx context.Context) error {
-	updateFields := bson.M{
-		"$set": bson.M{
-			"status": verificationTaskCompleted,
-		},
-	}
-	result, err := verifier.verificationTaskCollection().UpdateMany(ctx, bson.M{"type": verificationTaskPrimary}, updateFields)
-	if err != nil {
-		return err
-	}
-	if result.MatchedCount == 0 {
-		return TaskError{Code: ErrorUpdateTask, Message: `no primary task found`}
-	}
+	return retry.Retry(
+		ctx,
+		verifier.logger,
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			result, err := verifier.verificationTaskCollection().UpdateMany(
+				ctx,
+				bson.M{"type": verificationTaskPrimary},
+				bson.M{
+					"$set": bson.M{
+						"status": verificationTaskCompleted,
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if result.MatchedCount == 0 {
+				return TaskError{
+					Code:    ErrorUpdateTask,
+					Message: `no primary task found`,
+				}
+			}
 
-	return err
+			return nil
+		},
+	)
 }


### PR DESCRIPTION
This changeset adds additional error codes to the retryer’s list of transient errors.

It also applies the retryer in several new places:
- metadata prep at the beginning of check
- generation of recheck tasks
- clearing of the recheck queue
- fetching failed & incomplete tasks
- find the next worker task
- get verification status
- inserting a partition verification task
- inserting a recheck task
- updating a verification task
- creating primary task
- setting the primary task to complete

A few functions are renamed for clarity as well, and some function calls are rewritten to read (hopefully) a bit more clearly.