### PR TITLE
Fix various typos and logging anomalies.

### DIFF
--- a/internal/reportutils/reportutils.go
+++ b/internal/reportutils/reportutils.go
@@ -183,5 +183,6 @@ func FindBestUnit[T num16Plus](count T) DataUnit {
 // FmtBytes is a convenience that combines BytesToUnit with FindBestUnit.
 // Use it to format a single count of bytes.
 func FmtBytes[T num16Plus](count T) string {
-	return BytesToUnit(count, FindBestUnit(count))
+	unit := FindBestUnit(count)
+	return BytesToUnit(count, unit) + " " + string(unit)
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -146,7 +146,7 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 		err = nil
 	}
 
-	if err != nil {
+	if err == nil {
 		verifier.logger.Debug().
 			Int("generation", generation).
 			Msgf("Check finished.")
@@ -432,11 +432,6 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			duration := verifier.workerSleepDelayMillis * time.Millisecond
 
 			if duration > 0 {
-				verifier.logger.Debug().
-					Int("workerNum", workerNum).
-					Stringer("duration", duration).
-					Msg("No tasks found. Sleeping.")
-
 				time.Sleep(duration)
 			}
 
@@ -453,6 +448,8 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 		switch task.Type {
 		case verificationTaskVerifyCollection:
 			err := verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
+			verifier.workerTracker.Unset(workerNum)
+
 			if err != nil {
 				return err
 			}
@@ -464,6 +461,8 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 			}
 		case verificationTaskVerifyDocuments:
 			err := verifier.ProcessVerifyTask(ctx, workerNum, task)
+			verifier.workerTracker.Unset(workerNum)
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes the following:

- reportutils.FmtBytes() needs the unit after the number; right now it just gives the number.
- The “Check finished” log should print if there is no error, not if there is an error.
- The “No tasks found” log should be suppressed.
- The worker tracker needs entries unset once they are done being processed.
- The findCmd log should not print for recheck tasks since the list of IDs can be long.
- The “Finished document comparison task” log should print only if that task succeeds.