### PR TITLE
REP-5621 migration-verifier: Report field-order-sensitive mismatch details

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -41,17 +41,17 @@ type ReadConcernSetting string
 
 const (
 	//TODO: add comments for each of these so the warnings will stop :)
-	Missing            = "Missing"
-	Failed             = "Failed"
-	Mismatch           = "Mismatch"
-	ClusterTarget      = "dstClient"
-	ClusterSource      = "srcClient"
-	SrcNamespaceField  = "query_filter.namespace"
-	DstNamespaceField  = "query_filter.to"
-	NumWorkers         = 10
-	Idle               = "idle"
-	Check              = "check"
-	Recheck            = "recheck"
+	Missing           = "Missing"
+	Failed            = "Failed"
+	Mismatch          = "Mismatch"
+	ClusterTarget     = "dstClient"
+	ClusterSource     = "srcClient"
+	SrcNamespaceField = "query_filter.namespace"
+	DstNamespaceField = "query_filter.to"
+	NumWorkers        = 10
+	Idle              = "idle"
+	Check             = "check"
+	Recheck           = "recheck"
 
 	// ReadConcernMajority means to force majority read concern.
 	// This is generally desirable to ensure consistency.

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -41,17 +41,18 @@ type ReadConcernSetting string
 
 const (
 	//TODO: add comments for each of these so the warnings will stop :)
-	Missing           = "Missing"
-	Failed            = "Failed"
-	Mismatch          = "Mismatch"
-	ClusterTarget     = "dstClient"
-	ClusterSource     = "srcClient"
-	SrcNamespaceField = "query_filter.namespace"
-	DstNamespaceField = "query_filter.to"
-	NumWorkers        = 10
-	Idle              = "idle"
-	Check             = "check"
-	Recheck           = "recheck"
+	Missing            = "Missing"
+	Failed             = "Failed"
+	Mismatch           = "Mismatch"
+	FieldOrderMismatch = "FieldOrderMismatch"
+	ClusterTarget      = "dstClient"
+	ClusterSource      = "srcClient"
+	SrcNamespaceField  = "query_filter.namespace"
+	DstNamespaceField  = "query_filter.to"
+	NumWorkers         = 10
+	Idle               = "idle"
+	Check              = "check"
+	Recheck            = "recheck"
 
 	// ReadConcernMajority means to force majority read concern.
 	// This is generally desirable to ensure consistency.
@@ -556,30 +557,30 @@ func (verifier *Verifier) compareOneDocument(srcClientDoc, dstClientDoc bson.Raw
 	}
 	//verifier.logger.Info().Msg("Byte comparison failed for id %s, falling back to field comparison", id)
 
-	if verifier.ignoreBSONFieldOrder {
-		mismatch, err := BsonUnorderedCompareRawDocumentWithDetails(srcClientDoc, dstClientDoc)
-		if err != nil {
-			return nil, err
-		}
-		if mismatch == nil {
+	mismatch, err := BsonUnorderedCompareRawDocumentWithDetails(srcClientDoc, dstClientDoc)
+	if err != nil {
+		return nil, err
+	}
+	if mismatch == nil {
+		if verifier.ignoreBSONFieldOrder {
 			return nil, nil
 		}
-		results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, srcClientDoc.Lookup("_id"), "" /* fieldPrefix */)
-		return results, nil
-	}
-	dataSize := len(srcClientDoc)
-	if dataSize < len(dstClientDoc) {
-		dataSize = len(dstClientDoc)
-	}
+		dataSize := len(srcClientDoc)
+		if dataSize < len(dstClientDoc) {
+			dataSize = len(dstClientDoc)
+		}
 
-	// If we're respecting field order we have just done a binary compare so don't know the mismatching fields.
-	return []VerificationResult{{
-		ID:        srcClientDoc.Lookup("_id"),
-		Details:   Mismatch,
-		Cluster:   ClusterTarget,
-		NameSpace: namespace,
-		dataSize:  dataSize,
-	}}, nil
+		// If we're respecting field order we have just done a binary compare so we have fields in different order.
+		return []VerificationResult{{
+			ID:        srcClientDoc.Lookup("_id"),
+			Details:   FieldOrderMismatch,
+			Cluster:   ClusterTarget,
+			NameSpace: namespace,
+			dataSize:  dataSize,
+		}}, nil
+	}
+	results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, srcClientDoc.Lookup("_id"), "" /* fieldPrefix */)
+	return results, nil
 }
 
 func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, task *VerificationTask) error {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -44,7 +44,6 @@ const (
 	Missing            = "Missing"
 	Failed             = "Failed"
 	Mismatch           = "Mismatch"
-	FieldOrderMismatch = "FieldOrderMismatch"
 	ClusterTarget      = "dstClient"
 	ClusterSource      = "srcClient"
 	SrcNamespaceField  = "query_filter.namespace"
@@ -573,7 +572,7 @@ func (verifier *Verifier) compareOneDocument(srcClientDoc, dstClientDoc bson.Raw
 		// If we're respecting field order we have just done a binary compare so we have fields in different order.
 		return []VerificationResult{{
 			ID:        srcClientDoc.Lookup("_id"),
-			Details:   FieldOrderMismatch,
+			Details:   Mismatch + fmt.Sprintf(" : Document %s has fields in different order", srcClientDoc.Lookup("_id")),
 			Cluster:   ClusterTarget,
 			NameSpace: namespace,
 			dataSize:  dataSize,

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/10gen/migration-verifier/mslices"
 	"github.com/cespare/permute/v2"
 	"github.com/rs/zerolog"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -99,18 +98,11 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	results, docCount, byteCount, err := verifier.FetchAndCompareDocuments(ctx, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(2, docCount, "should find source docs")
-	suite.Assert().NotZero(byteCount, "should tally docs’ size")
+	suite.Assert().NotZero(byteCount, "should tally docs' size")
 	suite.Assert().Len(results, 2)
-	suite.Assert().Equal(
-		[]any{Mismatch, Mismatch},
-		lo.Map(
-			results,
-			func(result VerificationResult, _ int) any {
-				return result.Details
-			},
-		),
-		"details as expected",
-	)
+	for _, res := range results {
+		suite.Assert().Regexp(regexp.MustCompile("^"+Mismatch), res.Details, "details as expected")
+	}
 
 	// Test fetchDocuments for ids with a global filter.
 
@@ -118,9 +110,9 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")
-	suite.Assert().NotZero(byteCount, "should tally docs’ size")
+	suite.Assert().NotZero(byteCount, "should tally docs' size")
 	suite.Require().Len(results, 1)
-	suite.Assert().Equal(Mismatch, results[0].Details)
+	suite.Assert().Regexp(regexp.MustCompile("^"+Mismatch), results[0].Details, "mismatch expeceted")
 	suite.Assert().EqualValues(
 		any(id),
 		results[0].ID.(bson.RawValue).AsInt64(),
@@ -135,9 +127,9 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")
-	suite.Assert().NotZero(byteCount, "should tally docs’ size")
+	suite.Assert().NotZero(byteCount, "should tally docs' size")
 	suite.Require().Len(results, 1)
-	suite.Assert().Equal(Mismatch, results[0].Details)
+	suite.Assert().Regexp(regexp.MustCompile("^"+Mismatch), results[0].Details, "mismatch expeceted")
 	suite.Assert().EqualValues(
 		any(id),
 		results[0].ID.(bson.RawValue).AsInt64(),


### PR DESCRIPTION
Report mismatch details in the case of field-order-sensitive verification:
1. Report mismatched fields if the field content is different.
2. Report different field order if the field content matches but the field order is different.