### PR TITLE
REP-5358 Revamp retryer.

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -2,29 +2,21 @@ package retry
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/10gen/migration-verifier/internal/logger"
+	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/util"
+	"github.com/10gen/migration-verifier/mmongo"
+	"github.com/10gen/migration-verifier/msync"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
 )
 
 type RetryCallback = func(context.Context, *FuncInfo) error
-
-// Retry is a convenience that creates a retryer and executes it.
-// See RunForTransientErrorsOnly for argument details.
-func Retry(
-	ctx context.Context,
-	logger *logger.Logger,
-	callbacks ...RetryCallback,
-) error {
-	retryer := New(DefaultDurationLimit)
-	return retryer.Run(ctx, logger, callbacks...)
-}
 
 // Run() runs each given callback in parallel. If none of them fail,
 // then no error is returned.
@@ -54,19 +46,20 @@ func Retry(
 //
 // This returns an error if the duration limit is reached, or if f() returns a
 // non-transient error.
-func (r *Retryer) Run(
-	ctx context.Context, logger *logger.Logger, funcs ...RetryCallback,
-) error {
-	return r.runRetryLoop(ctx, logger, funcs)
+func (r *Retryer) Run(ctx context.Context, logger *logger.Logger) error {
+	return r.runRetryLoop(ctx, logger)
 }
 
 // runRetryLoop contains the core logic for the retry loops.
 func (r *Retryer) runRetryLoop(
 	ctx context.Context,
 	logger *logger.Logger,
-	funcs []RetryCallback,
 ) error {
 	var err error
+
+	if len(r.callbacks) == 0 {
+		return errors.Errorf("retryer (%s) run with no callbacks", r.description)
+	}
 
 	startTime := time.Now()
 
@@ -74,23 +67,33 @@ func (r *Retryer) runRetryLoop(
 		durationLimit: r.retryLimit,
 	}
 	funcinfos := lo.RepeatBy(
-		len(funcs),
+		len(r.callbacks),
 		func(_ int) *FuncInfo {
 			return &FuncInfo{
-				lastResetTime: startTime,
-				loopInfo:      li,
+				lastResetTime:   msync.NewTypedAtomic(startTime),
+				loopDescription: r.description,
+				loopInfo:        li,
 			}
 		},
 	)
 	sleepTime := minSleepTime
 
 	for {
+		if li.attemptsSoFar > 0 {
+			r.addDescriptionToEvent(logger.Info()).
+				Int("attemptsSoFar", li.attemptsSoFar).
+				Msg("Retrying after failure.")
+		}
+
 		if beforeFunc, hasBefore := r.before.Get(); hasBefore {
 			beforeFunc()
 		}
 
 		eg, egCtx := errgroup.WithContext(ctx)
-		for i, curFunc := range funcs {
+
+		for i, curCbInfo := range r.callbacks {
+			curFunc := curCbInfo.callback
+
 			if curFunc == nil {
 				panic("curFunc should be non-nil")
 			}
@@ -99,6 +102,31 @@ func (r *Retryer) runRetryLoop(
 			}
 
 			eg.Go(func() error {
+				cbDoneChan := make(chan struct{})
+				defer close(cbDoneChan)
+
+				go func() {
+					ticker := time.NewTicker(time.Minute)
+					defer ticker.Stop()
+
+					for {
+						lastSuccessTime := funcinfos[i].lastResetTime.Load()
+
+						select {
+						case <-cbDoneChan:
+							return
+						case <-ticker.C:
+							if funcinfos[i].lastResetTime.Load() == lastSuccessTime {
+								logger.Warn().
+									Str("callbackDescription", curCbInfo.description).
+									Time("lastSuccessAt", lastSuccessTime).
+									Str("elapsedTime", reportutils.DurationToHMS(time.Since(lastSuccessTime))).
+									Msg("Operation has not reported success for a while.")
+							}
+						}
+					}
+				}()
+
 				err := curFunc(egCtx, funcinfos[i])
 
 				if err != nil {
@@ -124,19 +152,21 @@ func (r *Retryer) runRetryLoop(
 			panic(fmt.Sprintf("Error should be a %T, not %T: %v", groupErr, err, err))
 		}
 
+		failedFuncInfo := funcinfos[groupErr.funcNum]
+
 		// Not a transient error? Fail immediately.
-		if !r.shouldRetryWithSleep(logger, sleepTime, groupErr.errFromCallback) {
+		if !r.shouldRetryWithSleep(logger, sleepTime, *failedFuncInfo, groupErr.errFromCallback) {
 			return groupErr.errFromCallback
 		}
 
-		li.attemptNumber++
+		li.attemptsSoFar++
 
 		// Our error is transient. If we've exhausted the allowed time
 		// then fail.
-		failedFuncInfo := funcinfos[groupErr.funcNum]
+
 		if failedFuncInfo.GetDurationSoFar() > li.durationLimit {
 			return RetryDurationLimitExceededErr{
-				attempts: li.attemptNumber,
+				attempts: li.attemptsSoFar,
 				duration: failedFuncInfo.GetDurationSoFar(),
 				lastErr:  groupErr.errFromCallback,
 			}
@@ -146,7 +176,9 @@ func (r *Retryer) runRetryLoop(
 		// up to maxSleepTime.
 		select {
 		case <-ctx.Done():
-			logger.Error().Err(ctx.Err()).Msg("Context was canceled. Aborting retry loop.")
+			r.addDescriptionToEvent(logger.Error()).
+				Err(ctx.Err()).
+				Msg("Context was canceled. Aborting retry loop.")
 			return ctx.Err()
 		case <-time.After(sleepTime):
 			sleepTime *= sleepTimeMultiplier
@@ -160,10 +192,25 @@ func (r *Retryer) runRetryLoop(
 		// Set all of the funcs that did *not* fail as having just succeeded.
 		for i, curInfo := range funcinfos {
 			if i != groupErr.funcNum {
-				curInfo.lastResetTime = now
+				curInfo.lastResetTime.Store(now)
 			}
 		}
 	}
+}
+
+func (r *Retryer) addDescriptionToEvent(event *zerolog.Event) *zerolog.Event {
+	if description, hasDesc := r.description.Get(); hasDesc {
+		event.Str("description", description)
+	} else {
+		event.Strs("description", lo.Map(
+			r.callbacks,
+			func(cbInfo retryCallbackInfo, _ int) string {
+				return cbInfo.description
+			},
+		))
+	}
+
+	return event
 }
 
 //
@@ -179,36 +226,41 @@ func (r *Retryer) runRetryLoop(
 func (r *Retryer) shouldRetryWithSleep(
 	logger *logger.Logger,
 	sleepTime time.Duration,
+	funcinfo FuncInfo,
 	err error,
 ) bool {
-	// Randomly retry approximately 1 in 100 calls to the wrapped
-	// function. This is only enabled in tests.
-	if r.retryRandomly && rand.Int()%100 == 0 {
-		logger.Debug().Msgf("Waiting %s seconds to retry operation because of test code forcing a retry.", sleepTime)
-		return true
-	}
-
 	if err == nil {
-		return false
+		panic("nil error should not get here")
 	}
 
-	errCode := util.GetErrorCode(err)
-	if util.IsTransientError(err) {
-		logger.Warn().Int("error code", errCode).Err(err).Msgf(
-			"Waiting %s seconds to retry operation after transient error.", sleepTime)
+	isTransient := util.IsTransientError(err) || lo.SomeBy(
+		r.additionalErrorCodes,
+		func(code int) bool {
+			return mmongo.ErrorHasCode(err, code)
+		},
+	)
+
+	event := logger.WithLevel(
+		lo.Ternary(isTransient, zerolog.InfoLevel, zerolog.WarnLevel),
+	)
+
+	if loopDesc, hasLoopDesc := r.description.Get(); hasLoopDesc {
+		event.Str("operationDescription", loopDesc)
+	}
+
+	event.Str("callbackDescription", funcinfo.description).
+		Int("error code", util.GetErrorCode(err)).
+		Err(err)
+
+	if isTransient {
+		event.
+			Stringer("delay", sleepTime).
+			Msg("Pausing before retrying after transient error.")
+
 		return true
 	}
 
-	for _, code := range r.additionalErrorCodes {
-		if code == errCode {
-			logger.Warn().Int("error code", errCode).Err(err).Msgf(
-				"Waiting %s seconds to retry operation after an error because it is in our additional codes list.", sleepTime)
-			return true
-		}
-	}
-
-	logger.Debug().Err(err).Int("error code", errCode).
-		Msg("Not retrying on error because it is not transient nor is it in our additional codes list.")
+	event.Msg("Non-transient error occurred.")
 
 	return false
 }

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/10gen/migration-verifier/option"
@@ -15,14 +16,13 @@ type retryCallbackInfo struct {
 // Retryer handles retrying operations that fail because of network failures.
 type Retryer struct {
 	retryLimit           time.Duration
-	retryRandomly        bool
 	before               option.Option[func()]
 	callbacks            []retryCallbackInfo
 	description          option.Option[string]
 	additionalErrorCodes []int
 }
 
-// New returns a new retryer.
+// New returns a new Retryer with DefaultDurationLimit as its time limit.
 func New() *Retryer {
 	return &Retryer{
 		retryLimit: DefaultDurationLimit,
@@ -30,47 +30,51 @@ func New() *Retryer {
 }
 
 // WithErrorCodes returns a new Retryer that will retry on the codes passed to
-// this method. This allows for a single function to customize the codes it
+// this method. This allows for a single retryer to customize the codes it
 // wants to retry on. Note that if the Retryer already has additional custom
 // error codes set, these are _replaced_ when this method is called.
 func (r *Retryer) WithErrorCodes(codes ...int) *Retryer {
-	r2 := *r
+	r2 := r.clone()
 	r2.additionalErrorCodes = codes
 
-	return &r2
+	return r2
 }
 
+// WithRetryLimit returns a new retryer with the specified time limit.
 func (r *Retryer) WithRetryLimit(limit time.Duration) *Retryer {
-	r2 := *r
+	r2 := r.clone()
 	r2.retryLimit = limit
 
-	return &r2
+	return r2
 }
 
-// WithBefore sets a callback that always runs before any retryer callback.
+// WithBefore returns a new retryer with a callback that always runs before
+// any retryer callback.
 //
 // This is useful if there are multiple callbacks and you need to reset some
 // condition before each retryer iteration. (In the single-callback case it’s
 // largely redundant.)
 func (r *Retryer) WithBefore(todo func()) *Retryer {
-	r2 := *r
+	r2 := r.clone()
 	r2.before = option.Some(todo)
 
-	return &r2
+	return r2
 }
 
+// WithDescription returns a new retryer with the given description.
 func (r *Retryer) WithDescription(msg string, args ...any) *Retryer {
-	r2 := *r
+	r2 := r.clone()
 	r2.description = option.Some(fmt.Sprintf(msg, args...))
 
-	return &r2
+	return r2
 }
 
+// WithCallback returns a new retryer with the additional callback.
 func (r *Retryer) WithCallback(
 	callback RetryCallback,
 	msg string, args ...any,
 ) *Retryer {
-	r2 := *r
+	r2 := r.clone()
 
 	r2.callbacks = append(
 		r2.callbacks,
@@ -79,6 +83,17 @@ func (r *Retryer) WithCallback(
 			description: fmt.Sprintf(msg, args...),
 		},
 	)
+
+	return r2
+}
+
+func (r *Retryer) clone() *Retryer {
+	r2 := *r
+
+	r2.before = option.FromPointer(r.before.ToPointer())
+	r2.description = option.FromPointer(r.description.ToPointer())
+	r2.callbacks = slices.Clone(r.callbacks)
+	r2.additionalErrorCodes = slices.Clone(r.additionalErrorCodes)
 
 	return &r2
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -123,6 +123,10 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 				)
 			}
 
+			verifier.logger.Debug().
+				Interface("taskCountsByStatus", verificationStatus).
+				Send()
+
 			if waitForTaskCreation%2 == 0 {
 				if generation > 0 || verifier.gen0PendingCollectionTasks.Load() == 0 {
 					verifier.PrintVerificationSummary(ctx, GenerationInProgress)

--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -34,7 +34,7 @@ func (verifier *Verifier) FetchAndCompareDocuments(
 	var byteCount types.ByteCount
 
 	retryer := retry.New().WithDescription(
-		"reading task %v's documents (namespace: %s)",
+		"comparing task %v's documents (namespace: %s)",
 		task.PrimaryKey,
 		task.QueryFilter.Namespace,
 	)

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1268,7 +1268,11 @@ func (verifier *Verifier) GetVerificationStatus(ctx context.Context) (*Verificat
 	).Run(ctx, verifier.logger)
 
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(
+			err,
+			"failed to count generation %d's tasks by status",
+			generation,
+		)
 	}
 
 	verificationStatus := VerificationStatus{}

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -612,7 +612,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 				Interface("task", task.PrimaryKey).
 				Str("namespace", task.QueryFilter.Namespace).
 				Int("mismatchesCount", len(problems)).
-				Msg("Document comparison task failed, but it may pass in the next generation.")
+				Msg("Discrepancies found. Will recheck in the next generation.")
 
 			var mismatches []VerificationResult
 			var missingIds []interface{}

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1501,6 +1501,7 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 
 	if err != nil {
 		verifier.logger.Err(err).Msgf("Failed to report per-namespace statistics")
+		return
 	}
 
 	verifier.printChangeEventStatistics(strBuilder)

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -750,9 +750,8 @@ func (verifier *Verifier) getShardKeyFields(
 //  2. Fetch shard keys.
 //  3. Fetch the size: # of docs, and # of bytes.
 func (verifier *Verifier) partitionAndInspectNamespace(ctx context.Context, namespace string) ([]*partitions.Partition, []string, types.DocumentCount, types.ByteCount, error) {
-	retryer := retry.New(retry.DefaultDurationLimit)
 	dbName, collName := SplitNamespace(namespace)
-	namespaceAndUUID, err := uuidutil.GetCollectionNamespaceAndUUID(ctx, verifier.logger, retryer,
+	namespaceAndUUID, err := uuidutil.GetCollectionNamespaceAndUUID(ctx, verifier.logger,
 		verifier.srcClientDatabase(dbName), collName)
 	if err != nil {
 		return nil, nil, 0, 0, err
@@ -767,7 +766,7 @@ func (verifier *Verifier) partitionAndInspectNamespace(ctx context.Context, name
 	replicator1 := partitions.Replicator{ID: "verifier"}
 	replicators := []partitions.Replicator{replicator1}
 	partitionList, srcDocs, srcBytes, err := partitions.PartitionCollectionWithSize(
-		ctx, namespaceAndUUID, retryer, verifier.srcClient, replicators, verifier.logger, verifier.partitionSizeInBytes, verifier.globalFilter)
+		ctx, namespaceAndUUID, verifier.srcClient, replicators, verifier.logger, verifier.partitionSizeInBytes, verifier.globalFilter)
 	if err != nil {
 		return nil, nil, 0, 0, err
 	}
@@ -1239,9 +1238,7 @@ func (verifier *Verifier) GetVerificationStatus(ctx context.Context) (*Verificat
 
 	var results []bson.Raw
 
-	err := retry.Retry(
-		ctx,
-		verifier.logger,
+	err := retry.New().WithCallback(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
 			cursor, err := taskCollection.Aggregate(
 				ctx,
@@ -1266,7 +1263,10 @@ func (verifier *Verifier) GetVerificationStatus(ctx context.Context) (*Verificat
 
 			return cursor.All(ctx, &results)
 		},
-	)
+		"counting generation %d's (non-primary) tasks by status",
+		generation,
+	).Run(ctx, verifier.logger)
+
 	if err != nil {
 		return nil, err
 	}

--- a/msync/typed_atomic.go
+++ b/msync/typed_atomic.go
@@ -1,0 +1,50 @@
+package msync
+
+import "sync/atomic"
+
+// TypedAtomic is a type-safe wrapper around the standard-library atomic.Value.
+// TypedAtomic serves largely the same purpose as atomic.Pointer but stores
+// the value itself rather than a pointer to it. This is often more ergonomic
+// than an atomic.Pointer: it can be used to store constants directly (where
+// taking a pointer is inconvenient), and it defaults to the type's zero value
+// rather than a nil pointer.
+type TypedAtomic[T any] struct {
+	v atomic.Value
+}
+
+// NewTypedAtomic returns a new TypedAtomic, initialized to val.
+func NewTypedAtomic[T any](val T) *TypedAtomic[T] {
+	var v atomic.Value
+	v.Store(val)
+	return &TypedAtomic[T]{v}
+}
+
+// Load returns the value set by the most recent Store. It returns the zero
+// value for the type if there has been no call to Store.
+func (ta *TypedAtomic[T]) Load() T {
+	return orZero[T](ta.v.Load())
+}
+
+// Store sets the value TypedAtomic to val. Store(nil) panics.
+func (ta *TypedAtomic[T]) Store(val T) {
+	ta.v.Store(val)
+}
+
+// Swap stores newVal into the TypedAtomic and returns the previous value. It
+// returns the zero value for the type if the value is empty.
+func (ta *TypedAtomic[T]) Swap(newVal T) T {
+	return orZero[T](ta.v.Swap(newVal))
+}
+
+// CompareAndSwap executes the compare-and-swap operation for the TypedAtomic.
+func (ta *TypedAtomic[T]) CompareAndSwap(oldVal, newVal T) bool {
+	return ta.v.CompareAndSwap(oldVal, newVal)
+}
+
+func orZero[T any](val any) T {
+	if val == nil {
+		return *new(T)
+	}
+
+	return val.(T)
+}

--- a/msync/typed_atomic_test.go
+++ b/msync/typed_atomic_test.go
@@ -1,0 +1,59 @@
+package msync
+
+import (
+	"sync"
+)
+
+func (s *unitTestSuite) TestTypedAtomic() {
+	ta := NewTypedAtomic(42)
+
+	s.Require().Equal(42, ta.Load())
+	s.Require().False(ta.CompareAndSwap(17, 99))
+	s.Require().True(ta.CompareAndSwap(42, 99))
+	s.Require().Equal(99, ta.Load())
+	s.Require().Equal(99, ta.Swap(42))
+	s.Require().Equal(42, ta.Load())
+
+	ta.Store(17)
+	s.Require().Equal(17, ta.Load())
+
+	// This block is for race detection under -race.
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ta.Load()
+			ta.Store(i)
+		}()
+	}
+	wg.Wait()
+}
+
+func (s *unitTestSuite) TestAtomicZeroValues() {
+	s.Run("string", func() {
+		var ta TypedAtomic[string]
+		s.Require().Equal("", ta.Load())
+		s.Require().Equal("", ta.Swap("foo"))
+		s.Require().Equal("foo", ta.Load())
+	})
+
+	s.Run("int", func() {
+		var ta TypedAtomic[int]
+		s.Require().Equal(0, ta.Load())
+		s.Require().Equal(0, ta.Swap(42))
+		s.Require().Equal(42, ta.Load())
+	})
+
+	s.Run("arbitrary data", func() {
+		type data struct {
+			I int
+			S string
+		}
+
+		var ta TypedAtomic[data]
+		s.Require().Equal(data{}, ta.Load())
+		s.Require().Equal(data{}, ta.Swap(data{76, "trombones"}))
+		s.Require().Equal(data{76, "trombones"}, ta.Load())
+	})
+}


### PR DESCRIPTION
This improves the retryer in several ways that should aid in debugging such failures as REP-5358:

- There are now descriptions for each callback and (optionally) the loop itself. Those descriptions go in the relevant log messages.
- NoteSuccess() also takes a description that goes into logs.
- Retried failures are now noted at info level rather than debug.
- The retryer now notes success of a retried operation.
- Long-running operations that go without a success for >1min will be noted in the log as a warning.
- The “retry randomly” functionality is removed. (None of the existing tests use it.)

The above requires a revamp of the retryer interface, so all callers into it are rewritten.