### PR TITLE
Add a few additional data points to logs.

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -567,10 +567,14 @@ func (verifier *Verifier) compareOneDocument(srcClientDoc, dstClientDoc bson.Raw
 func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, task *VerificationTask) error {
 	start := time.Now()
 
-	verifier.logger.Debug().
+	debugLog := verifier.logger.Debug().
 		Int("workerNum", workerNum).
 		Interface("task", task.PrimaryKey).
-		Msg("Processing document comparison task.")
+		Str("namespace", task.QueryFilter.Namespace)
+
+	task.augmentLogWithDetails(debugLog)
+
+	debugLog.Msg("Processing document comparison task.")
 
 	problems, docsCount, bytesCount, err := verifier.FetchAndCompareDocuments(
 		ctx,
@@ -662,6 +666,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 	verifier.logger.Debug().
 		Int("workerNum", workerNum).
 		Interface("task", task.PrimaryKey).
+		Str("namespace", task.QueryFilter.Namespace).
 		Stringer("timeElapsed", time.Since(start)).
 		Msg("Finished document comparison task.")
 


### PR DESCRIPTION
This adds:
- “Processing document comparison task” now mentions a) the namespace, and b) either the range’s min & max (gen0/check) or the # of documents (gen1+/recheck).
- “Finished document comparison task” now mentions the namespace.
- Logs for creation of recheck tasks now give the task ID.
- A new “Scheduled documents for recheck in the new generation” log that gives the total # and size of rechecks.

These data points would have been nice conveniences when reviewing logs for InfoMedia’s recent migration.