### PR TITLE
Fix changing-namespaces table caption in logs.

### DIFF
--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -449,12 +449,12 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder) {
 					),
 				)
 			}
-
-			builder.WriteString("\nSource’s most frequently-changing namespaces:\n")
 		}
 	}
 
 	if eventsTable != nil {
+		builder.WriteString("\nSource’s most frequently-changing namespaces:\n")
+
 		eventsTable.Render()
 	}
 }


### PR DESCRIPTION
This fixes a cosmetic issue in logs where the “Source’s most frequently-changing namespaces” table header appeared apart from the actual table.