### PR TITLE
Add git revision to migration-verifier.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -77,7 +77,7 @@ jobs:
         run: yes | m stable && dirname $(readlink $(which mongod)) > .metapath
 
       - name: Build
-        run: go build main/migration_verifier.go
+        run: ./build.sh
 
       - name: Start clusters
         run: |-

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ _This Repository is NOT an officially supported MongoDB product. This tool reduc
 
 
 ```
-go build main/migration_verifier.go
+./build.sh
 ```
-
-
 
 # Operational UX Once Running 
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+commit=$(git show --no-patch --format='%H')
+
+go build -ldflags="-X 'main.Revision=$commit'" main/migration_verifier.go

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -43,6 +43,9 @@ const (
 	pprofInterval         = "pprofInterval"
 )
 
+// This gets set at build time.
+var Revision = "Unknown; build with build.sh."
+
 func main() {
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
@@ -154,9 +157,10 @@ func main() {
 	}
 
 	app := &cli.App{
-		Name:  "migration-verifier",
-		Usage: "verify migration correctness",
-		Flags: flags,
+		Name:    "migration-verifier",
+		Usage:   "verify migration correctness",
+		Version: Revision,
+		Flags:   flags,
 		Before: func(cCtx *cli.Context) error {
 			confFile := cCtx.String(configFileFlag)
 
@@ -202,6 +206,10 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	logPath := cCtx.String(logPath)
 
 	v := verifier.NewVerifier(verifierSettings, logPath)
+
+	v.GetLogger().Info().
+		Str("revision", Revision).
+		Msg("migration-verifier started.")
 
 	err := v.SetSrcURI(ctx, cCtx.String(srcURI))
 	if err != nil {


### PR DESCRIPTION
This will help debugging cases where migration-verifier may have been built from an old revision.