### PR TITLE
Add events per second to log, and use same “now” in progress logs.

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -13,7 +13,8 @@ type NamespaceCount uint64
 // ByteCount represents a count of bytes.
 type ByteCount uint64
 
-type realNumber interface {
+// RealNumber represents any real (i.e., non-complex) number type.
+type RealNumber interface {
 	constraints.Integer | constraints.Float
 }
 
@@ -35,6 +36,6 @@ type realNumber interface {
 //	}
 //
 // ```
-func ToNumericTypeOf[To, From realNumber](value From, _ To) To {
+func ToNumericTypeOf[To, From RealNumber](value From, _ To) To {
 	return To(value)
 }

--- a/internal/util/math.go
+++ b/internal/util/math.go
@@ -1,0 +1,8 @@
+package util
+
+import "github.com/10gen/migration-verifier/internal/types"
+
+// Divide is syntactic sugar around float64(numerator) / float64(denominator).
+func Divide[N types.RealNumber, D types.RealNumber](numerator N, denominator D) float64 {
+	return float64(numerator) / float64(denominator)
+}

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1494,9 +1494,11 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 
 	strBuilder.WriteString(header + "\n\n")
 
+	elapsedSinceGenStart := time.Since(verifier.generationStartTime)
+
 	strBuilder.WriteString(fmt.Sprintf(
 		"Generation time elapsed: %s\n",
-		reportutils.DurationToHMS(time.Since(verifier.generationStartTime)),
+		reportutils.DurationToHMS(elapsedSinceGenStart),
 	))
 
 	metadataMismatches, anyCollsIncomplete, err := verifier.reportCollectionMetadataMismatches(ctx, strBuilder)
@@ -1510,7 +1512,7 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 	case Gen0MetadataAnalysisComplete:
 		fallthrough
 	case GenerationInProgress:
-		hasTasks, err = verifier.printNamespaceStatistics(ctx, strBuilder)
+		hasTasks, err = verifier.printNamespaceStatistics(ctx, strBuilder, elapsedSinceGenStart)
 	case GenerationComplete:
 		hasTasks, err = verifier.printEndOfGenerationStatistics(ctx, strBuilder)
 	default:
@@ -1522,7 +1524,7 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 		return
 	}
 
-	verifier.printChangeEventStatistics(strBuilder)
+	verifier.printChangeEventStatistics(strBuilder, elapsedSinceGenStart)
 
 	// Only print the worker status table if debug logging is enabled.
 	if verifier.logger.Debug().Enabled() {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1494,7 +1494,8 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 
 	strBuilder.WriteString(header + "\n\n")
 
-	elapsedSinceGenStart := time.Since(verifier.generationStartTime)
+	now := time.Now()
+	elapsedSinceGenStart := now.Sub(verifier.generationStartTime)
 
 	strBuilder.WriteString(fmt.Sprintf(
 		"Generation time elapsed: %s\n",
@@ -1512,9 +1513,9 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 	case Gen0MetadataAnalysisComplete:
 		fallthrough
 	case GenerationInProgress:
-		hasTasks, err = verifier.printNamespaceStatistics(ctx, strBuilder, elapsedSinceGenStart)
+		hasTasks, err = verifier.printNamespaceStatistics(ctx, strBuilder, now)
 	case GenerationComplete:
-		hasTasks, err = verifier.printEndOfGenerationStatistics(ctx, strBuilder)
+		hasTasks, err = verifier.printEndOfGenerationStatistics(ctx, strBuilder, now)
 	default:
 		panic("Bad generation status: " + genstatus)
 	}
@@ -1524,13 +1525,13 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 		return
 	}
 
-	verifier.printChangeEventStatistics(strBuilder, elapsedSinceGenStart)
+	verifier.printChangeEventStatistics(strBuilder, now)
 
 	// Only print the worker status table if debug logging is enabled.
 	if verifier.logger.Debug().Enabled() {
 		switch genstatus {
 		case Gen0MetadataAnalysisComplete, GenerationInProgress:
-			verifier.printWorkerStatus(strBuilder)
+			verifier.printWorkerStatus(strBuilder, now)
 		}
 	}
 

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/types"
+	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/olekukonko/tablewriter"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/exp/maps"
@@ -170,7 +171,7 @@ OUTB:
 }
 
 // Boolean returned indicates whether this generation has any tasks.
-func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuilder *strings.Builder) (bool, error) {
+func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuilder *strings.Builder, elapsed time.Duration) (bool, error) {
 	stats, err := verifier.GetNamespaceStatistics(ctx)
 	if err != nil {
 		return false, err
@@ -208,8 +209,6 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 		completedNss, totalNss,
 		reportutils.FmtPercent(completedNss, totalNss),
 	))
-
-	elapsed := time.Since(verifier.generationStartTime)
 
 	docsPerSecond := float64(comparedDocs) / elapsed.Seconds()
 	bytesPerSecond := float64(comparedBytes) / elapsed.Seconds()
@@ -308,7 +307,7 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 	return true, nil
 }
 
-func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, strBuilder *strings.Builder) (bool, error) {
+func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, strBuilder *strings.Builder, elapsed time.Duration) (bool, error) {
 	stats, err := verifier.GetNamespaceStatistics(ctx)
 	if err != nil {
 		return false, err
@@ -342,8 +341,6 @@ func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, st
 	))
 
 	dataUnit := reportutils.FindBestUnit(comparedBytes)
-
-	elapsed := time.Since(verifier.generationStartTime)
 
 	docsPerSecond := float64(comparedDocs) / elapsed.Seconds()
 	bytesPerSecond := float64(comparedBytes) / elapsed.Seconds()
@@ -380,7 +377,7 @@ func (verifier *Verifier) printMismatchInvestigationNotes(strBuilder *strings.Bu
 	}
 }
 
-func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder) {
+func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, elapsed time.Duration) {
 	var eventsTable *tablewriter.Table
 
 	for _, cluster := range []struct {
@@ -404,7 +401,12 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder) {
 
 		eventsDescr := "none"
 		if totalEvents > 0 {
-			eventsDescr = fmt.Sprintf("%d total, across %d namespace(s)", totalEvents, activeNamespacesCount)
+			eventsDescr = fmt.Sprintf(
+				"%d total (%s/sec), across %d namespace(s)",
+				totalEvents,
+				reportutils.FmtFloat(util.Divide(totalEvents, elapsed.Seconds())),
+				activeNamespacesCount,
+			)
 		}
 
 		builder.WriteString(fmt.Sprintf("\n%s change events this generation: %s\n", cluster.title, eventsDescr))

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -171,7 +171,7 @@ OUTB:
 }
 
 // Boolean returned indicates whether this generation has any tasks.
-func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuilder *strings.Builder, elapsed time.Duration) (bool, error) {
+func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuilder *strings.Builder, now time.Time) (bool, error) {
 	stats, err := verifier.GetNamespaceStatistics(ctx)
 	if err != nil {
 		return false, err
@@ -209,6 +209,8 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 		completedNss, totalNss,
 		reportutils.FmtPercent(completedNss, totalNss),
 	))
+
+	elapsed := now.Sub(verifier.generationStartTime)
 
 	docsPerSecond := float64(comparedDocs) / elapsed.Seconds()
 	bytesPerSecond := float64(comparedBytes) / elapsed.Seconds()
@@ -307,7 +309,7 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 	return true, nil
 }
 
-func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, strBuilder *strings.Builder, elapsed time.Duration) (bool, error) {
+func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, strBuilder *strings.Builder, now time.Time) (bool, error) {
 	stats, err := verifier.GetNamespaceStatistics(ctx)
 	if err != nil {
 		return false, err
@@ -341,6 +343,8 @@ func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, st
 	))
 
 	dataUnit := reportutils.FindBestUnit(comparedBytes)
+
+	elapsed := now.Sub(verifier.generationStartTime)
 
 	docsPerSecond := float64(comparedDocs) / elapsed.Seconds()
 	bytesPerSecond := float64(comparedBytes) / elapsed.Seconds()
@@ -377,7 +381,7 @@ func (verifier *Verifier) printMismatchInvestigationNotes(strBuilder *strings.Bu
 	}
 }
 
-func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, elapsed time.Duration) {
+func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, now time.Time) {
 	var eventsTable *tablewriter.Table
 
 	for _, cluster := range []struct {
@@ -398,6 +402,8 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, e
 			nsTotals[ns] = events.Total()
 			totalEvents += nsTotals[ns]
 		}
+
+		elapsed := now.Sub(verifier.generationStartTime)
 
 		eventsDescr := "none"
 		if totalEvents > 0 {
@@ -461,7 +467,7 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, e
 	}
 }
 
-func (verifier *Verifier) printWorkerStatus(builder *strings.Builder) {
+func (verifier *Verifier) printWorkerStatus(builder *strings.Builder, now time.Time) {
 
 	table := tablewriter.NewWriter(builder)
 	table.SetHeader([]string{"Thread #", "Namespace", "Task", "Time Elapsed"})
@@ -492,7 +498,7 @@ func (verifier *Verifier) printWorkerStatus(builder *strings.Builder) {
 				strconv.Itoa(w),
 				wsmap[w].Namespace,
 				taskIdStr,
-				reportutils.DurationToHMS(time.Since(wsmap[w].StartTime)),
+				reportutils.DurationToHMS(now.Sub(wsmap[w].StartTime)),
 			},
 		)
 	}


### PR DESCRIPTION
This adds a simple events-per-second computation to the progress logs, which will provide a useful at-a-glance metric of how active the change streams are. It also changes the logic a bit to compute all time deltas from the same “now”.