### PR TITLE
REP-5550 Add resumability for recheck generations

### DIFF
--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -182,8 +182,7 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 	}
 	verifier.running = true
 	verifier.globalFilter = filter
-	verifier.initializeChangeStreamReaders()
-	verifier.mux.Unlock()
+
 	defer func() {
 		verifier.mux.Lock()
 		verifier.running = false
@@ -211,6 +210,12 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 			verifier.logger.Info().Msg("Starting new verification.")
 		}
 	}
+
+	// Now that we’ve initialized verifier.generation we can
+	// start the change stream readers.
+	verifier.initializeChangeStreamReaders()
+	verifier.mux.Unlock()
+
 	err = retry.New().WithCallback(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
 			err = verifier.AddMetaIndexes(ctx)

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -193,11 +193,13 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 		verifier.logger.Info().Msg("Dropping old verifier metadata")
 		err = verifier.verificationDatabase().Drop(ctx)
 		if err != nil {
+			verifier.mux.Unlock()
 			return err
 		}
 	} else {
 		genOpt, err := verifier.readGeneration(ctx)
 		if err != nil {
+			verifier.mux.Unlock()
 			return err
 		}
 

--- a/internal/verifier/check_runner.go
+++ b/internal/verifier/check_runner.go
@@ -13,6 +13,10 @@ type CheckRunner struct {
 	doNextGenerationChan chan struct{}
 }
 
+// RunVerifierCheck starts a Check and returns a CheckRunner to track this
+// Verifier.
+//
+// The next method to call is AwaitGenerationEnd.
 func RunVerifierCheck(ctx context.Context, t *testing.T, verifier *Verifier) *CheckRunner {
 	verifierDoneChan := make(chan error)
 

--- a/internal/verifier/generation.go
+++ b/internal/verifier/generation.go
@@ -1,0 +1,63 @@
+package verifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/10gen/migration-verifier/option"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	generationCollName  = "generation"
+	generationFieldName = "generation"
+)
+
+func (v *Verifier) persistGenerationWhileLocked(ctx context.Context) error {
+	generation, _ := v.getGenerationWhileLocked()
+
+	db := v.verificationDatabase()
+
+	result, err := db.Collection(generationCollName).ReplaceOne(
+		ctx,
+		bson.D{},
+		bson.D{{generationFieldName, generation}},
+		options.Replace().SetUpsert(true),
+	)
+
+	if err == nil && (result.ModifiedCount+result.UpsertedCount != 1) {
+		panic(fmt.Sprintf("persist of generation (%d) should affect exactly 1 doc! (%+v)", generation, result))
+	}
+
+	return err
+}
+
+func (v *Verifier) readGeneration(ctx context.Context) (option.Option[int], error) {
+	db := v.verificationDatabase()
+
+	result := db.Collection(generationCollName).FindOne(
+		ctx,
+		bson.D{},
+	)
+
+	parsed := struct {
+		Generation int `bson:"generation"`
+	}{}
+
+	err := result.Decode(&parsed)
+
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			err = nil
+		} else {
+			err = errors.Wrap(err, "failed to read persisted generation")
+		}
+
+		return option.None[int](), err
+	}
+
+	return option.Some(parsed.Generation), nil
+}

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -87,6 +87,32 @@ func (suite *IntegrationTestSuite) fetchRecheckDocs(ctx context.Context, verifie
 	return results
 }
 
+func (suite *IntegrationTestSuite) TestRecheckResumability() {
+	ctx := suite.Context()
+
+	verifier := suite.BuildVerifier()
+	verifier.SetVerifyAll(true)
+
+	runner := RunVerifierCheck(ctx, suite.T(), verifier)
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	suite.Require().NoError(runner.StartNextGeneration())
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	suite.Require().NoError(runner.StartNextGeneration())
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	suite.Require().EqualValues(2, verifier.generation)
+
+	verifier2 := suite.BuildVerifier()
+	verifier2.SetVerifyAll(true)
+
+	runner2 := RunVerifierCheck(ctx, suite.T(), verifier2)
+	suite.Require().NoError(runner2.AwaitGenerationEnd())
+
+	suite.Require().EqualValues(2, verifier2.generation)
+}
+
 func (suite *IntegrationTestSuite) TestLargeIDInsertions() {
 	verifier := suite.BuildVerifier()
 	ctx := suite.Context()

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -186,7 +186,7 @@ func (suite *IntegrationTestSuite) TestRecheckResumability_Mismatch() {
 	)
 
 	recheckDocs := suite.fetchVerifierRechecks(ctx, verifier2)
-	suite.Require().Len(recheckDocs, 2, "expect # of rechecks")
+	suite.Require().Len(recheckDocs, 2, "expect # of rechecks: %+v", recheckDocs)
 }
 
 func (suite *IntegrationTestSuite) TestLargeIDInsertions() {

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -157,7 +157,9 @@ func (suite *IntegrationTestSuite) TestRecheckResumability_Mismatch() {
 		verificationStatus, err := verifier.GetVerificationStatus(ctx)
 		suite.Require().NoError(err)
 
-		if verificationStatus.FailedTasks != 0 {
+		recheckDocs := suite.fetchVerifierRechecks(ctx, verifier)
+
+		if verificationStatus.FailedTasks != 0 && len(recheckDocs) == 2 {
 			break
 		}
 

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -146,10 +146,10 @@ func (suite *IntegrationTestSuite) TestRecheckResumability_Mismatch() {
 		suite.Require().NoError(runner.AwaitGenerationEnd())
 	}
 
-	_, err := srcColl.InsertOne(ctx, bson.D{{"foo", "on src"}})
+	_, err := srcColl.InsertOne(ctx, bson.D{{"_id", "on src"}})
 	suite.Require().NoError(err)
 
-	_, err = dstColl.InsertOne(ctx, bson.D{{"foo", "on dst"}})
+	_, err = dstColl.InsertOne(ctx, bson.D{{"_id", "on dst"}})
 	suite.Require().NoError(err)
 
 	suite.T().Logf("Running verifier until it shows mismatch (generation=%d) ...", verifier.generation)


### PR DESCRIPTION
Previously migration-verifier did not persist its generation, so if it crashed in a generation after generation 0 it would still restart at generation 0.

This could cause any enqueued rechecks not to happen until the restarted verifier reached the prior verifier run’s generation. If the user called `writesOff` before then, though, the rechecks would never happen. Thus, migration-verifier could neglect important rechecks.

This fixes that by persisting migration-verifier’s generation at the start of each generation. Thus, any tasks that need to be rerun, or enqueued rechecks that need to be processed into checks for the next generation, will be replayed in the event of a crash.