### PR TITLE
Fix messaging around the destination’s mongos cache refresh.

### DIFF
--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -25,7 +25,7 @@ func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
 	verifier.srcClusterInfo = &clusterInfo
 
 	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
-		err := RefreshAllMongosInstances(
+		err := RefreshSrcMongosInstances(
 			ctx,
 			verifier.logger,
 			opts,
@@ -58,7 +58,7 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 	verifier.dstClusterInfo = &clusterInfo
 
 	if clusterInfo.VersionArray[0] < 5 && clusterInfo.Topology == util.TopologySharded {
-		err := RefreshAllMongosInstances(
+		err := RefreshDstMongosInstances(
 			ctx,
 			verifier.logger,
 			opts,


### PR DESCRIPTION
The verbiage around refreshing mongos cache assumed that the cluster was the source. This changeset fixes that so that the verbiage correctly says “source” or “destination”.

This also makes it no longer fatal if the single-host client fails to disconnect.