### PR TITLE
REP-5797 Fix spurious “Operation has not reported success for a while” logs.

### DIFF
--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -57,10 +57,11 @@ func (verifier *Verifier) FetchAndCompareDocuments(
 			"reading from destination",
 		).
 		WithCallback(
-			func(ctx context.Context, _ *retry.FuncInfo) error {
+			func(ctx context.Context, fi *retry.FuncInfo) error {
 				var err error
 				results, docCount, byteCount, err = verifier.compareDocsFromChannels(
 					ctx,
+					fi,
 					task,
 					srcChannel,
 					dstChannel,
@@ -76,6 +77,7 @@ func (verifier *Verifier) FetchAndCompareDocuments(
 
 func (verifier *Verifier) compareDocsFromChannels(
 	ctx context.Context,
+	fi *retry.FuncInfo,
 	task *VerificationTask,
 	srcChannel, dstChannel <-chan bson.Raw,
 ) (
@@ -190,6 +192,8 @@ func (verifier *Verifier) compareDocsFromChannels(
 						break
 					}
 
+					fi.NoteSuccess("received document from source")
+
 					srcDocCount++
 					srcByteCount += types.ByteCount(len(srcDoc))
 				}
@@ -214,6 +218,8 @@ func (verifier *Verifier) compareDocsFromChannels(
 						dstClosed = true
 						break
 					}
+
+					fi.NoteSuccess("received document from destination")
 				}
 
 				return nil


### PR DESCRIPTION
`compareDocsFromChannels` compares all documents for an entire partition, which can take a while. That function hasn’t been reporting any midway successes, which has caused “Operation has not reported success for a while” warnings while it processes documents. Those warnings could even cause spurious failures.

This changeset fixes that by having it report success when it receives a document.