### PR TITLE
REP-5337 Don’t mongos-refresh on pre-v5 clusters.

### DIFF
--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -57,8 +57,20 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 
 	verifier.dstClusterInfo = &clusterInfo
 
-	// We needn't refresh mongoses on the destination,
-	// regardless of server version.
+	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
+		err := RefreshAllMongosInstances(
+			ctx,
+			verifier.logger,
+			opts,
+		)
+
+		if err != nil {
+			return errors.Wrap(
+				err,
+				"failed to refresh destination mongos instances",
+			)
+		}
+	}
 
 	return checkURIAgainstServerVersion(uri, clusterInfo)
 }

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -57,20 +57,8 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 
 	verifier.dstClusterInfo = &clusterInfo
 
-	if clusterInfo.Topology == util.TopologySharded {
-		err := RefreshAllMongosInstances(
-			ctx,
-			verifier.logger,
-			opts,
-		)
-
-		if err != nil {
-			return errors.Wrap(
-				err,
-				"failed to refresh source mongos instances",
-			)
-		}
-	}
+	// NB: Destination clusters don’t need mongoses refreshed
+	// as source clusters do.
 
 	return checkURIAgainstServerVersion(uri, clusterInfo)
 }

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -57,20 +57,8 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 
 	verifier.dstClusterInfo = &clusterInfo
 
-	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
-		err := RefreshAllMongosInstances(
-			ctx,
-			verifier.logger,
-			opts,
-		)
-
-		if err != nil {
-			return errors.Wrap(
-				err,
-				"failed to refresh destination mongos instances",
-			)
-		}
-	}
+	// We needn't refresh mongoses on the destination,
+	// regardless of server version.
 
 	return checkURIAgainstServerVersion(uri, clusterInfo)
 }

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -24,7 +24,7 @@ func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
 
 	verifier.srcClusterInfo = &clusterInfo
 
-	if clusterInfo.Topology == util.TopologySharded {
+	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
 		err := RefreshAllMongosInstances(
 			ctx,
 			verifier.logger,
@@ -57,8 +57,20 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 
 	verifier.dstClusterInfo = &clusterInfo
 
-	// NB: Destination clusters don’t need mongoses refreshed
-	// as source clusters do.
+	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
+		err := RefreshAllMongosInstances(
+			ctx,
+			verifier.logger,
+			opts,
+		)
+
+		if err != nil {
+			return errors.Wrap(
+				err,
+				"failed to refresh destination mongos instances",
+			)
+		}
+	}
 
 	return checkURIAgainstServerVersion(uri, clusterInfo)
 }


### PR DESCRIPTION
PR #64 introduced a bug where it would try to refresh mongoses regardless of server version.

This fixes that by only refreshing mongoses for pre-v5 server versions.