### PR TITLE
Fix change stream lag calculation.

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -318,7 +318,7 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 	var curTs primitive.Timestamp
 	curTs, err := extractTimestampFromResumeToken(cs.ResumeToken())
 	if err == nil {
-		lagSecs := int32(sess.OperationTime().T) - int32(curTs.T)
+		lagSecs := int64(sess.OperationTime().T) - int64(curTs.T)
 		csr.lag.Store(option.Some(time.Second * time.Duration(lagSecs)))
 	} else {
 		csr.logger.Warn().

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -318,7 +318,7 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 	var curTs primitive.Timestamp
 	curTs, err := extractTimestampFromResumeToken(cs.ResumeToken())
 	if err == nil {
-		lagSecs := curTs.T - sess.OperationTime().T
+		lagSecs := int32(sess.OperationTime().T) - int32(curTs.T)
 		csr.lag.Store(option.Some(time.Second * time.Duration(lagSecs)))
 	} else {
 		csr.logger.Warn().
@@ -570,6 +570,10 @@ func (csr *ChangeStreamReader) StartChangeStream(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	csr.logger.Debug().
+		Interface("startTimestamp", startTs).
+		Msgf("Started %s", csr)
 
 	csr.startAtTs = &startTs
 

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -315,10 +315,10 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 			Msg("Updated lastChangeEventTime.")
 	}
 
-	var curTs primitive.Timestamp
-	curTs, err := extractTimestampFromResumeToken(cs.ResumeToken())
+	var tokenTs primitive.Timestamp
+	tokenTs, err := extractTimestampFromResumeToken(cs.ResumeToken())
 	if err == nil {
-		lagSecs := int64(sess.OperationTime().T) - int64(curTs.T)
+		lagSecs := int64(sess.OperationTime().T) - int64(tokenTs.T)
 		csr.lag.Store(option.Some(time.Second * time.Duration(lagSecs)))
 	} else {
 		csr.logger.Warn().

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -571,10 +571,6 @@ func (csr *ChangeStreamReader) StartChangeStream(ctx context.Context) error {
 		return err
 	}
 
-	csr.logger.Debug().
-		Interface("startTimestamp", startTs).
-		Msgf("Started %s", csr)
-
 	csr.startAtTs = &startTs
 
 	csr.changeStreamRunning = true

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -329,6 +329,7 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 	_, err := db.Collection("mycoll").InsertOne(ctx, bson.D{})
 	suite.Require().NoError(err)
 
+	// On sharded clusters sometimes the event hasn’t shown yet.
 	suite.Require().Eventually(
 		func() bool {
 			suite.Require().NoError(

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -345,6 +345,8 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 		100*time.Millisecond,
 	)
 
+	// NB: The lag will include whatever time elapsed above before
+	// verifier read the event, so it can be several seconds.
 	suite.Assert().Less(
 		verifier.srcChangeStreamReader.GetLag().MustGet(),
 		10*time.Minute,

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -347,7 +347,7 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 
 	suite.Assert().Less(
 		verifier.srcChangeStreamReader.GetLag().MustGet(),
-		10*time.Second,
+		10*time.Minute,
 		"verifier lag is as expected",
 	)
 }

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -335,7 +335,7 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 	)
 
 	suite.Assert().Less(
-		verifier.srcChangeStreamReader.lag.Load().MustGet(),
+		verifier.srcChangeStreamReader.GetLag().MustGet(),
 		10*time.Second,
 		"verifier lag is as expected",
 	)


### PR DESCRIPTION
The previous logic was backwards, which caused uint overflow.

This adds a test that usually passes without this change but should occasionally fail. (It should always pass, though, with this change.)