### PR TITLE
REP-5317 Ignore mongosync DBs on destination.

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -213,7 +213,10 @@ func (csr *ChangeStreamReader) GetChangeStreamFilter() (pipeline mongo.Pipeline)
 	if len(csr.namespaces) == 0 {
 		pipeline = mongo.Pipeline{
 			{{"$match", bson.D{
-				{"ns.db", bson.D{{"$ne", csr.metaDB.Name()}}},
+				{"ns.db", bson.D{{"$nin", bson.A{
+					primitive.Regex{Pattern: MongosyncMetaDBsPattern},
+					csr.metaDB.Name(),
+				}}}},
 			}}},
 		}
 	} else {

--- a/internal/verifier/integration_test_suite.go
+++ b/internal/verifier/integration_test_suite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/util"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -27,6 +28,8 @@ type IntegrationTestSuite struct {
 	testContext                                     context.Context
 	contextCanceller                                context.CancelCauseFunc
 	initialDbNames                                  mapset.Set[string]
+
+	zerologGlobalLogLevel zerolog.Level
 }
 
 var _ suite.TestingSuite = &IntegrationTestSuite{}
@@ -111,10 +114,13 @@ func (suite *IntegrationTestSuite) SetupTest() {
 	}
 
 	suite.testContext, suite.contextCanceller = ctx, canceller
+	suite.zerologGlobalLogLevel = zerolog.GlobalLevel()
 }
 
 func (suite *IntegrationTestSuite) TearDownTest() {
 	suite.T().Logf("Tearing down test %#q", suite.T().Name())
+
+	zerolog.SetGlobalLevel(suite.zerologGlobalLogLevel)
 
 	suite.contextCanceller(errors.Errorf("tearing down test %#q", suite.T().Name()))
 	suite.testContext, suite.contextCanceller = nil, nil

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -40,7 +40,9 @@ func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *
 	if err != nil {
 		return nil, err
 	}
-	logger.Debug().Msgf("All user databases: %+v", dbNames)
+	logger.Debug().
+		Strs("databases", dbNames).
+		Msg("All user databases.")
 
 	collectionNamespaces := []string{}
 	for _, dbName := range dbNames {
@@ -53,7 +55,11 @@ func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *
 		if err != nil {
 			return nil, err
 		}
-		logger.Debug().Msgf("Collections for database %s: %+v", dbName, specifications)
+		logger.Debug().
+			Str("database", dbName).
+			Interface("specifications", specifications).
+			Msg("Found database members.")
+
 		for _, spec := range specifications {
 			collectionNamespaces = append(collectionNamespaces, dbName+"."+spec.Name)
 		}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -53,6 +53,10 @@ func TestIntegration(t *testing.T) {
 		metaConnStr: envVals["MVTEST_META"],
 	}
 
+	oldLogLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(oldLogLevel)
+
 	suite.Run(t, testSuite)
 }
 


### PR DESCRIPTION
REVIEWER NOTE: The first couple commits here are general cleanup. This PR will be merged via rebase.

-----

To make migration-verifier’s change stream work with mongosync CI we need to ignore mongosync’s internal databases, which mongosync will manipulate alongside migration-verifier.

This changeset adjusts the change stream logic accordingly.