### PR TITLE
REP-5329 Teach retryer to run +1 callback in parallel.

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -324,7 +324,7 @@ func GetSizeAndDocumentCount(ctx context.Context, logger *logger.Logger, retryer
 		Capped bool  `bson:"capped"`
 	}{}
 
-	err := retryer.Run(ctx, logger, func(ri *retry.Info) error {
+	err := retryer.Run(ctx, logger, func(ctx context.Context, ri *retry.Info) error {
 		ri.Log(logger.Logger, "collStats", "source", srcDB.Name(), collName, "Retrieving collection size and document count.")
 		request := bson.D{
 			{"aggregate", collName},
@@ -395,7 +395,7 @@ func GetDocumentCountAfterFiltering(ctx context.Context, logger *logger.Logger, 
 	}
 	pipeline = append(pipeline, bson.D{{"$count", "numFilteredDocs"}})
 
-	err := retryer.Run(ctx, logger, func(ri *retry.Info) error {
+	err := retryer.Run(ctx, logger, func(ctx context.Context, ri *retry.Info) error {
 		ri.Log(logger.Logger, "count", "source", srcDB.Name(), collName, "Counting filtered documents.")
 		request := bson.D{
 			{"aggregate", collName},
@@ -488,7 +488,7 @@ func getOuterIDBound(
 	}...)
 
 	// Get one document containing only the smallest or largest _id value in the collection.
-	err := retryer.Run(ctx, subLogger, func(ri *retry.Info) error {
+	err := retryer.Run(ctx, subLogger, func(ctx context.Context, ri *retry.Info) error {
 		ri.Log(subLogger.Logger, "aggregate", "source", srcDB.Name(), collName, fmt.Sprintf("getting %s _id partition bound", minOrMaxBound))
 		cursor, cmdErr :=
 			srcDB.RunCommandCursor(ctx, bson.D{
@@ -577,7 +577,7 @@ func getMidIDBounds(
 	// Get a cursor for the $sample and $bucketAuto aggregation.
 	var midIDBounds []interface{}
 	agRetryer := retryer.WithErrorCodes(util.SampleTooManyDuplicates)
-	err := agRetryer.Run(ctx, logger, func(ri *retry.Info) error {
+	err := agRetryer.Run(ctx, logger, func(ctx context.Context, ri *retry.Info) error {
 		ri.Log(logger.Logger, "aggregate", "source", srcDB.Name(), collName, "Retrieving mid _id partition bounds using $sample.")
 		cursor, cmdErr :=
 			srcDB.RunCommandCursor(ctx, bson.D{

--- a/internal/retry/constants.go
+++ b/internal/retry/constants.go
@@ -3,16 +3,8 @@ package retry
 import "time"
 
 const (
-	// DefaultDurationLimit is the default time limit for all retries. This is
-	// currently 10 minutes.
+	// DefaultDurationLimit is the default time limit for all retries.
 	DefaultDurationLimit = 10 * time.Minute
-
-	// The number of CollectionUUIDMismatch error retries we do
-	// before logging a warning. Under normal circumstances, we
-	// don't ever expect more than a couple. Anything more than
-	// that requires collection renames to interleave between
-	// retry attempts.
-	numCollectionUUIDRetriesBeforeWarning = 10
 
 	// Constants for spacing out the retry attempts.
 	// See: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/internal/retry/error.go
+++ b/internal/retry/error.go
@@ -1,0 +1,27 @@
+package retry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/10gen/migration-verifier/internal/reportutils"
+)
+
+type RetryDurationLimitExceededErr struct {
+	lastErr  error
+	attempts int
+	duration time.Duration
+}
+
+func (rde RetryDurationLimitExceededErr) Error() string {
+	return fmt.Sprintf(
+		"retryable function did not succeed after %d attempt(s) over %s; last error was: %v",
+		rde.attempts,
+		reportutils.DurationToHMS(rde.duration),
+		rde.lastErr,
+	)
+}
+
+func (rde RetryDurationLimitExceededErr) Unwrap() error {
+	return rde.lastErr
+}

--- a/internal/retry/error.go
+++ b/internal/retry/error.go
@@ -25,3 +25,15 @@ func (rde RetryDurationLimitExceededErr) Error() string {
 func (rde RetryDurationLimitExceededErr) Unwrap() error {
 	return rde.lastErr
 }
+
+// errgroupErr is an internal error type that we return from errgroup
+// callbacks. It allows us to know (reliably) which error is the one
+// that triggers the errgroup's failure
+type errgroupErr struct {
+	funcNum         int
+	errFromCallback error
+}
+
+func (ege errgroupErr) Error() string {
+	return fmt.Sprintf("func %d failed: %v", ege.funcNum, ege.errFromCallback)
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -6,210 +6,57 @@ import (
 	"time"
 
 	"github.com/10gen/migration-verifier/internal/logger"
+	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
-// RunForUUIDAndTransientErrors retries f() for the CollectionUUIDMismatch error and for transient errors.
-// This should be used to run a driver operation that optionally specifies the `collectionUUID` parameter
-// for a collection that may have been:
+// Run retries f() whenever a transient error happens, up to the retryer's
+// configured duration limit.
 //
-//   - Dropped and requires no further action from f().
-//   - Renamed and requires a retry for f() with an updated collection name.
-//
-// IMPORTANT: This function should generally NOT be used within a transaction callback. It may be used
-// within a transaction callback if and only if:
+// IMPORTANT: This function should generally NOT be used within a transaction
+// callback. It may be used within a transaction callback if and only if:
 //
 //   - f() uses a different context than the transaction's session context, and:
-//   - f() runs driver operations on a different cluster than the one the transaction is being run on.
+//   - f() runs driver operations on a different cluster than the one the
+//     transaction is being run on.
 //
 // See: https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#interaction-with-retryable-writes
 //
-// The collection's expected name should be provided as the expectedCollName parameter if f() uses the
-// `collectionUUID` parameter. The expectedCollName may be set to the empty string if f() is guaranteed
-// to know the collection's name (e.g. for mongosync's metadata) or if f() does not need to reference a
-// collection (e.g. when running a command against the admin database).
-//
-// f() is provided with a collection name string, which is the one that should be used in the body
-// of f() when a collection name is needed. The initial value of this string is expectedCollName.
-//
-// RunForUUIDAndTransientErrors always returns the collection's current name. It returns
-// an error if the duration limit is reached, or if f() returns a non-transient error.
-func (r *Retryer) RunForUUIDAndTransientErrors(
-	ctx context.Context, logger *logger.Logger, expectedCollName string, f func(*Info, string) error,
-) (string, error) {
-	return r.runRetryLoop(ctx, logger, expectedCollName, f, true, true)
-}
-
-// RunForUUIDErrorOnly retries f() for the CollectionUUIDMismatch error only. This should primarily
-// be used to wrap a transaction callback containing an operation that specifies the `collectionUUID`
-// parameter for a collection that may have been:
-//
-//   - Dropped and requires no further action from f().
-//   - Renamed and requires a retry for f() with an updated collection name.
-//
-// We retry only CollectionUUIDMismatch errors for transactions since transactions are already sufficiently
-// retried for transient errors by the driver.
-//
-// The collection's expected name should be provided as the expectedCollName parameter and shouldn't be blank.
-//
-// f() is provided with a collection name string, which is the one that should be used in the body
-// of f() where a collection name is needed. The initial value of this string is expectedCollName.
-//
-// RunForUUIDErrorOnly returns the collection's current name in all cases.
-func (r *Retryer) RunForUUIDErrorOnly(
-	ctx context.Context, logger *logger.Logger, expectedCollName string, f func(*Info, string) error,
-) (string, error) {
-	// Since we're not actually sleeping when checking for UUID/name mismatch
-	// errors, we don't need to provide a real context to handle
-	// cancellations.
-	return r.runRetryLoop(ctx, logger, expectedCollName, f, false, true)
-}
-
-// RunForTransientErrorsOnly retries f() for transient errors only, and
-// does not check for UUID mismatch error.
-//
-// RunForUUIDErrorOnly returns the collection's current name if f() succeeds.
-func (r *Retryer) RunForTransientErrorsOnly(
+// This returns an error if the duration limit is reached, or if f() returns a
+// non-transient error.
+func (r *Retryer) Run(
 	ctx context.Context, logger *logger.Logger, f func(*Info) error,
 ) error {
-	wrapper := func(ri *Info, _ string) error {
-		return f(ri)
-	}
-	_, err := r.runRetryLoop(ctx, logger, "", wrapper, true, false)
-	return err
+	return r.runRetryLoop(ctx, logger, f)
 }
 
-// runRetryLoop contains the core logic for the retry loops. This is separated
-// into its own method so we can share this logic between retries with and
-// without transient error handling. It's important that we _always_ return a
-// collection name, even if we're also returning an error. The reason is that
-// there is some code that does something like this:
-//
-//	collName, err := retryer.RunForUUIDAndTransientErrors(ctx, logger, collName, f)
-//	if someCondition && isSomeSortOfError(err) {
-//	    collName, err := retryer.RunForUUIDAndTransientErrors(ctx, logger, collName, f)
-//	}
-//
-// If we return an empty string on an error then we will break that second
-// call. Arguably, this sort of pattern should maybe be moved into the
-// retryer, but until it is we cannot change this function's return vals.
+// runRetryLoop contains the core logic for the retry loops.
 func (r *Retryer) runRetryLoop(
 	ctx context.Context,
 	logger *logger.Logger,
-	expectedCollName string,
-	f func(*Info, string) error,
-	handleTransientErrors bool,
-	handleUUIDMismatchErrors bool,
-) (string, error) {
-	util.Invariant(
-		logger,
-		handleTransientErrors || handleUUIDMismatchErrors,
-		"runRetryLoop must be called with at least one of handleTransientErrors or handleUUIDMismatchErrors set to true",
-	)
-
-	// If we are given an empty string as a name, that means that the
-	// collection was already dropped, so there's nothing else to do.
-	if handleUUIDMismatchErrors && expectedCollName == "" {
-		logger.Debug().Msg(
-			"The collection name is empty, meaning the collection was dropped, so we will not start this operation")
-		return "", nil
-	}
-
+	f func(*Info) error,
+) error {
 	var err error
 
 	ri := &Info{
-		attemptNumber:            0,
-		durationSoFar:            0,
-		durationLimit:            r.retryLimit,
-		shouldResetDuration:      false,
-		numCollectionUUIDRetries: 0,
+		durationLimit: r.retryLimit,
 	}
 	sleepTime := minSleepTime
-
-	// We start with the expected collection name that is provided.
-	currCollName := expectedCollName
 
 	for ri.durationSoFar <= ri.durationLimit {
 		retryStartTime := time.Now()
 
 		// Run f() with the current collection name.
-		err = f(ri, currCollName)
-
-		// If f() returned a CollectionUUIDMismatch error, get the updated collection name
-		// from the error. If the name is blank, it means the collection no longer exists.
-		if handleUUIDMismatchErrors && util.IsCollectionUUIDMismatchError(err) {
-			prevCollName := currCollName
-			currCollName, err = util.GetActualCollectionFromCollectionUUIDMismatchError(logger, err)
-			if err != nil {
-				return currCollName, err
-			}
-			if currCollName == "" {
-				logger.Debug().
-					Str("expected collection name", expectedCollName).
-					Str("previous collection name", prevCollName).
-					Msg("The collection was dropped so we will not retry this operation")
-				return currCollName, nil
-			}
-
-			// If this happens something is terribly wrong with the server
-			// we're talking to or in our code.
-			if prevCollName == currCollName {
-				logger.Error().
-					Str("expected collection name", expectedCollName).
-					Str("previous collection name", prevCollName).
-					Str("actual collection name", currCollName).
-					Msg("Got a collection UUID mismatch error but the actual collection name matches the last used name. Giving up on retries.")
-				return currCollName, err
-			}
-
-			logger.Debug().
-				Str("expected collection name", expectedCollName).
-				Str("previous collection name", prevCollName).
-				Str("actual collection name", currCollName).
-				Msg("Got a collection UUID mismatch error and will retry with the actual collection name.")
-
-			ri.numCollectionUUIDRetries++
-			// We warn for an unusually high number of CollectionUUIDMismatch errors. This shouldn't happen in practice.
-			if ri.numCollectionUUIDRetries >= numCollectionUUIDRetriesBeforeWarning {
-				logger.Warn().
-					Msgf("Unexpectedly high number of CollectionUUIDMismatch error retries for collection with "+
-						"expected name %s (%d retries so far).", expectedCollName, ri.numCollectionUUIDRetries)
-			}
-
-			continue
-		}
-
-		// isPreV50CollectionUUIDNotSupportErr is the helper function to check the error returned from MongoDB pre-V5.0
-		// because of collectionUUID not supported.
-		isPreV50CollectionUUIDNotSupportErr := func(err error) bool {
-			return util.IsFailedToParseError(err) && util.HasServerErrorMessage(err, "collectionUUID")
-		}
-		// isV50CollectionUUIDNotSupportErr is the helper function to check the error returned from MongoDB V5.0
-		// because of collectionUUID not supported.
-		isV50CollectionUUIDNotSupportErr := func(err error) bool {
-			return util.HasServerErrorMessage(err, "collectionUUID is not supported")
-		}
-
-		// If this is the first time we've come across a failure to parse
-		// collection UUID, try again with the UUID elided (if the caller used
-		// RequestWithUUID).
-		if r.retryOnUUIDNotSupported && !r.aggregateDisallowsUUIDs &&
-			(isPreV50CollectionUUIDNotSupportErr(err) || isV50CollectionUUIDNotSupportErr(err)) {
-			logger.Debug().Msg("Server does not support UUIDs in 'aggregate'. Will retry without UUID.")
-			ri.attemptNumber++
-			r.aggregateDisallowsUUIDs = true
-			continue
-		}
+		err = f(ri)
 
 		// If f() returned a transient error, sleep and increase the sleep
 		// time for the next retry, maxing out at the maxSleepTime.
-		if r.shouldRetryWithSleep(logger, handleTransientErrors, sleepTime, err) {
+		if r.shouldRetryWithSleep(logger, sleepTime, err) {
 			select {
 			case <-ctx.Done():
 				logger.Error().Err(ctx.Err()).Msg("Context was canceled. Aborting retry loop.")
-				return currCollName, ctx.Err()
+				return ctx.Err()
 			case <-time.After(sleepTime):
 				sleepTime *= sleepTimeMultiplier
 				if sleepTime > maxSleepTime {
@@ -228,18 +75,14 @@ func (r *Retryer) runRetryLoop(
 			continue
 		}
 
-		// If f() had no error, return the current collection name.
-		if err == nil {
-			return currCollName, nil
-		}
-
-		return currCollName, err
+		return err
 	}
 
-	return currCollName, errors.Wrapf(err,
-		"retryable function did not succeed after %d attempt(s) over %.2f second(s)",
+	return errors.Wrapf(err,
+		"retryable function did not succeed after %d attempt(s) over %s",
 		ri.attemptNumber,
-		ri.durationSoFar.Seconds())
+		reportutils.DurationToHMS(ri.durationSoFar),
+	)
 }
 
 //
@@ -254,7 +97,6 @@ func (r *Retryer) runRetryLoop(
 
 func (r *Retryer) shouldRetryWithSleep(
 	logger *logger.Logger,
-	handleTransientErrors bool,
 	sleepTime time.Duration,
 	err error,
 ) bool {
@@ -263,10 +105,6 @@ func (r *Retryer) shouldRetryWithSleep(
 	if r.retryRandomly && rand.Int()%100 == 0 {
 		logger.Debug().Msgf("Waiting %s seconds to retry operation because of test code forcing a retry.", sleepTime)
 		return true
-	}
-
-	if !handleTransientErrors {
-		return false
 	}
 
 	if err == nil {
@@ -292,14 +130,4 @@ func (r *Retryer) shouldRetryWithSleep(
 		Msg("Not retrying on error because it is not transient nor is it in our additional codes list.")
 
 	return false
-}
-
-// Use this method for aggregates which should take a UUID in new versions but not old ones.
-// Pass the request without the collectionUUID field in 'request'.
-// Currently, use only for 'aggregate'; 'find' always supports UUID.
-func (r *Retryer) RequestWithUUID(request bson.D, uuid util.UUID) bson.D {
-	if r.aggregateDisallowsUUIDs {
-		return request
-	}
-	return append(append(bson.D{}, request[0], bson.E{"collectionUUID", uuid}), request[1:]...)
 }

--- a/internal/retry/retry_info.go
+++ b/internal/retry/retry_info.go
@@ -15,7 +15,7 @@ import (
 type Info struct {
 	attemptNumber int
 
-	durationSoFar time.Duration
+	lastResetTime time.Time
 	durationLimit time.Duration
 
 	// Used to reset the time elapsed for long running operations.
@@ -52,7 +52,7 @@ func (ri *Info) Log(logger *zerolog.Logger, cmdName string, clientType string, d
 	}
 	event.Str("context", msg).
 		Int("attemptNumber", ri.attemptNumber).
-		Str("durationSoFar", reportutils.DurationToHMS(ri.durationSoFar)).
+		Str("durationSoFar", reportutils.DurationToHMS(ri.GetDurationSoFar())).
 		Str("durationLimit", reportutils.DurationToHMS(ri.durationLimit)).
 		Msg("Running retryable function")
 }
@@ -65,7 +65,7 @@ func (ri *Info) GetAttemptNumber() int {
 // GetDurationSoFar returns the Info's current duration so far. This duration
 // applies to the duration of retrying for transient errors only.
 func (ri *Info) GetDurationSoFar() time.Duration {
-	return ri.durationSoFar
+	return time.Since(ri.lastResetTime)
 }
 
 // IterationSuccess is used to tell the retry util to reset its measurement

--- a/internal/retry/retry_info.go
+++ b/internal/retry/retry_info.go
@@ -3,6 +3,7 @@ package retry
 import (
 	"time"
 
+	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/rs/zerolog"
 )
 
@@ -19,9 +20,6 @@ type Info struct {
 
 	// Used to reset the time elapsed for long running operations.
 	shouldResetDuration bool
-
-	// Mostly useful for testing.
-	numCollectionUUIDRetries int
 }
 
 // Log will log a debug-level message for the current Info values and the provided strings.
@@ -54,8 +52,8 @@ func (ri *Info) Log(logger *zerolog.Logger, cmdName string, clientType string, d
 	}
 	event.Str("context", msg).
 		Int("attemptNumber", ri.attemptNumber).
-		Int("durationSoFar (seconds)", int(ri.durationSoFar.Seconds())).
-		Int("durationLimit (seconds)", int(ri.durationLimit.Seconds())).
+		Str("durationSoFar", reportutils.DurationToHMS(ri.durationSoFar)).
+		Str("durationLimit", reportutils.DurationToHMS(ri.durationLimit)).
 		Msg("Running retryable function")
 }
 
@@ -68,12 +66,6 @@ func (ri *Info) GetAttemptNumber() int {
 // applies to the duration of retrying for transient errors only.
 func (ri *Info) GetDurationSoFar() time.Duration {
 	return ri.durationSoFar
-}
-
-// GetNumCollectionUUIDMismatchRetries returns the number of retries for
-// CollectionUUIDMismatch errors so far. Mostly useful for testing.
-func (ri *Info) GetNumCollectionUUIDMismatchRetries() int {
-	return ri.numCollectionUUIDRetries
 }
 
 // IterationSuccess is used to tell the retry util to reset its measurement

--- a/internal/retry/retry_info.go
+++ b/internal/retry/retry_info.go
@@ -7,19 +7,20 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Info stores information relevant to the retrying done. It should
+// LoopInfo stores information relevant to the retrying done. It should
 // primarily be used within the closure passed to the retry helpers.
 //
 // The attempt number is 0-indexed (0 means this is the first attempt).
 // The duration tracks the duration of retrying for transient errors only.
-type Info struct {
+type LoopInfo struct {
 	attemptNumber int
+	durationLimit time.Duration
+}
+
+type FuncInfo struct {
+	loopInfo *LoopInfo
 
 	lastResetTime time.Time
-	durationLimit time.Duration
-
-	// Used to reset the time elapsed for long running operations.
-	shouldResetDuration bool
 }
 
 // Log will log a debug-level message for the current Info values and the provided strings.
@@ -30,7 +31,7 @@ type Info struct {
 //
 // Useful for keeping track of DDL commands that access/change the cluster in some way.
 // Generally not recommended for CRUD commands, which may result in too many log lines.
-func (ri *Info) Log(logger *zerolog.Logger, cmdName string, clientType string, database string, collection string, msg string) {
+func (fi *FuncInfo) Log(logger *zerolog.Logger, cmdName string, clientType string, database string, collection string, msg string) {
 	// Don't log if no logger is provided. Mostly useful for
 	// integration tests where we don't want additional logs.
 	if logger == nil {
@@ -51,31 +52,29 @@ func (ri *Info) Log(logger *zerolog.Logger, cmdName string, clientType string, d
 		event.Str("collection", collection)
 	}
 	event.Str("context", msg).
-		Int("attemptNumber", ri.attemptNumber).
-		Str("durationSoFar", reportutils.DurationToHMS(ri.GetDurationSoFar())).
-		Str("durationLimit", reportutils.DurationToHMS(ri.durationLimit)).
+		Int("attemptNumber", fi.GetAttemptNumber()).
+		Str("durationSoFar", reportutils.DurationToHMS(fi.GetDurationSoFar())).
+		Str("durationLimit", reportutils.DurationToHMS(fi.loopInfo.durationLimit)).
 		Msg("Running retryable function")
 }
 
 // GetAttemptNumber returns the Info's current attempt number (0-indexed).
-func (ri *Info) GetAttemptNumber() int {
-	return ri.attemptNumber
+func (fi *FuncInfo) GetAttemptNumber() int {
+	return fi.loopInfo.attemptNumber
 }
 
 // GetDurationSoFar returns the Info's current duration so far. This duration
 // applies to the duration of retrying for transient errors only.
-func (ri *Info) GetDurationSoFar() time.Duration {
-	return time.Since(ri.lastResetTime)
+func (fi *FuncInfo) GetDurationSoFar() time.Duration {
+	return time.Since(fi.lastResetTime)
 }
 
-// IterationSuccess is used to tell the retry util to reset its measurement
+// NoteSuccess is used to tell the retry util to reset its measurement
 // of how long the closure has been running for. This is useful for long
 // running operations that might run successfully for a few days and then fail.
-// Essentially, calling this function tells the retry util not to include the
-// closure's run time as a part of the overall measurement of how long the
-// closure took including retries, since that measurement is used to determine
-// whether we want to retry the operation or not. (If the measurement is greater
-// than the retry time, we will not retry.)
-func (ri *Info) IterationSuccess() {
-	ri.shouldResetDuration = true
+//
+// Call this after every successful command in a multi-command callback.
+// (It’s useless--but harmless--in a single-command callback.)
+func (i *FuncInfo) NoteSuccess() {
+	i.lastResetTime = time.Now()
 }

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -4,14 +4,11 @@ import (
 	"time"
 )
 
-// Retryer handles retrying operations that fail because of network and UUID
-// mismatch failures.
+// Retryer handles retrying operations that fail because of network failures.
 type Retryer struct {
-	retryLimit              time.Duration
-	retryRandomly           bool
-	additionalErrorCodes    []int
-	retryOnUUIDNotSupported bool
-	aggregateDisallowsUUIDs bool
+	retryLimit           time.Duration
+	retryRandomly        bool
+	additionalErrorCodes []int
 }
 
 // New returns a new retryer.
@@ -23,9 +20,8 @@ func New(retryLimit time.Duration) Retryer {
 // retryRandomly field.
 func NewWithRandomlyRetries(retryLimit time.Duration, retryRandomly bool) Retryer {
 	return Retryer{
-		retryLimit:           retryLimit,
-		retryRandomly:        retryRandomly,
-		additionalErrorCodes: nil,
+		retryLimit:    retryLimit,
+		retryRandomly: retryRandomly,
 	}
 }
 
@@ -34,20 +30,8 @@ func NewWithRandomlyRetries(retryLimit time.Duration, retryRandomly bool) Retrye
 // wants to retry on. Note that if the Retryer already has additional custom
 // error codes set, these are _replaced_ when this method is called.
 func (r Retryer) WithErrorCodes(codes ...int) Retryer {
-	return Retryer{
-		retryLimit:           r.retryLimit,
-		retryRandomly:        r.retryRandomly,
-		additionalErrorCodes: codes,
-	}
-}
+	r2 := r
+	r2.additionalErrorCodes = codes
 
-// Mongod versions older than 5.0 do not support collectionUUID in aggregate commands.  This method
-// will result in not using the UUID and instead using the collection name in those cases.  Be
-// warned that this will make the application vulnerable to inconsistencies due to collection
-// renames.
-//
-// See also RequestWithUUID in retry.go
-func (r Retryer) SetRetryOnUUIDNotSupported() Retryer {
-	r.retryOnUUIDNotSupported = true
-	return r
+	return r2
 }

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -3,11 +3,9 @@ package retry
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/10gen/migration-verifier/internal/util"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -17,16 +15,12 @@ func (suite *UnitTestSuite) TestRetryer() {
 
 	suite.Run("with a function that immediately succeeds", func() {
 		attemptNumber := -1
-		f := func(ri *Info, _ string) error {
+		f := func(ri *Info) error {
 			attemptNumber = ri.GetAttemptNumber()
 			return nil
 		}
 
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
-		suite.NoError(err)
-		suite.Equal(0, attemptNumber)
-
-		_, err = retryer.RunForUUIDErrorOnly(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.NoError(err)
 		suite.Equal(0, attemptNumber)
 
@@ -35,14 +29,14 @@ func (suite *UnitTestSuite) TestRetryer() {
 			return nil
 		}
 
-		err = retryer.RunForTransientErrorsOnly(suite.Context(), logger, f2)
+		err = retryer.Run(suite.Context(), logger, f2)
 		suite.NoError(err)
 		suite.Equal(0, attemptNumber)
 	})
 
 	suite.Run("with a function that succeeds after two attempts", func() {
 		attemptNumber := -1
-		f := func(ri *Info, _ string) error {
+		f := func(ri *Info) error {
 			attemptNumber = ri.GetAttemptNumber()
 			if attemptNumber < 2 {
 				return mongo.CommandError{
@@ -53,7 +47,7 @@ func (suite *UnitTestSuite) TestRetryer() {
 			return nil
 		}
 
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.NoError(err)
 		suite.Equal(2, attemptNumber)
 
@@ -69,51 +63,9 @@ func (suite *UnitTestSuite) TestRetryer() {
 			return nil
 		}
 
-		err = retryer.RunForTransientErrorsOnly(suite.Context(), logger, f2)
+		err = retryer.Run(suite.Context(), logger, f2)
 		suite.NoError(err)
 		suite.Equal(2, attemptNumber)
-	})
-
-	suite.Run("with a UUID vs name mismatch error", func() {
-		attemptLimit := 4
-		attemptNumber := -1
-		f := func(ri *Info, _ string) error {
-			attemptNumber = ri.GetNumCollectionUUIDMismatchRetries()
-			if attemptNumber < attemptLimit/2 {
-				// The actual name needs to change each time we retry or we'll
-				// abort early.
-				raw, err := bson.Marshal(bson.D{{"actualCollection", fmt.Sprintf("foo%d", attemptNumber)}})
-				suite.NoError(err)
-				return mongo.CommandError{
-					Name: "UUIDMismatchError",
-					Code: 361,
-					Raw:  bson.Raw(raw),
-				}
-			}
-			return nil
-		}
-		_, err := retryer.RunForUUIDErrorOnly(suite.Context(), logger, "bar", f)
-		suite.NoError(err)
-		suite.Equal(attemptLimit/2, attemptNumber)
-	})
-
-	suite.Run("the mismatch error returns the same name as was used", func() {
-		attemptNumber := -1
-		f := func(ri *Info, _ string) error {
-			attemptNumber = ri.GetNumCollectionUUIDMismatchRetries()
-			raw, err := bson.Marshal(bson.D{{"actualCollection", "foo"}})
-			suite.NoError(err)
-			return mongo.CommandError{
-				Name: "UUIDMismatchError",
-				Code: 361,
-				Raw:  bson.Raw(raw),
-			}
-		}
-		_, err := retryer.RunForUUIDErrorOnly(suite.Context(), logger, "bar", f)
-		suite.NoError(err)
-		// We only did one retry because the actual collection name matched the
-		// previous attempt.
-		suite.Equal(1, attemptNumber)
 	})
 }
 
@@ -125,12 +77,12 @@ func (suite *UnitTestSuite) TestRetryerDurationLimitIsZero() {
 		Labels: []string{"NetworkError"},
 		Name:   "NetworkError",
 	}
-	f := func(ri *Info, _ string) error {
+	f := func(ri *Info) error {
 		attemptNumber = ri.attemptNumber
 		return cmdErr
 	}
 
-	_, err := retryer.RunForUUIDErrorOnly(suite.Context(), suite.Logger(), "bar", f)
+	err := retryer.Run(suite.Context(), suite.Logger(), f)
 	suite.Equal(cmdErr, err)
 	suite.Equal(0, attemptNumber)
 }
@@ -151,7 +103,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 	// 1) Not calling IterationSuccess() means f will not be retried, since the
 	// durationLimit is exceeded
 	noSuccessIterations := 0
-	f1 := func(ri *Info, _ string) error {
+	f1 := func(ri *Info) error {
 		// Artificially advance how much time was taken.
 		ri.durationSoFar += 2 * ri.durationLimit
 
@@ -163,7 +115,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 		return nil
 	}
 
-	_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f1)
+	err := retryer.Run(suite.Context(), logger, f1)
 	// err is not nil and err is not the network error thrown by the function.
 	suite.Error(err)
 	suite.NotEqual(err, transientNetworkError)
@@ -172,7 +124,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 	// 2) Calling IterationSuccess() means f will run more than once because the
 	// duration should be reset.
 	successIterations := 0
-	f2 := func(ri *Info, _ string) error {
+	f2 := func(ri *Info) error {
 		// Artificially advance how much time was taken.
 		ri.durationSoFar += 2 * ri.durationLimit
 
@@ -186,7 +138,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 		return nil
 	}
 
-	_, err = retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f2)
+	err = retryer.Run(suite.Context(), logger, f2)
 	suite.NoError(err)
 	suite.Equal(2, successIterations)
 }
@@ -198,7 +150,7 @@ func (suite *UnitTestSuite) TestCancelViaContext() {
 	counter := 0
 	var wg sync.WaitGroup
 	wg.Add(1)
-	f := func(_ *Info, _ string) error {
+	f := func(_ *Info) error {
 		counter++
 		if counter == 1 {
 			return errors.New("not master")
@@ -212,7 +164,7 @@ func (suite *UnitTestSuite) TestCancelViaContext() {
 	// retry code will see the cancel before the timer it sets expires.
 	cancel()
 	go func() {
-		_, err := retryer.RunForUUIDAndTransientErrors(ctx, logger, "foo", f)
+		err := retryer.Run(ctx, logger, f)
 		suite.ErrorIs(err, context.Canceled)
 		suite.Equal(1, counter)
 		wg.Done()
@@ -230,7 +182,7 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	}
 
 	var attemptNumber int
-	f := func(ri *Info, _ string) error {
+	f := func(ri *Info) error {
 		attemptNumber = ri.GetAttemptNumber()
 		if attemptNumber == 0 {
 			return customError
@@ -240,7 +192,7 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 
 	suite.Run("with no additional error codes", func() {
 		retryer := New(DefaultDurationLimit)
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.Equal(42, util.GetErrorCode(err))
 		suite.Equal(0, attemptNumber)
 	})
@@ -248,7 +200,7 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	suite.Run("with one additional error code", func() {
 		retryer := New(DefaultDurationLimit)
 		retryer = retryer.WithErrorCodes(42)
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.NoError(err)
 		suite.Equal(1, attemptNumber)
 	})
@@ -256,7 +208,7 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	suite.Run("with multiple additional error codes", func() {
 		retryer := New(DefaultDurationLimit)
 		retryer = retryer.WithErrorCodes(42, 43, 44)
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.NoError(err)
 		suite.Equal(1, attemptNumber)
 	})
@@ -264,76 +216,8 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	suite.Run("with multiple additional error codes that don't match error", func() {
 		retryer := New(DefaultDurationLimit)
 		retryer = retryer.WithErrorCodes(41, 43, 44)
-		_, err := retryer.RunForUUIDAndTransientErrors(suite.Context(), logger, "foo", f)
+		err := retryer.Run(suite.Context(), logger, f)
 		suite.Equal(42, util.GetErrorCode(err))
 		suite.Equal(0, attemptNumber)
 	})
-}
-
-func (suite *UnitTestSuite) TestRetryerWithEmptyCollectionName() {
-	retryer := New(DefaultDurationLimit)
-	emptyCollNameError := errors.New("Empty collection name")
-	f := func(_ *Info, collName string) error {
-		if collName == "" {
-			return emptyCollNameError
-		}
-		return nil
-	}
-
-	name, err := retryer.RunForUUIDErrorOnly(suite.Context(), suite.Logger(), "", f)
-	suite.NoError(err)
-	suite.Equal("", name)
-}
-
-// Test fix for REP-4197
-func (suite *UnitTestSuite) TestV50RetryerWithUUIDNotSupportedError() {
-	retryer := New(0)
-
-	attemptNumber := 0
-	cmdErr := mongo.CommandError{
-		Message: "(Location4928902) collectionUUID is not supported on a mongos",
-	}
-	f := func(ri *Info, _ string) error {
-		attemptNumber = ri.attemptNumber
-		if attemptNumber == 0 {
-			return cmdErr
-		} else {
-			return nil
-		}
-	}
-
-	r := retryer.SetRetryOnUUIDNotSupported()
-	r.aggregateDisallowsUUIDs = false
-	_, err := r.RunForUUIDAndTransientErrors(suite.Context(), suite.Logger(), "bar", f)
-	// The aggregateDisallowsUUIDs will be set to True in the retry
-	suite.True(r.aggregateDisallowsUUIDs)
-	suite.NoError(err)
-	suite.Equal(1, attemptNumber)
-}
-
-func (suite *UnitTestSuite) TestPreV50RetryerWithUUIDNotSupportedError() {
-	retryer := New(0)
-
-	attemptNumber := 0
-	cmdErr := mongo.CommandError{
-		Message: "(FailedToParse) unrecognized field 'collectionUUID",
-		Name:    "FailedToParseError",
-		Code:    9,
-	}
-	f := func(ri *Info, _ string) error {
-		attemptNumber = ri.attemptNumber
-		if attemptNumber == 0 {
-			return cmdErr
-		} else {
-			return nil
-		}
-	}
-
-	r := retryer.SetRetryOnUUIDNotSupported()
-	r.aggregateDisallowsUUIDs = false
-	_, err := r.RunForUUIDAndTransientErrors(suite.Context(), suite.Logger(), "bar", f)
-	// The aggregateDisallowsUUIDs will be set to True in the retry
-	suite.True(r.aggregateDisallowsUUIDs)
-	suite.NoError(err)
-	suite.Equal(1, attemptNumber)
 }

--- a/internal/uuidutil/get_uuid.go
+++ b/internal/uuidutil/get_uuid.go
@@ -47,7 +47,7 @@ func GetCollectionUUID(ctx context.Context, logger *logger.Logger, retryer retry
 	err := retryer.Run(
 		ctx,
 		logger,
-		func(ri *retry.Info) error {
+		func(_ context.Context, ri *retry.Info) error {
 			ri.Log(logger.Logger, "ListCollectionSpecifications", db.Name(), collName, "Getting collection UUID.", "")
 			var driverErr error
 			collSpecs, driverErr = db.ListCollectionSpecifications(ctx, filter, opts)

--- a/internal/uuidutil/get_uuid.go
+++ b/internal/uuidutil/get_uuid.go
@@ -44,7 +44,7 @@ func GetCollectionUUID(ctx context.Context, logger *logger.Logger, retryer retry
 	opts := options.ListCollections().SetNameOnly(false)
 
 	var collSpecs []*mongo.CollectionSpecification
-	err := retryer.RunForTransientErrorsOnly(
+	err := retryer.Run(
 		ctx,
 		logger,
 		func(ri *retry.Info) error {

--- a/internal/uuidutil/get_uuid.go
+++ b/internal/uuidutil/get_uuid.go
@@ -47,7 +47,7 @@ func GetCollectionUUID(ctx context.Context, logger *logger.Logger, retryer retry
 	err := retryer.Run(
 		ctx,
 		logger,
-		func(_ context.Context, ri *retry.Info) error {
+		func(_ context.Context, ri *retry.FuncInfo) error {
 			ri.Log(logger.Logger, "ListCollectionSpecifications", db.Name(), collName, "Getting collection UUID.", "")
 			var driverErr error
 			collSpecs, driverErr = db.ListCollectionSpecifications(ctx, filter, opts)

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -398,7 +398,7 @@ func (verifier *Verifier) StartChangeStream(ctx context.Context) error {
 		err := retryer.Run(
 			ctx,
 			verifier.logger,
-			func(ri *retry.Info) error {
+			func(ctx context.Context, ri *retry.Info) error {
 				srcChangeStream, startTs, err := verifier.createChangeStream(ctx)
 				if err != nil {
 					if parentThreadWaiting {

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -160,7 +160,7 @@ func (verifier *Verifier) GetChangeStreamFilter() (pipeline mongo.Pipeline) {
 // shouldn’t really happen anyway by definition.
 func (verifier *Verifier) readAndHandleOneChangeEventBatch(
 	ctx context.Context,
-	ri *retry.Info,
+	ri *retry.FuncInfo,
 	cs *mongo.ChangeStream,
 ) error {
 	eventsRead := 0
@@ -188,7 +188,7 @@ func (verifier *Verifier) readAndHandleOneChangeEventBatch(
 		eventsRead++
 	}
 
-	ri.IterationSuccess()
+	ri.NoteSuccess()
 
 	if eventsRead == 0 {
 		return nil
@@ -204,7 +204,7 @@ func (verifier *Verifier) readAndHandleOneChangeEventBatch(
 
 func (verifier *Verifier) iterateChangeStream(
 	ctx context.Context,
-	ri *retry.Info,
+	ri *retry.FuncInfo,
 	cs *mongo.ChangeStream,
 ) error {
 	var lastPersistedTime time.Time
@@ -398,7 +398,7 @@ func (verifier *Verifier) StartChangeStream(ctx context.Context) error {
 		err := retryer.Run(
 			ctx,
 			verifier.logger,
-			func(ctx context.Context, ri *retry.Info) error {
+			func(ctx context.Context, ri *retry.FuncInfo) error {
 				srcChangeStream, startTs, err := verifier.createChangeStream(ctx)
 				if err != nil {
 					if parentThreadWaiting {

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -395,7 +395,7 @@ func (verifier *Verifier) StartChangeStream(ctx context.Context) error {
 
 		parentThreadWaiting := true
 
-		err := retryer.RunForTransientErrorsOnly(
+		err := retryer.Run(
 			ctx,
 			verifier.logger,
 			func(ri *retry.Info) error {

--- a/internal/verifier/clustertime.go
+++ b/internal/verifier/clustertime.go
@@ -34,7 +34,7 @@ func GetNewClusterTime(
 	err := retryer.Run(
 		ctx,
 		logger,
-		func(ctx context.Context, _ *retry.Info) error {
+		func(ctx context.Context, _ *retry.FuncInfo) error {
 			var err error
 			clusterTime, err = runAppendOplogNote(
 				ctx,
@@ -56,7 +56,7 @@ func GetNewClusterTime(
 	err = retryer.Run(
 		ctx,
 		logger,
-		func(ctx context.Context, _ *retry.Info) error {
+		func(ctx context.Context, _ *retry.FuncInfo) error {
 			var err error
 			_, err = runAppendOplogNote(
 				ctx,

--- a/internal/verifier/clustertime.go
+++ b/internal/verifier/clustertime.go
@@ -34,7 +34,7 @@ func GetNewClusterTime(
 	err := retryer.Run(
 		ctx,
 		logger,
-		func(_ *retry.Info) error {
+		func(ctx context.Context, _ *retry.Info) error {
 			var err error
 			clusterTime, err = runAppendOplogNote(
 				ctx,
@@ -56,7 +56,7 @@ func GetNewClusterTime(
 	err = retryer.Run(
 		ctx,
 		logger,
-		func(_ *retry.Info) error {
+		func(ctx context.Context, _ *retry.Info) error {
 			var err error
 			_, err = runAppendOplogNote(
 				ctx,

--- a/internal/verifier/clustertime.go
+++ b/internal/verifier/clustertime.go
@@ -31,7 +31,7 @@ func GetNewClusterTime(
 
 	// First we just fetch the latest cluster time among all shards without
 	// updating any shards’ oplogs.
-	err := retryer.RunForTransientErrorsOnly(
+	err := retryer.Run(
 		ctx,
 		logger,
 		func(_ *retry.Info) error {
@@ -53,7 +53,7 @@ func GetNewClusterTime(
 	// fetchClusterTime() will have taught the mongos about the most current
 	// shard’s cluster time. Now we tell that mongos to update all lagging
 	// shards to that time.
-	err = retryer.RunForTransientErrorsOnly(
+	err = retryer.Run(
 		ctx,
 		logger,
 		func(_ *retry.Info) error {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -738,7 +738,7 @@ func (verifier *Verifier) getShardingInfo(ctx context.Context, namespaceAndUUID 
 //  2. Fetch shard keys.
 //  3. Fetch the size: # of docs, and # of bytes.
 func (verifier *Verifier) partitionAndInspectNamespace(ctx context.Context, namespace string) ([]*partitions.Partition, []string, types.DocumentCount, types.ByteCount, error) {
-	retryer := retry.New(retry.DefaultDurationLimit).SetRetryOnUUIDNotSupported()
+	retryer := retry.New(retry.DefaultDurationLimit)
 	dbName, collName := SplitNamespace(namespace)
 	namespaceAndUUID, err := uuidutil.GetCollectionNamespaceAndUUID(ctx, verifier.logger, retryer,
 		verifier.srcClientDatabase(dbName), collName)

--- a/internal/verifier/mongos_refresh.go
+++ b/internal/verifier/mongos_refresh.go
@@ -59,10 +59,10 @@ func RefreshAllMongosInstances(
 			return err
 		}
 
-		err = r.RunForTransientErrorsOnly(
+		err = r.Run(
 			ctx,
 			l,
-			func(ri *retry.Info) error {
+			func(ctx context.Context, _ *retry.FuncInfo) error {
 				// Query a collection on the config server with linearizable read concern to advance the config
 				// server primary's majority-committed optime. This populates the $configOpTime.
 				opts := options.Database().SetReadConcern(readconcern.Linearizable())
@@ -173,10 +173,10 @@ func runListShards(
 	client *mongo.Client,
 ) (*mongo.SingleResult, error) {
 	var res *mongo.SingleResult
-	err := r.RunForTransientErrorsOnly(
+	err := r.Run(
 		ctx,
 		l,
-		func(_ *retry.Info) error {
+		func(ctx context.Context, _ *retry.FuncInfo) error {
 			res = client.Database("admin").RunCommand(ctx, bson.D{{"listShards", 1}})
 			return res.Err()
 		},

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -133,7 +133,7 @@ func (verifier *Verifier) insertRecheckDocs(
 			}
 
 			retryer := retry.New(retry.DefaultDurationLimit)
-			err := retryer.RunForTransientErrorsOnly(
+			err := retryer.Run(
 				groupCtx,
 				verifier.logger,
 				func(_ *retry.Info) error {

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -136,9 +136,9 @@ func (verifier *Verifier) insertRecheckDocs(
 			err := retryer.Run(
 				groupCtx,
 				verifier.logger,
-				func(_ *retry.Info) error {
+				func(retryCtx context.Context, _ *retry.Info) error {
 					_, err := verifier.verificationDatabase().Collection(recheckQueue).BulkWrite(
-						groupCtx,
+						retryCtx,
 						models,
 						options.BulkWrite().SetOrdered(false),
 					)

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -136,7 +136,7 @@ func (verifier *Verifier) insertRecheckDocs(
 			err := retryer.Run(
 				groupCtx,
 				verifier.logger,
-				func(retryCtx context.Context, _ *retry.Info) error {
+				func(retryCtx context.Context, _ *retry.FuncInfo) error {
 					_, err := verifier.verificationDatabase().Collection(recheckQueue).BulkWrite(
 						retryCtx,
 						models,


### PR DESCRIPTION
We need retry logic around `find` cursor iteration, but the retryer’s IterationSuccess() method won’t work properly with how we compare partitions document-by-document. If, for example, the source hangs but we call IterationSuccess() on every destination success, we’ll never time out the retries. But we need IterationSuccess() to work or else there are no retries for partitions that take a long time to read.

This changeset fixes that by rewriting the retryer to take multiple callbacks. Each callback now takes a context that the retryer uses to stop the function whenever another thread has failed.

Since migration-verifier doesn’t handle DDL events, there’s no point to handling collection UUIDs. Thus, the initial commits in this PR resolve longstanding technical debt.

This also synchronizes migration-verifier’s internal list of transient errors with mongosync’s.