### PR TITLE
REP-5470 Fix hang when handler thread hits an error.

### DIFF
--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// WrapCtxErrWithCause returns the error from the given context.
+//
+// Unlike in the standard library, this WrapCtxErrWithCause() is a wrapper around:
+// - the underlying context’WrapCtxErrWithCauserr(), and
+// - the "cause" from a cancellation, timeout, or deadline
+//
+// Thus, errors.Is() will still work against built-in errors
+// (e.g., context.Canceled).
+//
+// NB: This is copied from mongosync.
+func WrapCtxErrWithCause(ctx context.Context) error {
+	cause := context.Cause(ctx)
+	err := ctx.Err() //nolint:gocritic
+
+	if cause == nil {
+		return err
+	}
+
+	// Usually the cause is distinct from the stdlib’s error. Sometimes, though,
+	// you might have something like
+	// `cancel(fmt.Errorf("All done (%w)", context.Canceled))`. In this case
+	// the cause wraps the stdlib error, so there’s no point in wrapping again.
+	// (It reads oddly: `context canceled: All done (context canceled)`.)
+	//
+	// Thus, we just return the cause here.
+	if errors.Is(cause, err) {
+		return cause
+	}
+
+	return fmt.Errorf("%w: %w", err, cause)
+}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -49,8 +49,8 @@ func (verifier *Verifier) waitForChangeStream(ctx context.Context, csr *ChangeSt
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-csr.error.Ready():
-		err := csr.error.Get()
+	case <-csr.readerError.Ready():
+		err := csr.readerError.Get()
 		verifier.logger.Warn().Err(err).
 			Msgf("Received error from %s.", csr)
 		return err
@@ -88,11 +88,11 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 	// If the change stream fails, everything should stop.
 	eg.Go(func() error {
 		select {
-		case <-verifier.srcChangeStreamReader.error.Ready():
-			err := verifier.srcChangeStreamReader.error.Get()
+		case <-verifier.srcChangeStreamReader.readerError.Ready():
+			err := verifier.srcChangeStreamReader.readerError.Get()
 			return errors.Wrapf(err, "%s failed", verifier.srcChangeStreamReader)
-		case <-verifier.dstChangeStreamReader.error.Ready():
-			err := verifier.dstChangeStreamReader.error.Get()
+		case <-verifier.dstChangeStreamReader.readerError.Ready():
+			err := verifier.dstChangeStreamReader.readerError.Get()
 			return errors.Wrapf(err, "%s failed", verifier.dstChangeStreamReader)
 		case <-ctx.Done():
 			return nil

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -245,37 +245,47 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 	verifier.logger.Debug().
 		Msg("WritesOff called.")
 
-	verifier.mux.Lock()
-	if verifier.writesOff {
-		verifier.mux.Unlock()
-		return errors.New("writesOff already set")
-	}
-	verifier.writesOff = true
+	var srcFinalTs, dstFinalTs primitive.Timestamp
+	var err error
 
-	verifier.logger.Debug().Msg("Signalling that writes are done.")
+	// The anonymous function here makes it easier to ensure
+	// that we unlock the mutex.
+	err = func() error {
+		verifier.mux.Lock()
+		defer verifier.mux.Unlock()
 
-	srcFinalTs, err := GetNewClusterTime(
-		ctx,
-		verifier.logger,
-		verifier.srcClient,
-	)
+		if verifier.writesOff {
+			return errors.New("writesOff already set")
+		}
+		verifier.writesOff = true
 
+		verifier.logger.Debug().Msg("Signalling that writes are done.")
+
+		srcFinalTs, err = GetNewClusterTime(
+			ctx,
+			verifier.logger,
+			verifier.srcClient,
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch source's cluster time")
+		}
+
+		dstFinalTs, err = GetNewClusterTime(
+			ctx,
+			verifier.logger,
+			verifier.dstClient,
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch destination's cluster time")
+		}
+
+		return nil
+	}()
 	if err != nil {
-		verifier.mux.Unlock()
-		return errors.Wrapf(err, "failed to fetch source's cluster time")
+		return err
 	}
-
-	dstFinalTs, err := GetNewClusterTime(
-		ctx,
-		verifier.logger,
-		verifier.dstClient,
-	)
-
-	if err != nil {
-		verifier.mux.Unlock()
-		return errors.Wrapf(err, "failed to fetch destination's cluster time")
-	}
-	verifier.mux.Unlock()
 
 	// This has to happen outside the lock because the change streams
 	// might be inserting docs into the recheck queue, which happens

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -281,16 +281,16 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 	// might be inserting docs into the recheck queue, which happens
 	// under the lock.
 	select {
-	case <-verifier.srcChangeStreamReader.error.Ready():
-		err := verifier.srcChangeStreamReader.error.Get()
+	case <-verifier.srcChangeStreamReader.readerError.Ready():
+		err := verifier.srcChangeStreamReader.readerError.Get()
 		return errors.Wrapf(err, "tried to send writes-off timestamp to %s, but change stream already failed", verifier.srcChangeStreamReader)
 	default:
 		verifier.srcChangeStreamReader.writesOffTs.Set(srcFinalTs)
 	}
 
 	select {
-	case <-verifier.dstChangeStreamReader.error.Ready():
-		err := verifier.dstChangeStreamReader.error.Get()
+	case <-verifier.dstChangeStreamReader.readerError.Ready():
+		err := verifier.dstChangeStreamReader.readerError.Get()
 		return errors.Wrapf(err, "tried to send writes-off timestamp to %s, but change stream already failed", verifier.dstChangeStreamReader)
 	default:
 		verifier.dstChangeStreamReader.writesOffTs.Set(dstFinalTs)

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -429,11 +429,14 @@ func (suite *IntegrationTestSuite) TestFailedVerificationTaskInsertions() {
 	event.OpType = "update"
 	err = verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event}, src)
 	suite.Require().NoError(err)
+
 	event.OpType = "flibbity"
-	err = verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event}, src)
-	badEventErr := UnknownEventError{}
-	suite.Require().ErrorAs(err, &badEventErr)
-	suite.Assert().Equal("flibbity", badEventErr.Event.OpType)
+	suite.Assert().Panics(
+		func() {
+			_ = verifier.HandleChangeStreamEvents(ctx, []ParsedEvent{event}, src)
+		},
+		"HandleChangeStreamEvents should panic if it gets an unknown optype",
+	)
 
 	verifier.generation++
 	func() {


### PR DESCRIPTION
This fixes a hang that previously happened if migration-verifier received an event that it couldn’t handle.

Specific changes:
- The event optype and namespace presence are checked right after decoding. Previously this happened in the handler, which was the immediate cause of the hang that this changeset fixes. Doing this check makes the failure faster and more prominent.
- If the handler fails, it stores its error, and the reader checks for that error.
- Many debug-level logs are added.
- Context cancellations/timeouts are reported with their Cause.
- WritesOff() is rewritten to make it easier to reason about the mutex handling’s correctness.
- The generation-end error check no longer mistakenly assumes that, if the worker-controller thread finished without error, then all is well.

This also removes a flapping assertion in `TestStartAtTimeNoChanges`.