### PR TITLE
Ignore/log `modify` events on the destination.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/huandu/go-clone v1.6.0 // indirect
+	github.com/huandu/go-clone/generic v1.7.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,11 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
+github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
+github.com/huandu/go-clone/generic v1.7.2 h1:47pQphxs1Xc9cVADjOHN+Bm5D0hNagwH9UXErbxgVKA=
+github.com/huandu/go-clone/generic v1.7.2/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
@@ -90,6 +95,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -360,19 +360,21 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 			// We expect modify events on the destination as part of finalizing
 			// a migration. For example, mongosync enables indexes’ uniqueness
 			// constraints and sets capped collection sizes.
-			if opType == modifyEventType && csr.onModifyEvent == onModifyEventIgnore {
-				csr.logger.Info().
-					Stringer("changeStream", csr).
-					Interface("event", cs.Current).
-					Msg("This event is probably internal to the migration. Ignoring.")
+			/*
+				if opType == modifyEventType && csr.onModifyEvent == onModifyEventIgnore {
+					csr.logger.Info().
+						Stringer("changeStream", csr).
+						Interface("event", cs.Current).
+						Msg("This event is probably internal to the migration. Ignoring.")
 
-				// Discard this event, then keep reading.
-				changeEventBatch = changeEventBatch[:len(changeEventBatch)-1]
+					// Discard this event, then keep reading.
+					changeEventBatch = changeEventBatch[:len(changeEventBatch)-1]
 
-				continue
-			} else {
-				return UnknownEventError{Event: clone.Clone(cs.Current)}
-			}
+					continue
+				} else {
+			*/
+			return UnknownEventError{Event: clone.Clone(cs.Current)}
+			//}
 		}
 
 		// This shouldn’t happen, but just in case:

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -12,6 +12,7 @@ import (
 	"github.com/10gen/migration-verifier/msync"
 	"github.com/10gen/migration-verifier/option"
 	mapset "github.com/deckarep/golang-set/v2"
+	clone "github.com/huandu/go-clone/generic"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/samber/mo"
@@ -57,12 +58,18 @@ const (
 )
 
 type UnknownEventError struct {
-	Event *ParsedEvent
+	Event bson.Raw
 }
 
 func (uee UnknownEventError) Error() string {
 	return fmt.Sprintf("received event with unknown optype: %+v", uee.Event)
 }
+
+type modifyEventHandling string
+
+const (
+	onModifyEventDiscard modifyEventHandling = "discard"
+)
 
 type ChangeStreamReader struct {
 	readerType whichCluster
@@ -85,6 +92,8 @@ type ChangeStreamReader struct {
 	startAtTs *primitive.Timestamp
 
 	lag *msync.TypedAtomic[option.Option[time.Duration]]
+
+	onModifyEvent modifyEventHandling
 }
 
 func (verifier *Verifier) initializeChangeStreamReaders() {
@@ -117,6 +126,7 @@ func (verifier *Verifier) initializeChangeStreamReaders() {
 		handlerError:         util.NewEventual[error](),
 		doneChan:             make(chan struct{}),
 		lag:                  msync.NewTypedAtomic(option.None[time.Duration]()),
+		onModifyEvent:        onModifyEventDiscard,
 	}
 }
 
@@ -343,8 +353,20 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 			Int("batchSize", len(changeEventBatch)).
 			Msg("Received a change event.")
 
-		if !supportedEventOpTypes.Contains(changeEventBatch[eventsRead].OpType) {
-			return UnknownEventError{Event: &changeEventBatch[eventsRead]}
+		opType := changeEventBatch[eventsRead].OpType
+		if !supportedEventOpTypes.Contains(opType) {
+
+			// We expect modify events on the destination as part of finalizing
+			// a migration. For example, mongosync enables indexes’ uniqueness
+			// constraints and sets capped collection sizes.
+			if opType == "modify" && csr.onModifyEvent == onModifyEventDiscard {
+				csr.logger.Info().
+					Stringer("changeStream", csr).
+					Interface("event", cs.Current).
+					Msg("This event is probably internal to the migration. Discarding.")
+			} else {
+				return UnknownEventError{Event: clone.Clone(cs.Current)}
+			}
 		}
 
 		// This shouldn’t happen, but just in case:

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -27,8 +27,9 @@ type modifyEventHandling string
 const (
 	fauxDocSizeForDeleteEvents = 1024
 
+	modifyEventType = "modify"
+
 	onModifyEventIgnore modifyEventHandling = "ignore"
-	modifyEventType                         = "modify"
 )
 
 var supportedEventOpTypes = mapset.NewSet(

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -361,7 +361,6 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 			// a migration. For example, mongosync enables indexes’ uniqueness
 			// constraints and sets capped collection sizes.
 			if opType == modifyEventType && csr.onModifyEvent == onModifyEventIgnore {
-				fmt.Printf("\n============== ignoring event: %+v\n\n", cs.Current)
 				csr.logger.Info().
 					Stringer("changeStream", csr).
 					Stringer("event", cs.Current).

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -360,21 +360,20 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 			// We expect modify events on the destination as part of finalizing
 			// a migration. For example, mongosync enables indexes’ uniqueness
 			// constraints and sets capped collection sizes.
-			/*
-				if opType == modifyEventType && csr.onModifyEvent == onModifyEventIgnore {
-					csr.logger.Info().
-						Stringer("changeStream", csr).
-						Interface("event", cs.Current).
-						Msg("This event is probably internal to the migration. Ignoring.")
+			if opType == modifyEventType && csr.onModifyEvent == onModifyEventIgnore {
+				fmt.Printf("\n============== ignoring event: %+v\n\n", cs.Current)
+				csr.logger.Info().
+					Stringer("changeStream", csr).
+					Interface("event", cs.Current).
+					Msg("This event is probably internal to the migration. Ignoring.")
 
-					// Discard this event, then keep reading.
-					changeEventBatch = changeEventBatch[:len(changeEventBatch)-1]
+				// Discard this event, then keep reading.
+				changeEventBatch = changeEventBatch[:len(changeEventBatch)-1]
 
-					continue
-				} else {
-			*/
-			return UnknownEventError{Event: clone.Clone(cs.Current)}
-			//}
+				continue
+			} else {
+				return UnknownEventError{Event: clone.Clone(cs.Current)}
+			}
 		}
 
 		// This shouldn’t happen, but just in case:

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -365,6 +365,11 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 					Stringer("changeStream", csr).
 					Interface("event", cs.Current).
 					Msg("This event is probably internal to the migration. Ignoring.")
+
+				// Discard this event, then keep reading.
+				changeEventBatch = changeEventBatch[:len(changeEventBatch)-1]
+
+				continue
 			} else {
 				return UnknownEventError{Event: clone.Clone(cs.Current)}
 			}

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -364,7 +364,7 @@ func (csr *ChangeStreamReader) readAndHandleOneChangeEventBatch(
 				fmt.Printf("\n============== ignoring event: %+v\n\n", cs.Current)
 				csr.logger.Info().
 					Stringer("changeStream", csr).
-					Interface("event", cs.Current).
+					Stringer("event", cs.Current).
 					Msg("This event is probably internal to the migration. Ignoring.")
 
 				// Discard this event, then keep reading.

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -717,7 +717,7 @@ func (suite *IntegrationTestSuite) TestCreateForbidden() {
 
 	eventErr := UnknownEventError{}
 	suite.Require().ErrorAs(err, &eventErr)
-	suite.Assert().Equal("create", eventErr.Event.Lookup("operationType"))
+	suite.Assert().Equal("create", eventErr.Event.Lookup("operationType").StringValue())
 }
 
 func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
@@ -737,6 +737,7 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 			coll.Name(),
 			options.CreateCollection().
 				SetCapped(true).
+				SetSizeInBytes(123123).
 				SetMaxDocuments(1000),
 		),
 	)

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -776,6 +776,14 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		"should alter capped size",
 	)
 
+	// Run another generation to ensure the collMod gets into the change stream.
+	suite.Require().NoError(
+		verifierRunner.StartNextGeneration(),
+	)
+	suite.Require().NoError(
+		verifierRunner.AwaitGenerationEnd(),
+	)
+
 	err = verifier.WritesOff(ctx)
 	if err == nil {
 		err = verifierRunner.Await()

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -729,18 +729,20 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		suite.T().Skipf("This test requires dst server v6+. (Found: %v)", buildInfo.VersionArray)
 	}
 
-	db := suite.srcMongoClient.Database(suite.DBNameForTest())
-	coll := db.Collection("mycoll")
-	suite.Require().NoError(
-		db.CreateCollection(
-			ctx,
-			coll.Name(),
-			options.CreateCollection().
-				SetCapped(true).
-				SetSizeInBytes(123123).
-				SetMaxDocuments(1000),
-		),
-	)
+	for _, client := range mslices.Of(suite.srcMongoClient, suite.dstMongoClient) {
+		db := client.Database(suite.DBNameForTest())
+		coll := db.Collection("mycoll")
+		suite.Require().NoError(
+			db.CreateCollection(
+				ctx,
+				coll.Name(),
+				options.CreateCollection().
+					SetCapped(true).
+					SetSizeInBytes(123123).
+					SetMaxDocuments(1000),
+			),
+		)
+	}
 
 	verifier := suite.BuildVerifier()
 

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -776,14 +776,6 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		"should alter capped size",
 	)
 
-	// Run another generation to ensure the collMod gets into the change stream.
-	suite.Require().NoError(
-		verifierRunner.StartNextGeneration(),
-	)
-	suite.Require().NoError(
-		verifierRunner.AwaitGenerationEnd(),
-	)
-
 	err = verifier.WritesOff(ctx)
 	if err == nil {
 		err = verifierRunner.Await()

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/testutil"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/mslices"
+	"github.com/10gen/migration-verifier/mstrings"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
@@ -746,7 +747,7 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 
 	verifier := suite.BuildVerifier()
 
-	logBuffer := &strings.Builder{}
+	logBuffer := &mstrings.SyncBuilder{}
 
 	multiOut := io.MultiWriter(
 		logger.DefaultLogWriter,

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -722,11 +722,11 @@ func (suite *IntegrationTestSuite) TestCreateForbidden() {
 
 func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 	ctx := suite.Context()
-	buildInfo, err := util.GetClusterInfo(ctx, suite.srcMongoClient)
+	buildInfo, err := util.GetClusterInfo(ctx, suite.dstMongoClient)
 	suite.Require().NoError(err)
 
 	if buildInfo.VersionArray[0] < 6 {
-		suite.T().Skipf("This test requires server v6+. (Found: %v)", buildInfo.VersionArray)
+		suite.T().Skipf("This test requires dst server v6+. (Found: %v)", buildInfo.VersionArray)
 	}
 
 	db := suite.srcMongoClient.Database(suite.DBNameForTest())

--- a/mstrings/builder.go
+++ b/mstrings/builder.go
@@ -1,0 +1,27 @@
+package mstrings
+
+import (
+	"strings"
+	"sync"
+)
+
+// SyncBuilder is a race-safe version of the standard library’s strings.Builder.
+// As of this writing it doesn’t implement all of the standard library’s logic.
+type SyncBuilder struct {
+	mutex   sync.RWMutex
+	builder strings.Builder
+}
+
+func (b *SyncBuilder) String() string {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	return b.builder.String()
+}
+
+func (b *SyncBuilder) Write(p []byte) (int, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.builder.Write(p)
+}

--- a/vendor/github.com/huandu/go-clone/.gitignore
+++ b/vendor/github.com/huandu/go-clone/.gitignore
@@ -1,0 +1,40 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Intellij
+*.iml
+.idea/
+
+# VS Code
+debug
+debug_test
+.vscode/
+
+# Mac
+.DS_Store
+
+# go workspace
+go.work
+go.work.sum

--- a/vendor/github.com/huandu/go-clone/LICENSE
+++ b/vendor/github.com/huandu/go-clone/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Huan Du
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/huandu/go-clone/README.md
+++ b/vendor/github.com/huandu/go-clone/README.md
@@ -1,0 +1,269 @@
+# go-clone: Clone any Go data structure deeply and thoroughly
+
+[![Go](https://github.com/huandu/go-clone/workflows/Go/badge.svg)](https://github.com/huandu/go-clone/actions)
+[![Go Doc](https://godoc.org/github.com/huandu/go-clone?status.svg)](https://pkg.go.dev/github.com/huandu/go-clone)
+[![Go Report](https://goreportcard.com/badge/github.com/huandu/go-clone)](https://goreportcard.com/report/github.com/huandu/go-clone)
+[![Coverage Status](https://coveralls.io/repos/github/huandu/go-clone/badge.svg?branch=master)](https://coveralls.io/github/huandu/go-clone?branch=master)
+
+Package `clone` provides functions to deep clone any Go data. It also provides a wrapper to protect a pointer from any unexpected mutation.
+
+For users who use Go 1.18+, it's recommended to import `github.com/huandu/go-clone/generic` for generic APIs and arena support.
+
+`Clone`/`Slowly` can clone unexported fields and "no-copy" structs as well. Use this feature wisely.
+
+## Install
+
+Use `go get` to install this package.
+
+```shell
+go get github.com/huandu/go-clone
+```
+
+## Usage
+
+### `Clone` and `Slowly`
+
+If we want to clone any Go value, use `Clone`.
+
+```go
+t := &T{...}
+v := clone.Clone(t).(*T)
+reflect.DeepEqual(t, v) // true
+```
+
+For the sake of performance, `Clone` doesn't deal with values containing pointer cycles.
+If we need to clone such values, use `Slowly` instead.
+
+```go
+type ListNode struct {
+    Data int
+    Next *ListNode
+}
+node1 := &ListNode{
+    Data: 1,
+}
+node2 := &ListNode{
+    Data: 2,
+}
+node3 := &ListNode{
+    Data: 3,
+}
+node1.Next = node2
+node2.Next = node3
+node3.Next = node1
+
+// We must use `Slowly` to clone a circular linked list.
+node := Slowly(node1).(*ListNode)
+
+for i := 0; i < 10; i++ {
+    fmt.Println(node.Data)
+    node = node.Next
+}
+```
+
+### Generic APIs
+
+Starting from go1.18, Go started to support generic. With generic syntax, `Clone`/`Slowly` and other APIs can be called much cleaner like following.
+
+```go
+import "github.com/huandu/go-clone/generic"
+
+type MyType struct {
+    Foo string
+}
+
+original := &MyType{
+    Foo: "bar",
+}
+
+// The type of cloned is *MyType instead of interface{}.
+cloned := Clone(original)
+println(cloned.Foo) // Output: bar
+```
+
+It's required to update minimal Go version to 1.18 to opt-in generic syntax. It may not be a wise choice to update this package's `go.mod` and drop so many old Go compilers for such syntax candy. Therefore, I decide to create a new standalone package `github.com/huandu/go-clone/generic` to provide APIs with generic syntax.
+
+For new users who use Go 1.18+, the generic package is preferred and recommended.
+
+### Arena support
+
+Starting from Go1.20, arena is introduced as a new way to allocate memory. It's quite useful to improve overall performance in special scenarios.
+In order to clone a value with memory allocated from an arena, there are new methods `ArenaClone` and `ArenaCloneSlowly` available in `github.com/huandu/go-clone/generic`.
+
+```go
+// ArenaClone recursively deep clones v to a new value in arena a.
+// It works in the same way as Clone, except it allocates all memory from arena.
+func ArenaClone[T any](a *arena.Arena, v T) (nv T) 
+
+// ArenaCloneSlowly recursively deep clones v to a new value in arena a.
+// It works in the same way as Slowly, except it allocates all memory from arena.
+func ArenaCloneSlowly[T any](a *arena.Arena, v T) (nv T)
+```
+
+Due to limitations in arena API, memory of the internal data structure of `map` and `chan` is always allocated in heap by Go runtime ([see this issue](https://github.com/golang/go/issues/56230)).
+
+**Warning**: Per [discussion in the arena proposal](https://github.com/golang/go/issues/51317), the arena package may be changed incompatibly or removed in future. All arena related APIs in this package will be changed accordingly.
+
+### Memory allocations and the `Allocator`
+
+The `Allocator` is designed to allocate memory when cloning. It's also used to hold all customizations, e.g. custom clone functions, scalar types and opaque pointers, etc. There is a default allocator which allocates memory from heap. Almost all public APIs in this package use this default allocator to do their job.
+
+We can control how to allocate memory by creating a new `Allocator` by `NewAllocator`. It enables us to take full control over memory allocation when cloning. See [Allocator sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-Allocator) to understand how to customize an allocator.
+
+Let's take a closer look at the `NewAllocator` function.
+
+```go
+func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) *Allocator
+```
+
+- The first parameter `pool` is a pointer to a memory pool. It's used to allocate memory for cloning. It can be `nil` if we don't need a memory pool.
+- The second parameter `methods` is a pointer to a struct which contains all methods to allocate memory. It can be `nil` if we don't need to customize memory allocation.
+- The `Allocator` struct is allocated from the `methods.New` or the `methods.Parent` allocator or from heap.
+
+The `Parent` in `AllocatorMethods` is used to indicate the parent of the new allocator. With this feature, we can orgnize allocators into a tree structure. All customizations, including custom clone functions, scalar types and opaque pointers, etc, are inherited from parent allocators.
+
+There are some APIs designed for convenience.
+
+- We can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a *arena.Arena)`.
+- We can call `MakeCloner(allocator)` to create a helper struct with `Clone` and `CloneSlowly` methods in which the type of in and out parameters is `interface{}`.
+
+### Mark struct type as scalar
+
+Some struct types can be considered as scalar.
+
+A well-known case is `time.Time`.
+Although there is a pointer `loc *time.Location` inside `time.Time`, we always use `time.Time` by value in all methods.
+When cloning `time.Time`, it should be OK to return a shadow copy.
+
+Currently, following types are marked as scalar by default.
+
+- `time.Time`
+- `reflect.Value`
+
+If there is any type defined in built-in package should be considered as scalar, please open new issue to let me know.
+I will update the default.
+
+If there is any custom type should be considered as scalar, call `MarkAsScalar` to mark it manually. See [MarkAsScalar sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-MarkAsScalar) for more details.
+
+### Mark pointer type as opaque
+
+Some pointer values are used as enumerable const values.
+
+A well-known case is `elliptic.Curve`. In package `crypto/tls`, curve type of a certificate is checked by comparing values to pre-defined curve values, e.g. `elliptic.P521()`. In this case, the curve values, which are pointers or structs, cannot be cloned deeply.
+
+Currently, following types are marked as scalar by default.
+
+- `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`.
+- `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
+
+If there is any pointer type defined in built-in package should be considered as opaque, please open new issue to let me know.
+I will update the default.
+
+If there is any custom pointer type should be considered as opaque, call `MarkAsOpaquePointer` to mark it manually. See [MarkAsOpaquePointer sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-MarkAsOpaquePointer) for more details.
+
+### Clone "no-copy" types defined in `sync` and `sync/atomic`
+
+There are some "no-copy" types like `sync.Mutex`, `atomic.Value`, etc.
+They cannot be cloned by copying all fields one by one, but we can alloc a new zero value and call methods to do proper initialization.
+
+Currently, all "no-copy" types defined in `sync` and `sync/atomic` can be cloned properly using following strategies.
+
+- `sync.Mutex`: Cloned value is a newly allocated zero mutex.
+- `sync.RWMutex`: Cloned value is a newly allocated zero mutex.
+- `sync.WaitGroup`: Cloned value is a newly allocated zero wait group.
+- `sync.Cond`: Cloned value is a cond with a newly allocated zero lock.
+- `sync.Pool`: Cloned value is an empty pool with the same `New` function.
+- `sync.Map`: Cloned value is a sync map with cloned key/value pairs.
+- `sync.Once`: Cloned value is a once type with the same done flag.
+- `atomic.Value`/`atomic.Bool`/`atomic.Int32`/`atomic.Int64`/`atomic.Uint32`/`atomic.Uint64`/`atomic.Uintptr`: Cloned value is a new atomic value with the same value.
+
+If there is any type defined in built-in package should be considered as "no-copy" types, please open new issue to let me know.
+I will update the default.
+
+### Set custom clone functions
+
+If default clone strategy doesn't work for a struct type, we can call `SetCustomFunc` to register a custom clone function.
+
+```go
+SetCustomFunc(reflect.TypeOf(MyType{}), func(allocator *Allocator, old, new reflect.Value) {
+    // Customized logic to copy the old to the new.
+    // The old's type is MyType.
+    // The new is a zero value of MyType and new.CanAddr() always returns true.
+})
+```
+
+We can use `allocator` to clone any value or allocate new memory.
+It's allowed to call `allocator.Clone` or `allocator.CloneSlowly` on `old` to clone its struct fields in depth without worrying about dead loop.
+
+See [SetCustomFunc sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-SetCustomFunc) for more details.
+
+### Clone `atomic.Pointer[T]`
+
+As there is no way to predefine a custom clone function for generic type `atomic.Pointer[T]`, cloning such atomic type is not supported by default. If we want to support it, we need to register a custom clone function manually.
+
+Suppose we instantiate `atomic.Pointer[T]` with type `MyType1` and `MyType2` in a project, and then we can register custom clone functions like following.
+
+```go
+import "github.com/huandu/go-clone/generic"
+
+func init() {
+    // Register all instantiated atomic.Pointer[T] types in this project.
+    clone.RegisterAtomicPointer[MyType1]()
+    clone.RegisterAtomicPointer[MyType2]()
+}
+```
+
+### `Wrap`, `Unwrap` and `Undo`
+
+Package `clone` provides `Wrap`/`Unwrap` functions to protect a pointer value from any unexpected mutation.
+It's useful when we want to protect a variable which should be immutable by design,
+e.g. global config, the value stored in context, the value sent to a chan, etc.
+
+```go
+// Suppose we have a type T defined as following.
+//     type T struct {
+//         Foo int
+//     }
+v := &T{
+    Foo: 123,
+}
+w := Wrap(v).(*T) // Wrap value to protect it.
+
+// Use w freely. The type of w is the same as that of v.
+
+// It's OK to modify w. The change will not affect v.
+w.Foo = 456
+fmt.Println(w.Foo) // 456
+fmt.Println(v.Foo) // 123
+
+// Once we need the original value stored in w, call `Unwrap`.
+orig := Unwrap(w).(*T)
+fmt.Println(orig == v) // true
+fmt.Println(orig.Foo)  // 123
+
+// Or, we can simply undo any change made in w.
+// Note that `Undo` is significantly slower than `Unwrap`, thus
+// the latter is always preferred.
+Undo(w)
+fmt.Println(w.Foo) // 123
+```
+
+## Performance
+
+Here is the performance data running on my dev machine.
+
+```text
+go 1.20.1
+goos: darwin
+goarch: amd64
+cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+BenchmarkSimpleClone-12       7164530        156.7 ns/op       24 B/op        1 allocs/op
+BenchmarkComplexClone-12       628056         1871 ns/op     1488 B/op       21 allocs/op
+BenchmarkUnwrap-12           15498139        78.02 ns/op        0 B/op        0 allocs/op
+BenchmarkSimpleWrap-12        3882360        309.7 ns/op       72 B/op        2 allocs/op
+BenchmarkComplexWrap-12        949654         1245 ns/op      736 B/op       15 allocs/op
+```
+
+## License
+
+This package is licensed under MIT license. See LICENSE for details.

--- a/vendor/github.com/huandu/go-clone/allocator.go
+++ b/vendor/github.com/huandu/go-clone/allocator.go
@@ -1,0 +1,318 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"reflect"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+var typeOfAllocator = reflect.TypeOf(Allocator{})
+
+// defaultAllocator is the default allocator and allocates memory from heap.
+var defaultAllocator = &Allocator{
+	new:       heapNew,
+	makeSlice: heapMakeSlice,
+	makeMap:   heapMakeMap,
+	makeChan:  heapMakeChan,
+	isScalar:  IsScalar,
+}
+
+// Allocator is a utility type for memory allocation.
+type Allocator struct {
+	parent *Allocator
+
+	pool      unsafe.Pointer
+	new       func(pool unsafe.Pointer, t reflect.Type) reflect.Value
+	makeSlice func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value
+	makeMap   func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value
+	makeChan  func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value
+	isScalar  func(t reflect.Kind) bool
+
+	cachedStructTypes     sync.Map
+	cachedPointerTypes    sync.Map
+	cachedCustomFuncTypes sync.Map
+}
+
+// FromHeap creates an allocator which allocate memory from heap.
+func FromHeap() *Allocator {
+	return NewAllocator(nil, nil)
+}
+
+// NewAllocator creates an allocator which allocate memory from the pool.
+// Both pool and methods are optional.
+//
+// If methods.New is not nil, the allocator itself is created by calling methods.New.
+//
+// The pool is a pointer to the memory pool which is opaque to the allocator.
+// It's methods's responsibility to allocate memory from the pool properly.
+func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) (allocator *Allocator) {
+	parent := methods.parent()
+	new := methods.new(parent, pool)
+
+	// Allocate the allocator from the pool.
+	val := new(pool, typeOfAllocator)
+	allocator = (*Allocator)(unsafe.Pointer(val.Pointer()))
+	runtime.KeepAlive(val)
+
+	allocator.pool = pool
+	allocator.new = new
+	allocator.makeSlice = methods.makeSlice(parent, pool)
+	allocator.makeMap = methods.makeMap(parent, pool)
+	allocator.makeChan = methods.makeChan(parent, pool)
+	allocator.isScalar = methods.isScalar(parent)
+
+	if parent == nil {
+		parent = defaultAllocator
+	}
+
+	allocator.parent = parent
+	return
+}
+
+// New returns a new zero value of t.
+func (a *Allocator) New(t reflect.Type) reflect.Value {
+	return a.new(a.pool, t)
+}
+
+// MakeSlice creates a new zero-initialized slice value of t with len and cap.
+func (a *Allocator) MakeSlice(t reflect.Type, len, cap int) reflect.Value {
+	return a.makeSlice(a.pool, t, len, cap)
+}
+
+// MakeMap creates a new map with minimum size n.
+func (a *Allocator) MakeMap(t reflect.Type, n int) reflect.Value {
+	return a.makeMap(a.pool, t, n)
+}
+
+// MakeChan creates a new chan with buffer.
+func (a *Allocator) MakeChan(t reflect.Type, buffer int) reflect.Value {
+	return a.makeChan(a.pool, t, buffer)
+}
+
+// Clone recursively deep clone val to a new value with memory allocated from a.
+func (a *Allocator) Clone(val reflect.Value) reflect.Value {
+	return a.clone(val, true)
+}
+
+func (a *Allocator) clone(val reflect.Value, inCustomFunc bool) reflect.Value {
+	if !val.IsValid() {
+		return val
+	}
+
+	state := &cloneState{
+		allocator: a,
+	}
+
+	if inCustomFunc {
+		state.skipCustomFuncValue = val
+	}
+
+	return state.clone(val)
+}
+
+// CloneSlowly recursively deep clone val to a new value with memory allocated from a.
+// It marks all cloned values internally, thus it can clone v with cycle pointer.
+func (a *Allocator) CloneSlowly(val reflect.Value) reflect.Value {
+	return a.cloneSlowly(val, true)
+}
+
+func (a *Allocator) cloneSlowly(val reflect.Value, inCustomFunc bool) reflect.Value {
+	if !val.IsValid() {
+		return val
+	}
+
+	state := &cloneState{
+		allocator: a,
+		visited:   visitMap{},
+		invalid:   invalidPointers{},
+	}
+
+	if inCustomFunc {
+		state.skipCustomFuncValue = val
+	}
+
+	cloned := state.clone(val)
+	state.fix(cloned)
+	return cloned
+}
+
+func (a *Allocator) loadStructType(t reflect.Type) (st structType) {
+	st, ok := a.lookupStructType(t)
+
+	if ok {
+		return
+	}
+
+	num := t.NumField()
+	pointerFields := make([]structFieldType, 0, num)
+
+	// Find pointer fields in depth-first order.
+	for i := 0; i < num; i++ {
+		field := t.Field(i)
+		ft := field.Type
+		k := ft.Kind()
+
+		if a.isScalar(k) {
+			continue
+		}
+
+		switch k {
+		case reflect.Array:
+			if ft.Len() == 0 {
+				continue
+			}
+
+			elem := ft.Elem()
+
+			if a.isScalar(elem.Kind()) {
+				continue
+			}
+
+			if elem.Kind() == reflect.Struct {
+				if fst := a.loadStructType(elem); fst.CanShadowCopy() {
+					continue
+				}
+			}
+		case reflect.Struct:
+			if fst := a.loadStructType(ft); fst.CanShadowCopy() {
+				continue
+			}
+		}
+
+		pointerFields = append(pointerFields, structFieldType{
+			Offset: field.Offset,
+			Index:  i,
+		})
+	}
+
+	if len(pointerFields) == 0 {
+		pointerFields = nil // Release memory ASAP.
+	}
+
+	st = structType{
+		PointerFields: pointerFields,
+	}
+
+	// Load custom function.
+	current := a
+
+	for current != nil {
+		if fn, ok := current.cachedCustomFuncTypes.Load(t); ok {
+			st.fn = fn.(Func)
+			break
+		}
+
+		current = current.parent
+	}
+
+	a.cachedStructTypes.LoadOrStore(t, st)
+	return
+}
+
+func (a *Allocator) lookupStructType(t reflect.Type) (st structType, ok bool) {
+	var v interface{}
+	current := a
+
+	for current != nil {
+		v, ok = current.cachedStructTypes.Load(t)
+
+		if ok {
+			st = v.(structType)
+			return
+		}
+
+		current = current.parent
+	}
+
+	return
+}
+
+func (a *Allocator) isOpaquePointer(t reflect.Type) (ok bool) {
+	current := a
+
+	for current != nil {
+		if _, ok = current.cachedPointerTypes.Load(t); ok {
+			return
+		}
+
+		current = current.parent
+	}
+
+	return
+}
+
+// MarkAsScalar marks t as a scalar type so that all clone methods will copy t by value.
+// If t is not struct or pointer to struct, MarkAsScalar ignores t.
+//
+// In the most cases, it's not necessary to call it explicitly.
+// If a struct type contains scalar type fields only, the struct will be marked as scalar automatically.
+//
+// Here is a list of types marked as scalar by default:
+//   - time.Time
+//   - reflect.Value
+func (a *Allocator) MarkAsScalar(t reflect.Type) {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	a.cachedStructTypes.Store(t, zeroStructType)
+}
+
+// MarkAsOpaquePointer marks t as an opaque pointer so that all clone methods will copy t by value.
+// If t is not a pointer, MarkAsOpaquePointer ignores t.
+//
+// Here is a list of types marked as opaque pointers by default:
+//   - `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`;
+//   - `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
+func (a *Allocator) MarkAsOpaquePointer(t reflect.Type) {
+	if t.Kind() != reflect.Ptr {
+		return
+	}
+
+	a.cachedPointerTypes.Store(t, struct{}{})
+}
+
+// SetCustomFunc sets a custom clone function for type t.
+// If t is not struct or pointer to struct, SetCustomFunc ignores t.
+//
+// If fn is nil, remove the custom clone function for type t.
+func (a *Allocator) SetCustomFunc(t reflect.Type, fn Func) {
+	if fn == nil {
+		a.cachedCustomFuncTypes.Delete(t)
+		return
+	}
+
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	a.cachedCustomFuncTypes.Store(t, fn)
+}
+
+func heapNew(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+	return reflect.New(t)
+}
+
+func heapMakeSlice(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+	return reflect.MakeSlice(t, len, cap)
+}
+
+func heapMakeMap(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+	return reflect.MakeMapWithSize(t, n)
+}
+
+func heapMakeChan(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+	return reflect.MakeChan(t, buffer)
+}

--- a/vendor/github.com/huandu/go-clone/allocatormethods.go
+++ b/vendor/github.com/huandu/go-clone/allocatormethods.go
@@ -1,0 +1,115 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// AllocatorMethods defines all methods required by allocator.
+// If any of these methods is nil, allocator will use default method which allocates memory from heap.
+type AllocatorMethods struct {
+	// Parent is the allocator which handles all unhandled methods.
+	// If it's nil, it will be the default allocator.
+	Parent *Allocator
+
+	New       func(pool unsafe.Pointer, t reflect.Type) reflect.Value
+	MakeSlice func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value
+	MakeMap   func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value
+	MakeChan  func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value
+	IsScalar  func(k reflect.Kind) bool
+}
+
+func (am *AllocatorMethods) parent() *Allocator {
+	if am != nil && am.Parent != nil {
+		return am.Parent
+	}
+
+	return nil
+}
+
+func (am *AllocatorMethods) new(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+	if am != nil && am.New != nil {
+		return am.New
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.new
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+				return parent.New(t)
+			}
+		}
+	}
+
+	return defaultAllocator.new
+}
+
+func (am *AllocatorMethods) makeSlice(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+	if am != nil && am.MakeSlice != nil {
+		return am.MakeSlice
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeSlice
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+				return parent.MakeSlice(t, len, cap)
+			}
+		}
+	}
+
+	return defaultAllocator.makeSlice
+}
+
+func (am *AllocatorMethods) makeMap(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+	if am != nil && am.MakeMap != nil {
+		return am.MakeMap
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeMap
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+				return parent.MakeMap(t, n)
+			}
+		}
+	}
+
+	return defaultAllocator.makeMap
+}
+
+func (am *AllocatorMethods) makeChan(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+	if am != nil && am.MakeChan != nil {
+		return am.MakeChan
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeChan
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+				return parent.MakeChan(t, buffer)
+			}
+		}
+	}
+
+	return defaultAllocator.makeChan
+}
+
+func (am *AllocatorMethods) isScalar(parent *Allocator) func(t reflect.Kind) bool {
+	if am != nil && am.IsScalar != nil {
+		return am.IsScalar
+	}
+
+	if parent != nil {
+		return parent.isScalar
+	}
+
+	return defaultAllocator.isScalar
+}

--- a/vendor/github.com/huandu/go-clone/arena.go
+++ b/vendor/github.com/huandu/go-clone/arena.go
@@ -1,0 +1,9 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+//go:build !(go1.20 && goexperiment.arenas)
+// +build !go1.20 !goexperiment.arenas
+
+package clone
+
+const arenaIsEnabled = false

--- a/vendor/github.com/huandu/go-clone/arena_go120.go
+++ b/vendor/github.com/huandu/go-clone/arena_go120.go
@@ -1,0 +1,9 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+//go:build go1.20 && goexperiment.arenas
+// +build go1.20,goexperiment.arenas
+
+package clone
+
+const arenaIsEnabled = true

--- a/vendor/github.com/huandu/go-clone/atomic_go119.go
+++ b/vendor/github.com/huandu/go-clone/atomic_go119.go
@@ -1,0 +1,81 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+//go:build go1.19
+// +build go1.19
+
+package clone
+
+import (
+	"reflect"
+	"sync/atomic"
+)
+
+func init() {
+	SetCustomFunc(reflect.TypeOf(atomic.Bool{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Bool.
+		oldValue := old.Addr().Interface().(*atomic.Bool)
+		newValue := new.Addr().Interface().(*atomic.Bool)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Int32{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Int32.
+		oldValue := old.Addr().Interface().(*atomic.Int32)
+		newValue := new.Addr().Interface().(*atomic.Int32)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Int64{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Int64.
+		oldValue := old.Addr().Interface().(*atomic.Int64)
+		newValue := new.Addr().Interface().(*atomic.Int64)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Uint32{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Uint32.
+		oldValue := old.Addr().Interface().(*atomic.Uint32)
+		newValue := new.Addr().Interface().(*atomic.Uint32)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Uint64{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Uint64.
+		oldValue := old.Addr().Interface().(*atomic.Uint64)
+		newValue := new.Addr().Interface().(*atomic.Uint64)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Uintptr{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Uintptr.
+		oldValue := old.Addr().Interface().(*atomic.Uintptr)
+		newValue := new.Addr().Interface().(*atomic.Uintptr)
+		v := oldValue.Load()
+		newValue.Store(v)
+	})
+}

--- a/vendor/github.com/huandu/go-clone/clone.go
+++ b/vendor/github.com/huandu/go-clone/clone.go
@@ -1,0 +1,873 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+// Package clone provides functions to deep clone any Go data.
+// It also provides a wrapper to protect a pointer from any unexpected mutation.
+package clone
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+var heapCloneState = &cloneState{
+	allocator: defaultAllocator,
+}
+var cloner = MakeCloner(defaultAllocator)
+
+// Clone recursively deep clone v to a new value in heap.
+// It assumes that there is no pointer cycle in v,
+// e.g. v has a pointer points to v itself.
+// If there is a pointer cycle, use Slowly instead.
+//
+// Clone allocates memory and deeply copies values inside v in depth-first sequence.
+// There are a few special rules for following types.
+//
+//   - Scalar types: all number-like types are copied by value.
+//   - func: Copied by value as func is an opaque pointer at runtime.
+//   - string: Copied by value as string is immutable by design.
+//   - unsafe.Pointer: Copied by value as we don't know what's in it.
+//   - chan: A new empty chan is created as we cannot read data inside the old chan.
+//
+// Unlike many other packages, Clone is able to clone unexported fields of any struct.
+// Use this feature wisely.
+func Clone(v interface{}) interface{} {
+	return cloner.Clone(v)
+}
+
+func clone(allocator *Allocator, v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	val := reflect.ValueOf(v)
+	cloned := allocator.clone(val, false)
+	return cloned.Interface()
+}
+
+// Slowly recursively deep clone v to a new value in heap.
+// It marks all cloned values internally, thus it can clone v with cycle pointer.
+//
+// Slowly works exactly the same as Clone. See Clone doc for more details.
+func Slowly(v interface{}) interface{} {
+	return cloner.CloneSlowly(v)
+}
+
+func cloneSlowly(allocator *Allocator, v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	val := reflect.ValueOf(v)
+	cloned := allocator.cloneSlowly(val, false)
+	return cloned.Interface()
+}
+
+type cloneState struct {
+	allocator *Allocator
+	visited   visitMap
+	invalid   invalidPointers
+
+	// The value that should not be cloned by custom func.
+	// It's useful to avoid infinite loop when custom func calls allocator.Clone().
+	skipCustomFuncValue reflect.Value
+}
+
+type visit struct {
+	p     uintptr
+	extra int
+	t     reflect.Type
+}
+
+type visitMap map[visit]reflect.Value
+type invalidPointers map[visit]reflect.Value
+
+func (state *cloneState) clone(v reflect.Value) reflect.Value {
+	if state.allocator.isScalar(v.Kind()) {
+		return copyScalarValue(v)
+	}
+
+	switch v.Kind() {
+	case reflect.Array:
+		return state.cloneArray(v)
+	case reflect.Chan:
+		return state.allocator.MakeChan(v.Type(), v.Cap())
+	case reflect.Interface:
+		return state.cloneInterface(v)
+	case reflect.Map:
+		return state.cloneMap(v)
+	case reflect.Ptr:
+		return state.clonePtr(v)
+	case reflect.Slice:
+		return state.cloneSlice(v)
+	case reflect.Struct:
+		return state.cloneStruct(v)
+	case reflect.String:
+		return state.cloneString(v)
+	default:
+		panic(fmt.Errorf("go-clone: <bug> unsupported type `%v`", v.Type()))
+	}
+}
+
+func (state *cloneState) cloneArray(v reflect.Value) reflect.Value {
+	dst := state.allocator.New(v.Type())
+	state.copyArray(v, dst)
+	return dst.Elem()
+}
+
+func (state *cloneState) copyArray(src, nv reflect.Value) {
+	p := unsafe.Pointer(nv.Pointer()) // dst must be a Ptr.
+	dst := nv.Elem()
+	num := src.Len()
+
+	if state.allocator.isScalar(src.Type().Elem().Kind()) {
+		shadowCopy(src, p)
+		return
+	}
+
+	for i := 0; i < num; i++ {
+		dst.Index(i).Set(state.clone(src.Index(i)))
+	}
+}
+
+func (state *cloneState) cloneInterface(v reflect.Value) reflect.Value {
+	if v.IsNil() {
+		return reflect.Zero(v.Type())
+	}
+
+	t := v.Type()
+	elem := v.Elem()
+	return state.clone(elem).Convert(elem.Type()).Convert(t)
+}
+
+func (state *cloneState) cloneMap(v reflect.Value) reflect.Value {
+	if v.IsNil() {
+		return reflect.Zero(v.Type())
+	}
+
+	t := v.Type()
+
+	if state.visited != nil {
+		vst := visit{
+			p: v.Pointer(),
+			t: t,
+		}
+
+		if val, ok := state.visited[vst]; ok {
+			return val
+		}
+	}
+
+	nv := state.allocator.MakeMap(t, v.Len())
+
+	if state.visited != nil {
+		vst := visit{
+			p: v.Pointer(),
+			t: t,
+		}
+		state.visited[vst] = nv
+	}
+
+	for iter := mapIter(v); iter.Next(); {
+		key := state.clone(iter.Key())
+		value := state.clone(iter.Value())
+		nv.SetMapIndex(key, value)
+	}
+
+	return nv
+}
+
+func (state *cloneState) clonePtr(v reflect.Value) reflect.Value {
+	if v.IsNil() {
+		return reflect.Zero(v.Type())
+	}
+
+	t := v.Type()
+
+	if state.allocator.isOpaquePointer(t) {
+		if v.CanInterface() {
+			return v
+		}
+
+		ptr := state.allocator.New(t)
+		p := unsafe.Pointer(ptr.Pointer())
+		shadowCopy(v, p)
+		return ptr.Elem()
+	}
+
+	if state.visited != nil {
+		vst := visit{
+			p: v.Pointer(),
+			t: t,
+		}
+
+		if val, ok := state.visited[vst]; ok {
+			return val
+		}
+	}
+
+	src := v.Elem()
+	elemType := src.Type()
+	elemKind := src.Kind()
+	nv := state.allocator.New(elemType)
+
+	if state.visited != nil {
+		vst := visit{
+			p: v.Pointer(),
+			t: t,
+		}
+		state.visited[vst] = nv
+	}
+
+	switch elemKind {
+	case reflect.Struct:
+		state.copyStruct(src, nv)
+	case reflect.Array:
+		state.copyArray(src, nv)
+	default:
+		nv.Elem().Set(state.clone(src))
+	}
+
+	// If this pointer is the address of a struct field and it's a cycle pointer,
+	// it may be updated.
+	if state.visited != nil {
+		vst := visit{
+			p: v.Pointer(),
+			t: t,
+		}
+		nv = state.visited[vst]
+	}
+
+	return nv
+}
+
+func (state *cloneState) cloneSlice(v reflect.Value) reflect.Value {
+	if v.IsNil() {
+		return reflect.Zero(v.Type())
+	}
+
+	t := v.Type()
+	num := v.Len()
+
+	if state.visited != nil {
+		vst := visit{
+			p:     v.Pointer(),
+			extra: num,
+			t:     t,
+		}
+
+		if val, ok := state.visited[vst]; ok {
+			return val
+		}
+	}
+
+	c := v.Cap()
+	nv := state.allocator.MakeSlice(t, num, c)
+
+	if state.visited != nil {
+		vst := visit{
+			p:     v.Pointer(),
+			extra: num,
+			t:     t,
+		}
+		state.visited[vst] = nv
+	}
+
+	// For scalar slice, copy underlying values directly.
+	if state.allocator.isScalar(t.Elem().Kind()) {
+		src := unsafe.Pointer(v.Pointer())
+		dst := unsafe.Pointer(nv.Pointer())
+		sz := int(t.Elem().Size())
+		l := num * sz
+		cc := c * sz
+		copy((*[maxByteSize]byte)(dst)[:l:cc], (*[maxByteSize]byte)(src)[:l:cc])
+	} else {
+		for i := 0; i < num; i++ {
+			nv.Index(i).Set(state.clone(v.Index(i)))
+		}
+	}
+
+	return nv
+}
+
+func (state *cloneState) cloneStruct(v reflect.Value) reflect.Value {
+	t := v.Type()
+	nv := state.allocator.New(t)
+	state.copyStruct(v, nv)
+	return nv.Elem()
+}
+
+var typeOfByteSlice = reflect.TypeOf([]byte(nil))
+
+func (state *cloneState) cloneString(v reflect.Value) reflect.Value {
+	t := v.Type()
+	l := v.Len()
+	data := state.allocator.MakeSlice(typeOfByteSlice, l, l)
+
+	// The v is an unexported struct field.
+	if !v.CanInterface() {
+		v = reflect.ValueOf(v.String())
+	}
+
+	reflect.Copy(data, v)
+
+	nv := state.allocator.New(t)
+	slice := data.Interface().([]byte)
+	*(*stringHeader)(unsafe.Pointer(nv.Pointer())) = *(*stringHeader)(unsafe.Pointer(&slice))
+
+	return nv.Elem()
+}
+
+func (state *cloneState) copyStruct(src, nv reflect.Value) {
+	t := src.Type()
+	st := state.allocator.loadStructType(t)
+	ptr := unsafe.Pointer(nv.Pointer())
+
+	if st.Init(state.allocator, src, nv, state.skipCustomFuncValue == src) {
+		return
+	}
+
+	for _, pf := range st.PointerFields {
+		i := int(pf.Index)
+		p := unsafe.Pointer(uintptr(ptr) + pf.Offset)
+		field := src.Field(i)
+
+		// This field can be referenced by a pointer or interface inside itself.
+		// Put the pointer to this field to visited to avoid any error.
+		//
+		// See https://github.com/huandu/go-clone/issues/3.
+		if state.visited != nil && field.CanAddr() {
+			ft := field.Type()
+			fp := field.Addr().Pointer()
+			vst := visit{
+				p: fp,
+				t: reflect.PtrTo(ft),
+			}
+			nv := reflect.NewAt(ft, p)
+
+			// The address of this field was visited, so fp must be a cycle pointer.
+			// As this field is not fully cloned, the val stored in visited[visit] must be wrong.
+			// It must be replaced by nv which will be the right value (it's incomplete right now).
+			//
+			// Unfortunately, if the val was used by previous clone routines,
+			// there is no easy way to fix wrong values - all pointers must be traversed and fixed.
+			if val, ok := state.visited[vst]; ok {
+				state.invalid[visit{
+					p: val.Pointer(),
+					t: vst.t,
+				}] = nv
+			}
+
+			state.visited[vst] = nv
+		}
+
+		v := state.clone(field)
+		shadowCopy(v, p)
+	}
+}
+
+var typeOfString = reflect.TypeOf("")
+
+func shadowCopy(src reflect.Value, p unsafe.Pointer) {
+	switch src.Kind() {
+	case reflect.Bool:
+		*(*bool)(p) = src.Bool()
+	case reflect.Int:
+		*(*int)(p) = int(src.Int())
+	case reflect.Int8:
+		*(*int8)(p) = int8(src.Int())
+	case reflect.Int16:
+		*(*int16)(p) = int16(src.Int())
+	case reflect.Int32:
+		*(*int32)(p) = int32(src.Int())
+	case reflect.Int64:
+		*(*int64)(p) = src.Int()
+	case reflect.Uint:
+		*(*uint)(p) = uint(src.Uint())
+	case reflect.Uint8:
+		*(*uint8)(p) = uint8(src.Uint())
+	case reflect.Uint16:
+		*(*uint16)(p) = uint16(src.Uint())
+	case reflect.Uint32:
+		*(*uint32)(p) = uint32(src.Uint())
+	case reflect.Uint64:
+		*(*uint64)(p) = src.Uint()
+	case reflect.Uintptr:
+		*(*uintptr)(p) = uintptr(src.Uint())
+	case reflect.Float32:
+		*(*float32)(p) = float32(src.Float())
+	case reflect.Float64:
+		*(*float64)(p) = src.Float()
+	case reflect.Complex64:
+		*(*complex64)(p) = complex64(src.Complex())
+	case reflect.Complex128:
+		*(*complex128)(p) = src.Complex()
+
+	case reflect.Array:
+		t := src.Type()
+
+		if src.CanAddr() {
+			srcPtr := unsafe.Pointer(src.UnsafeAddr())
+			sz := t.Size()
+			copy((*[maxByteSize]byte)(p)[:sz:sz], (*[maxByteSize]byte)(srcPtr)[:sz:sz])
+			return
+		}
+
+		val := reflect.NewAt(t, p).Elem()
+
+		if src.CanInterface() {
+			val.Set(src)
+			return
+		}
+
+		sz := t.Elem().Size()
+		num := src.Len()
+
+		for i := 0; i < num; i++ {
+			elemPtr := unsafe.Pointer(uintptr(p) + uintptr(i)*sz)
+			shadowCopy(src.Index(i), elemPtr)
+		}
+	case reflect.Chan:
+		*((*uintptr)(p)) = src.Pointer()
+	case reflect.Func:
+		t := src.Type()
+		src = copyScalarValue(src)
+		val := reflect.NewAt(t, p).Elem()
+		val.Set(src)
+	case reflect.Interface:
+		*((*interfaceData)(p)) = parseReflectValue(src)
+	case reflect.Map:
+		*((*uintptr)(p)) = src.Pointer()
+	case reflect.Ptr:
+		*((*uintptr)(p)) = src.Pointer()
+	case reflect.Slice:
+		*(*sliceHeader)(p) = sliceHeader{
+			Data: src.Pointer(),
+			Len:  src.Len(),
+			Cap:  src.Cap(),
+		}
+	case reflect.String:
+		s := src.String()
+		val := reflect.NewAt(typeOfString, p).Elem()
+		val.SetString(s)
+	case reflect.Struct:
+		t := src.Type()
+		val := reflect.NewAt(t, p).Elem()
+
+		if src.CanInterface() {
+			val.Set(src)
+			return
+		}
+
+		num := t.NumField()
+
+		for i := 0; i < num; i++ {
+			field := t.Field(i)
+			fieldPtr := unsafe.Pointer(uintptr(p) + field.Offset)
+			shadowCopy(src.Field(i), fieldPtr)
+		}
+	case reflect.UnsafePointer:
+		// There is no way to copy unsafe.Pointer value.
+		*((*uintptr)(p)) = src.Pointer()
+
+	default:
+		panic(fmt.Errorf("go-clone: <bug> impossible type `%v` when cloning private field", src.Type()))
+	}
+}
+
+// fix tranverses v to update all pointer values in state.invalid.
+func (state *cloneState) fix(v reflect.Value) {
+	if state == nil || len(state.invalid) == 0 {
+		return
+	}
+
+	fix := &fixState{
+		allocator: state.allocator,
+		fixed:     fixMap{},
+		invalid:   state.invalid,
+	}
+	fix.fix(v)
+}
+
+type fixState struct {
+	allocator *Allocator
+	fixed     fixMap
+	invalid   invalidPointers
+}
+
+type fixMap map[visit]struct{}
+
+func (fix *fixState) new(t reflect.Type) reflect.Value {
+	return fix.allocator.New(t)
+}
+
+func (fix *fixState) fix(v reflect.Value) (copied reflect.Value, changed int) {
+	if fix.allocator.isScalar(v.Kind()) {
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Array:
+		return fix.fixArray(v)
+	case reflect.Chan:
+		// Do nothing.
+		return
+	case reflect.Interface:
+		return fix.fixInterface(v)
+	case reflect.Map:
+		return fix.fixMap(v)
+	case reflect.Ptr:
+		return fix.fixPtr(v)
+	case reflect.Slice:
+		return fix.fixSlice(v)
+	case reflect.Struct:
+		return fix.fixStruct(v)
+	case reflect.String:
+		// Do nothing.
+		return
+	default:
+		panic(fmt.Errorf("go-clone: <bug> unsupported type `%v`", v.Type()))
+	}
+}
+
+func (fix *fixState) fixArray(v reflect.Value) (copied reflect.Value, changed int) {
+	t := v.Type()
+	et := t.Elem()
+	kind := et.Kind()
+
+	if fix.allocator.isScalar(kind) {
+		return
+	}
+
+	l := v.Len()
+
+	for i := 0; i < l; i++ {
+		elem := v.Index(i)
+
+		if kind == reflect.Ptr {
+			vst := visit{
+				p: elem.Pointer(),
+				t: et,
+			}
+
+			if nv, ok := fix.invalid[vst]; ok {
+				// If elem cannot be set, v must be copied to make it settable.
+				// Don't do it unless there is no other choices.
+				if !elem.CanSet() {
+					copied = fix.new(t).Elem()
+					shadowCopy(v, unsafe.Pointer(copied.Addr().Pointer()))
+					_, changed = fix.fixArray(copied)
+					return
+				}
+
+				elem.Set(nv)
+				changed++
+				continue
+			}
+		}
+
+		fixed, c := fix.fix(elem)
+		changed += c
+
+		if fixed.IsValid() {
+			// If elem cannot be set, v must be copied to make it settable.
+			// Don't do it unless there is no other choices.
+			if !elem.CanSet() {
+				copied = fix.new(t).Elem()
+				shadowCopy(v, unsafe.Pointer(copied.Addr().Pointer()))
+				_, changed = fix.fixArray(copied)
+				return
+			}
+
+			elem.Set(fixed)
+		}
+	}
+
+	return
+}
+
+func (fix *fixState) fixInterface(v reflect.Value) (copied reflect.Value, changed int) {
+	if v.IsNil() {
+		return
+	}
+
+	elem := v.Elem()
+	t := elem.Type()
+	kind := elem.Kind()
+
+	if kind == reflect.Ptr {
+		vst := visit{
+			p: elem.Pointer(),
+			t: t,
+		}
+
+		if nv, ok := fix.invalid[vst]; ok {
+			copied = nv.Convert(v.Type())
+			changed++
+			return
+		}
+	}
+
+	copied, changed = fix.fix(elem)
+
+	if copied.IsValid() {
+		copied = copied.Convert(v.Type())
+	}
+
+	return
+}
+
+func (fix *fixState) fixMap(v reflect.Value) (copied reflect.Value, changed int) {
+	if v.IsNil() {
+		return
+	}
+
+	t := v.Type()
+	vst := visit{
+		p: v.Pointer(),
+		t: t,
+	}
+
+	if _, ok := fix.fixed[vst]; ok {
+		return
+	}
+
+	fix.fixed[vst] = struct{}{}
+
+	kt := t.Key()
+	et := t.Elem()
+	keyKind := kt.Kind()
+	elemKind := et.Kind()
+
+	if isScalar := fix.allocator.isScalar; isScalar(keyKind) && isScalar(elemKind) {
+		return
+	}
+
+	invalidKeys := map[reflect.Value][2]reflect.Value{}
+
+	for iter := mapIter(v); iter.Next(); {
+		key := iter.Key()
+		elem := iter.Value()
+		var fixed reflect.Value
+		c := 0
+
+		if elemKind == reflect.Ptr {
+			vst := visit{
+				p: elem.Pointer(),
+				t: et,
+			}
+
+			if nv, ok := fix.invalid[vst]; ok {
+				fixed = nv
+				c++
+			} else {
+				fixed, c = fix.fixPtr(elem)
+			}
+		} else {
+			fixed, c = fix.fix(elem)
+		}
+
+		changed += c
+		c = 0
+
+		if fixed.IsValid() {
+			v = forceSetMapIndex(v, key, fixed)
+			elem = fixed
+			fixed = reflect.Value{}
+		}
+
+		if keyKind == reflect.Ptr {
+			vst := visit{
+				p: key.Pointer(),
+				t: kt,
+			}
+
+			if nv, ok := fix.invalid[vst]; ok {
+				fixed = nv
+				c++
+			} else {
+				fixed, c = fix.fixPtr(key)
+			}
+		} else {
+			fixed, c = fix.fix(key)
+		}
+
+		changed += c
+
+		// Key cannot be changed immediately inside map range iteration.
+		// Do it later.
+		if fixed.IsValid() {
+			invalidKeys[key] = [2]reflect.Value{fixed, elem}
+		}
+	}
+
+	for key, kv := range invalidKeys {
+		v = forceSetMapIndex(v, key, reflect.Value{})
+		v = forceSetMapIndex(v, kv[0], kv[1])
+	}
+
+	return
+}
+
+func forceSetMapIndex(v, key, elem reflect.Value) (nv reflect.Value) {
+	nv = v
+
+	if !v.CanInterface() {
+		nv = forceClearROFlag(v)
+	}
+
+	if !key.CanInterface() {
+		key = forceClearROFlag(key)
+	}
+
+	if elem.IsValid() && !elem.CanInterface() {
+		elem = forceClearROFlag(elem)
+	}
+
+	nv.SetMapIndex(key, elem)
+	return
+}
+
+func (fix *fixState) fixPtr(v reflect.Value) (copied reflect.Value, changed int) {
+	if v.IsNil() {
+		return
+	}
+
+	vst := visit{
+		p: v.Pointer(),
+		t: v.Type(),
+	}
+
+	if _, ok := fix.invalid[vst]; ok {
+		panic(fmt.Errorf("go-clone: <bug> invalid pointers must have been fixed in other methods"))
+	}
+
+	if _, ok := fix.fixed[vst]; ok {
+		return
+	}
+
+	fix.fixed[vst] = struct{}{}
+
+	elem := v.Elem()
+	_, changed = fix.fix(elem)
+	return
+}
+
+func (fix *fixState) fixSlice(v reflect.Value) (copied reflect.Value, changed int) {
+	if v.IsNil() {
+		return
+	}
+
+	t := v.Type()
+	et := t.Elem()
+	kind := et.Kind()
+
+	if fix.allocator.isScalar(kind) {
+		return
+	}
+
+	l := v.Len()
+	p := unsafe.Pointer(v.Pointer())
+	vst := visit{
+		p:     uintptr(p),
+		extra: l,
+		t:     t,
+	}
+
+	if _, ok := fix.fixed[vst]; ok {
+		return
+	}
+
+	fix.fixed[vst] = struct{}{}
+
+	for i := 0; i < l; i++ {
+		elem := v.Index(i)
+		var fixed reflect.Value
+		c := 0
+
+		if kind == reflect.Ptr {
+			vst := visit{
+				p: elem.Pointer(),
+				t: et,
+			}
+
+			if nv, ok := fix.invalid[vst]; ok {
+				fixed = nv
+			} else {
+				fixed, c = fix.fixPtr(elem)
+			}
+		} else {
+			fixed, c = fix.fix(elem)
+		}
+
+		changed += c
+
+		if fixed.IsValid() {
+			sz := et.Size()
+			elemPtr := unsafe.Pointer(uintptr(p) + sz*uintptr(i))
+			shadowCopy(fixed, elemPtr)
+		}
+	}
+
+	return
+}
+
+func (fix *fixState) fixStruct(v reflect.Value) (copied reflect.Value, changed int) {
+	t := v.Type()
+	st := fix.allocator.loadStructType(t)
+
+	if len(st.PointerFields) == 0 {
+		return
+	}
+
+	for _, pf := range st.PointerFields {
+		i := int(pf.Index)
+		field := v.Field(i)
+
+		ft := field.Type()
+
+		if ft.Kind() == reflect.Ptr {
+			vst := visit{
+				p: field.Pointer(),
+				t: ft,
+			}
+
+			if nv, ok := fix.invalid[vst]; ok {
+				// If v is not addressable, a new struct must be allocated.
+				// Don't do it unless there is no other choices.
+				if !v.CanAddr() {
+					copied = fix.new(t).Elem()
+					shadowCopy(v, unsafe.Pointer(copied.Addr().Pointer()))
+					_, changed = fix.fixStruct(copied)
+					return
+				}
+
+				ptr := unsafe.Pointer(v.Addr().Pointer())
+				p := unsafe.Pointer(uintptr(ptr) + pf.Offset)
+				shadowCopy(nv, p)
+				continue
+			}
+		}
+
+		fixed, c := fix.fix(field)
+		changed += c
+
+		if fixed.IsValid() {
+			// If v is not addressable, a new struct must be allocated.
+			// Don't do it unless there is no other choices.
+			if !v.CanAddr() {
+				copied = fix.new(t).Elem()
+				shadowCopy(v, unsafe.Pointer(copied.Addr().Pointer()))
+				_, changed = fix.fixStruct(copied)
+				return
+			}
+
+			ptr := unsafe.Pointer(v.Addr().Pointer())
+			p := unsafe.Pointer(uintptr(ptr) + pf.Offset)
+			shadowCopy(fixed, p)
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/huandu/go-clone/cloner.go
+++ b/vendor/github.com/huandu/go-clone/cloner.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+// Cloner implements clone API with given allocator.
+type Cloner struct {
+	allocator *Allocator
+}
+
+// MakeCloner creates a cloner with given allocator.
+func MakeCloner(allocator *Allocator) Cloner {
+	return Cloner{
+		allocator: allocator,
+	}
+}
+
+// Clone clones v with given allocator.
+func (c Cloner) Clone(v interface{}) interface{} {
+	return clone(c.allocator, v)
+}
+
+// CloneSlowly clones v with given allocator.
+// It can clone v with cycle pointer.
+func (c Cloner) CloneSlowly(v interface{}) interface{} {
+	return cloneSlowly(c.allocator, v)
+}

--- a/vendor/github.com/huandu/go-clone/generic/LICENSE
+++ b/vendor/github.com/huandu/go-clone/generic/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Huan Du
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/huandu/go-clone/generic/README.md
+++ b/vendor/github.com/huandu/go-clone/generic/README.md
@@ -1,0 +1,8 @@
+# Generic `go-clone` API
+
+[![Go](https://github.com/huandu/go-clone/workflows/Go/badge.svg)](https://github.com/huandu/go-clone/actions)
+[![Go Doc](https://godoc.org/github.com/huandu/go-clone/generic?status.svg)](https://pkg.go.dev/github.com/huandu/go-clone/generic)
+
+This package is a set of generic API for `go-clone`. Almost all methods are simple proxies with a few exceptions. It requires `go1.18` or later to build this package.
+
+Please read document in [the main project](../README.md) for more information.

--- a/vendor/github.com/huandu/go-clone/generic/api.go
+++ b/vendor/github.com/huandu/go-clone/generic/api.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+// Package clone provides functions to deep clone any Go data.
+// It also provides a wrapper to protect a pointer from any unexpected mutation.
+//
+// This package is only a proxy to original go-clone package with generic support.
+// To minimize the maintenace cost, there is no doc in this package.
+// Please read the document in https://pkg.go.dev/github.com/huandu/go-clone instead.
+package clone
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/huandu/go-clone"
+)
+
+type Func = clone.Func
+type Allocator = clone.Allocator
+type AllocatorMethods = clone.AllocatorMethods
+type Cloner = clone.Cloner
+
+func Clone[T any](t T) T {
+	return clone.Clone(t).(T)
+}
+
+func Slowly[T any](t T) T {
+	return clone.Slowly(t).(T)
+}
+
+func Wrap[T any](t T) T {
+	return clone.Wrap(t).(T)
+}
+
+func Unwrap[T any](t T) T {
+	return clone.Unwrap(t).(T)
+}
+
+func Undo[T any](t T) {
+	clone.Undo(t)
+}
+
+func MarkAsOpaquePointer(t reflect.Type) {
+	clone.MarkAsOpaquePointer(t)
+}
+
+func MarkAsScalar(t reflect.Type) {
+	clone.MarkAsScalar(t)
+}
+
+func SetCustomFunc(t reflect.Type, fn Func) {
+	clone.SetCustomFunc(t, fn)
+}
+
+func FromHeap() *Allocator {
+	return clone.FromHeap()
+}
+
+func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) (allocator *Allocator) {
+	return clone.NewAllocator(pool, methods)
+}
+
+func IsScalar(k reflect.Kind) bool {
+	return clone.IsScalar(k)
+}
+
+func MakeCloner(allocator *Allocator) Cloner {
+	return clone.MakeCloner(allocator)
+}

--- a/vendor/github.com/huandu/go-clone/generic/arena.go
+++ b/vendor/github.com/huandu/go-clone/generic/arena.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+//go:build go1.20 && goexperiment.arenas
+// +build go1.20,goexperiment.arenas
+
+package clone
+
+import (
+	"arena"
+	"reflect"
+	"runtime"
+	"unsafe"
+
+	"github.com/huandu/go-clone"
+)
+
+// The arenaAllocator allocates memory from arena.
+var arenaAllocatorMethods = &clone.AllocatorMethods{
+	New:       arenaNew,
+	MakeSlice: arenaMakeSlice,
+	MakeMap:   arenaMakeMap,
+	MakeChan:  arenaMakeChan,
+}
+
+// FromArena creates an allocator using arena a to allocate memory.
+func FromArena(a *arena.Arena) *clone.Allocator {
+	return clone.NewAllocator(unsafe.Pointer(a), arenaAllocatorMethods)
+}
+
+// ArenaClone recursively deep clones v to a new value in arena a.
+// It works in the same way as Clone, except it allocates all memory from arena.
+func ArenaClone[T any](a *arena.Arena, v T) (nv T) {
+	src := reflect.ValueOf(v)
+	cloned := FromArena(a).Clone(src)
+
+	if !cloned.IsValid() {
+		return
+	}
+
+	dst := reflect.ValueOf(&nv).Elem()
+	dst.Set(cloned)
+	return
+}
+
+// ArenaCloneSlowly recursively deep clones v to a new value in arena a.
+// It works in the same way as Slowly, except it allocates all memory from arena.
+func ArenaCloneSlowly[T any](a *arena.Arena, v T) (nv T) {
+	src := reflect.ValueOf(v)
+	cloned := FromArena(a).CloneSlowly(src)
+
+	if !cloned.IsValid() {
+		return
+	}
+
+	dst := reflect.ValueOf(&nv).Elem()
+	dst.Set(cloned)
+	return
+}
+
+func arenaNew(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+	return reflect.ArenaNew((*arena.Arena)(pool), reflect.PtrTo(t))
+}
+
+// Define the slice header again to mute golint's warning.
+type sliceHeader reflect.SliceHeader
+
+func arenaMakeSlice(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+	a := (*arena.Arena)(pool)
+
+	// As of go1.20, there is no reflect method to allocate slice in arena.
+	// Following code is a hack to allocate a large enough byte buffer
+	// and then cast it to T[].
+	et := t.Elem()
+	l := int(et.Size())
+	total := l * cap
+
+	data := arena.MakeSlice[byte](a, total, total)
+	ptr := unsafe.Pointer(&data[0])
+	elem := reflect.NewAt(et, ptr)
+	slicePtr := reflect.ArenaNew(a, reflect.PtrTo(t))
+	*(*sliceHeader)(slicePtr.UnsafePointer()) = sliceHeader{
+		Data: elem.Pointer(),
+		Len:  l,
+		Cap:  cap,
+	}
+	runtime.KeepAlive(elem)
+
+	slice := slicePtr.Elem()
+	return slice.Slice3(0, len, cap)
+}
+
+func arenaMakeMap(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+	// As of go1.20, there is no way to allocate map in arena.
+	// Fallback to heap allocation.
+	return reflect.MakeMapWithSize(t, n)
+}
+
+func arenaMakeChan(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+	// As of go1.20, there is no way to allocate chan in arena.
+	// Fallback to heap allocation.
+	return reflect.MakeChan(t, buffer)
+}

--- a/vendor/github.com/huandu/go-clone/generic/register.go
+++ b/vendor/github.com/huandu/go-clone/generic/register.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+//go:build go1.19
+// +build go1.19
+
+package clone
+
+import (
+	"reflect"
+	"sync/atomic"
+)
+
+// Record the count of cloning atomic.Pointer[T] for test purpose only.
+var registerAtomicPointerCalled int32
+
+// RegisterAtomicPointer registers a custom clone function for atomic.Pointer[T].
+func RegisterAtomicPointer[T any]() {
+	SetCustomFunc(reflect.TypeOf(atomic.Pointer[T]{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Pointer[T].
+		oldValue := old.Addr().Interface().(*atomic.Pointer[T])
+		newValue := new.Addr().Interface().(*atomic.Pointer[T])
+		v := oldValue.Load()
+		newValue.Store(v)
+
+		atomic.AddInt32(&registerAtomicPointerCalled, 1)
+	})
+}

--- a/vendor/github.com/huandu/go-clone/headers.go
+++ b/vendor/github.com/huandu/go-clone/headers.go
@@ -1,0 +1,12 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import "reflect"
+
+// As golint reports warning on possible misuse of these headers,
+// avoid to use these header types directly to silience golint.
+
+type sliceHeader reflect.SliceHeader
+type stringHeader reflect.StringHeader

--- a/vendor/github.com/huandu/go-clone/interfacedata.go
+++ b/vendor/github.com/huandu/go-clone/interfacedata.go
@@ -1,0 +1,50 @@
+package clone
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const sizeOfPointers = unsafe.Sizeof((interface{})(0)) / unsafe.Sizeof(uintptr(0))
+
+// interfaceData is the underlying data of an interface.
+// As the reflect.Value's interfaceData method is deprecated,
+// it may be broken in any Go release.
+// It's better to create a custom to hold the data.
+//
+// The type of interfaceData fields must be poniters.
+// It's a way to cheat Go compile to generate calls to write barrier
+// when copying interfaces.
+type interfaceData struct {
+	_ [sizeOfPointers]unsafe.Pointer
+}
+
+var reflectValuePtrOffset uintptr
+
+func init() {
+	t := reflect.TypeOf(reflect.Value{})
+	found := false
+	fields := t.NumField()
+
+	for i := 0; i < fields; i++ {
+		field := t.Field(i)
+
+		if field.Type.Kind() == reflect.UnsafePointer {
+			found = true
+			reflectValuePtrOffset = field.Offset
+			break
+		}
+	}
+
+	if !found {
+		panic("go-clone: fail to find internal ptr field in reflect.Value")
+	}
+}
+
+// parseReflectValue returns the underlying interface data in a reflect value.
+// It assumes that v is an interface value.
+func parseReflectValue(v reflect.Value) interfaceData {
+	pv := (unsafe.Pointer)(uintptr(unsafe.Pointer(&v)) + reflectValuePtrOffset)
+	ptr := *(*unsafe.Pointer)(pv)
+	return *(*interfaceData)(ptr)
+}

--- a/vendor/github.com/huandu/go-clone/mapiter.go
+++ b/vendor/github.com/huandu/go-clone/mapiter.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+// +build !go1.12
+
+package clone
+
+import (
+	"reflect"
+)
+
+type iter struct {
+	m    reflect.Value
+	k    reflect.Value
+	keys []reflect.Value
+}
+
+func mapIter(m reflect.Value) *iter {
+	return &iter{
+		m:    m,
+		keys: m.MapKeys(),
+	}
+}
+
+func (it *iter) Next() bool {
+	if len(it.keys) == 0 {
+		return false
+	}
+
+	it.k = it.keys[0]
+	it.keys = it.keys[1:]
+	return true
+}
+
+func (it *iter) Key() reflect.Value {
+	return it.k
+}
+
+func (it *iter) Value() reflect.Value {
+	return it.m.MapIndex(it.k)
+}

--- a/vendor/github.com/huandu/go-clone/mapiter_go112.go
+++ b/vendor/github.com/huandu/go-clone/mapiter_go112.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+// +build go1.12
+
+package clone
+
+import (
+	"reflect"
+)
+
+func mapIter(m reflect.Value) *reflect.MapIter {
+	return m.MapRange()
+}

--- a/vendor/github.com/huandu/go-clone/memory.go
+++ b/vendor/github.com/huandu/go-clone/memory.go
@@ -1,0 +1,11 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+// maxByteSize is a large enough value to cheat Go compiler
+// when converting unsafe address to []byte.
+// It's not actually used in runtime.
+//
+// The value 2^30 is the max value AFAIK to make Go compiler happy on all archs.
+const maxByteSize = 1 << 30

--- a/vendor/github.com/huandu/go-clone/structtype.go
+++ b/vendor/github.com/huandu/go-clone/structtype.go
@@ -1,0 +1,298 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+type structType struct {
+	PointerFields []structFieldType
+	fn            Func
+}
+
+type structFieldType struct {
+	Offset uintptr // The offset from the beginning of the struct.
+	Index  int     // The index of the field.
+}
+
+var zeroStructType = structType{}
+
+func init() {
+	// Some well-known scalar-like structs.
+	MarkAsScalar(reflect.TypeOf(time.Time{}))
+	MarkAsScalar(reflect.TypeOf(reflect.Value{}))
+
+	// Special case for elliptic.Curve which is used by TLS ECC certificate.
+	// Package crypto/tls uses elliptic.Curve as enum values
+	// so that they should be treated as opaque pointers.
+	//
+	// As elliptic.Curve is an interface, it can be *elliptic.CurveParam or elliptic.p256Curve.
+	MarkAsOpaquePointer(reflect.TypeOf(&elliptic.CurveParams{}))
+	curves := []elliptic.Curve{
+		elliptic.P224(),
+		elliptic.P256(),
+		elliptic.P384(),
+		elliptic.P521(),
+	}
+
+	for _, curve := range curves {
+		MarkAsOpaquePointer(reflect.ValueOf(curve).Type())
+	}
+
+	// Special case for reflect.Type (actually *reflect.rtype):
+	// The *reflect.rtype should not be copied as it is immutable and
+	// may point to a variable that actual type is not reflect.rtype,
+	// e.g. *reflect.arrayType or *reflect.chanType.
+	MarkAsOpaquePointer(reflect.TypeOf(reflect.TypeOf(0)))
+
+	// Some well-known no-copy structs.
+	//
+	// Almost all structs defined in package "sync" and "sync/atomic" are set
+	// except `sync.Once` which can be safely cloned with a correct done value.
+	SetCustomFunc(reflect.TypeOf(sync.Mutex{}), emptyCloneFunc)
+	SetCustomFunc(reflect.TypeOf(sync.RWMutex{}), emptyCloneFunc)
+	SetCustomFunc(reflect.TypeOf(sync.WaitGroup{}), emptyCloneFunc)
+	SetCustomFunc(reflect.TypeOf(sync.Cond{}), func(allocator *Allocator, old, new reflect.Value) {
+		// Copy the New func from old value.
+		oldL := old.FieldByName("L")
+		newL := allocator.Clone(oldL)
+		new.FieldByName("L").Set(newL)
+	})
+	SetCustomFunc(reflect.TypeOf(sync.Pool{}), func(allocator *Allocator, old, new reflect.Value) {
+		// Copy the New func from old value.
+		oldFn := old.FieldByName("New")
+		newFn := allocator.Clone(oldFn)
+		new.FieldByName("New").Set(newFn)
+	})
+	SetCustomFunc(reflect.TypeOf(sync.Map{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone all values inside sync.Map.
+		oldMap := old.Addr().Interface().(*sync.Map)
+		newMap := new.Addr().Interface().(*sync.Map)
+		oldMap.Range(func(key, value interface{}) bool {
+			k := clone(allocator, key)
+			v := clone(allocator, value)
+			newMap.Store(k, v)
+			return true
+		})
+	})
+	SetCustomFunc(reflect.TypeOf(atomic.Value{}), func(allocator *Allocator, old, new reflect.Value) {
+		if !old.CanAddr() {
+			return
+		}
+
+		// Clone value inside atomic.Value.
+		oldValue := old.Addr().Interface().(*atomic.Value)
+		newValue := new.Addr().Interface().(*atomic.Value)
+		v := oldValue.Load()
+		cloned := clone(allocator, v)
+		newValue.Store(cloned)
+	})
+}
+
+// MarkAsScalar marks t as a scalar type in heap allocator,
+// so that all clone methods will copy t by value.
+// If t is not struct or pointer to struct, MarkAsScalar ignores t.
+//
+// In the most cases, it's not necessary to call it explicitly.
+// If a struct type contains scalar type fields only, the struct will be marked as scalar automatically.
+//
+// Here is a list of types marked as scalar by default:
+//   - time.Time
+//   - reflect.Value
+func MarkAsScalar(t reflect.Type) {
+	defaultAllocator.MarkAsScalar(t)
+}
+
+// MarkAsOpaquePointer marks t as an opaque pointer in heap allocator,
+// so that all clone methods will copy t by value.
+// If t is not a pointer, MarkAsOpaquePointer ignores t.
+//
+// Here is a list of types marked as opaque pointers by default:
+//   - `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`;
+//   - `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
+func MarkAsOpaquePointer(t reflect.Type) {
+	defaultAllocator.MarkAsOpaquePointer(t)
+}
+
+// Func is a custom func to clone value from old to new.
+// The new is a zero value
+// which `new.CanSet()` and `new.CanAddr()` is guaranteed to be true.
+//
+// Func must update the new to return result.
+type Func func(allocator *Allocator, old, new reflect.Value)
+
+// emptyCloneFunc is used to disable shadow copy.
+// It's useful when cloning sync.Mutex as cloned value must be a zero value.
+func emptyCloneFunc(allocator *Allocator, old, new reflect.Value) {}
+
+// SetCustomFunc sets a custom clone function for type t in heap allocator.
+// If t is not struct or pointer to struct, SetCustomFunc ignores t.
+//
+// If fn is nil, remove the custom clone function for type t.
+func SetCustomFunc(t reflect.Type, fn Func) {
+	defaultAllocator.SetCustomFunc(t, fn)
+}
+
+// Init creates a new value of src.Type() and shadow copies all content from src.
+// If noCustomFunc is set to true, custom clone function will be ignored.
+//
+// Init returns true if the value is cloned by a custom func.
+// Caller should skip cloning struct fields in depth.
+func (st *structType) Init(allocator *Allocator, src, nv reflect.Value, noCustomFunc bool) (done bool) {
+	dst := nv.Elem()
+
+	if !noCustomFunc && st.fn != nil {
+		if !src.CanInterface() {
+			src = forceClearROFlag(src)
+		}
+
+		st.fn(allocator, src, dst)
+		done = true
+		return
+	}
+
+	ptr := unsafe.Pointer(nv.Pointer())
+	shadowCopy(src, ptr)
+	done = len(st.PointerFields) == 0
+	return
+}
+
+func (st *structType) CanShadowCopy() bool {
+	return len(st.PointerFields) == 0 && st.fn == nil
+}
+
+// IsScalar returns true if k should be considered as a scalar type.
+//
+// For the sake of performance, string is considered as a scalar type unless arena is enabled.
+// If we need to deep copy string value in some cases, we can create a new allocator with custom isScalar function
+// in which we can return false when k is reflect.String.
+//
+//	// Create a new allocator which treats string as non-scalar type.
+//	allocator := NewAllocator(nil, &AllocatorMethods{
+//		IsScalar: func(k reflect.Kind) bool {
+//			return k != reflect.String && IsScalar(k)
+//		},
+//	})
+func IsScalar(k reflect.Kind) bool {
+	switch k {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128,
+		reflect.Func,
+		reflect.UnsafePointer,
+		reflect.Invalid:
+		return true
+
+	case reflect.String:
+		// If arena is not enabled, string can be copied as scalar safely
+		// as it's immutable by design.
+		return !arenaIsEnabled
+	}
+
+	return false
+}
+
+func copyScalarValue(src reflect.Value) reflect.Value {
+	if src.CanInterface() {
+		return src
+	}
+
+	// src is an unexported field value. Copy its value.
+	switch src.Kind() {
+	case reflect.Bool:
+		return reflect.ValueOf(src.Bool())
+
+	case reflect.Int:
+		return reflect.ValueOf(int(src.Int()))
+	case reflect.Int8:
+		return reflect.ValueOf(int8(src.Int()))
+	case reflect.Int16:
+		return reflect.ValueOf(int16(src.Int()))
+	case reflect.Int32:
+		return reflect.ValueOf(int32(src.Int()))
+	case reflect.Int64:
+		return reflect.ValueOf(src.Int())
+
+	case reflect.Uint:
+		return reflect.ValueOf(uint(src.Uint()))
+	case reflect.Uint8:
+		return reflect.ValueOf(uint8(src.Uint()))
+	case reflect.Uint16:
+		return reflect.ValueOf(uint16(src.Uint()))
+	case reflect.Uint32:
+		return reflect.ValueOf(uint32(src.Uint()))
+	case reflect.Uint64:
+		return reflect.ValueOf(src.Uint())
+	case reflect.Uintptr:
+		return reflect.ValueOf(uintptr(src.Uint()))
+
+	case reflect.Float32:
+		return reflect.ValueOf(float32(src.Float()))
+	case reflect.Float64:
+		return reflect.ValueOf(src.Float())
+
+	case reflect.Complex64:
+		return reflect.ValueOf(complex64(src.Complex()))
+	case reflect.Complex128:
+		return reflect.ValueOf(src.Complex())
+
+	case reflect.String:
+		return reflect.ValueOf(src.String())
+	case reflect.Func:
+		t := src.Type()
+
+		if src.IsNil() {
+			return reflect.Zero(t)
+		}
+
+		// Don't use this trick unless we have no choice.
+		return forceClearROFlag(src)
+	case reflect.UnsafePointer:
+		return reflect.ValueOf(unsafe.Pointer(src.Pointer()))
+	}
+
+	panic(fmt.Errorf("go-clone: <bug> impossible type `%v` when cloning private field", src.Type()))
+}
+
+var typeOfInterface = reflect.TypeOf((*interface{})(nil)).Elem()
+
+// forceClearROFlag clears all RO flags in v to make v accessible.
+// It's a hack based on the fact that InterfaceData is always available on RO data.
+// This hack can be broken in any Go version.
+// Don't use it unless we have no choice, e.g. copying func in some edge cases.
+func forceClearROFlag(v reflect.Value) reflect.Value {
+	var i interface{}
+	indirect := 0
+
+	// Save flagAddr.
+	for v.CanAddr() {
+		v = v.Addr()
+		indirect++
+	}
+
+	v = v.Convert(typeOfInterface)
+	nv := reflect.ValueOf(&i)
+	*(*interfaceData)(unsafe.Pointer(nv.Pointer())) = parseReflectValue(v)
+	cleared := nv.Elem().Elem()
+
+	for indirect > 0 {
+		cleared = cleared.Elem()
+		indirect--
+	}
+
+	return cleared
+}

--- a/vendor/github.com/huandu/go-clone/wrapper.go
+++ b/vendor/github.com/huandu/go-clone/wrapper.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"encoding/binary"
+	"hash/crc64"
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+var (
+	sizeOfChecksum = unsafe.Sizeof(uint64(0))
+
+	crc64Table = crc64.MakeTable(crc64.ECMA)
+
+	cachedWrapperTypes sync.Map
+)
+
+// Wrap creates a wrapper of v, which must be a pointer.
+// If v is not a pointer, Wrap simply returns v and do nothing.
+//
+// The wrapper is a deep clone of v's value. It holds a shadow copy to v internally.
+//
+//	t := &T{Foo: 123}
+//	v := Wrap(t).(*T)               // v is a clone of t.
+//	reflect.DeepEqual(t, v) == true // v equals t.
+//	v.Foo = 456                     // v.Foo is changed, but t.Foo doesn't change.
+//	orig := Unwrap(v)               // Use `Unwrap` to discard wrapper and return original value, which is t.
+//	orig.(*T) == t                  // orig and t is exactly the same.
+//	Undo(v)                         // Use `Undo` to discard any change on v.
+//	v.Foo == t.Foo                  // Now, the value of v and t are the same again.
+func Wrap(v interface{}) interface{} {
+	if v == nil {
+		return v
+	}
+
+	val := reflect.ValueOf(v)
+	pt := val.Type()
+
+	if val.Kind() != reflect.Ptr {
+		return v
+	}
+
+	t := pt.Elem()
+	elem := val.Elem()
+	ptr := unsafe.Pointer(val.Pointer())
+	cache, ok := cachedWrapperTypes.Load(t)
+
+	if !ok {
+		cache = reflect.StructOf([]reflect.StructField{
+			{
+				Name:      "T",
+				Type:      t,
+				Anonymous: true,
+			},
+			{
+				Name: "Checksum",
+				Type: reflect.TypeOf(uint64(0)),
+			},
+			{
+				Name: "Origin",
+				Type: pt,
+			},
+		})
+		cachedWrapperTypes.Store(t, cache)
+	}
+
+	wrapperType := cache.(reflect.Type)
+	pw := defaultAllocator.New(wrapperType)
+
+	wrapperPtr := unsafe.Pointer(pw.Pointer())
+	wrapper := pw.Elem()
+
+	// Equivalent code: wrapper.T = Clone(v)
+	field := wrapper.Field(0)
+	field.Set(heapCloneState.clone(elem))
+
+	// Equivalent code: wrapper.Checksum = makeChecksum(v)
+	checksumPtr := unsafe.Pointer((uintptr(wrapperPtr) + t.Size()))
+	*(*uint64)(checksumPtr) = makeChecksum(t, uintptr(wrapperPtr), uintptr(ptr))
+
+	// Equivalent code: wrapper.Origin = v
+	originPtr := unsafe.Pointer((uintptr(wrapperPtr) + t.Size() + sizeOfChecksum))
+	*(*uintptr)(originPtr) = uintptr(ptr)
+
+	return field.Addr().Interface()
+}
+
+func validateChecksum(t reflect.Type, ptr unsafe.Pointer) bool {
+	pw := uintptr(ptr)
+	orig := uintptr(getOrigin(t, ptr))
+	checksum := *(*uint64)(unsafe.Pointer(uintptr(ptr) + t.Size()))
+	expected := makeChecksum(t, pw, orig)
+
+	return checksum == expected
+}
+
+func makeChecksum(t reflect.Type, pw uintptr, orig uintptr) uint64 {
+	var data [binary.MaxVarintLen64 * 2]byte
+	binary.PutUvarint(data[:binary.MaxVarintLen64], uint64(pw))
+	binary.PutUvarint(data[binary.MaxVarintLen64:], uint64(orig))
+	return crc64.Checksum(data[:], crc64Table)
+}
+
+func getOrigin(t reflect.Type, ptr unsafe.Pointer) unsafe.Pointer {
+	return *(*unsafe.Pointer)(unsafe.Pointer(uintptr(ptr) + t.Size() + sizeOfChecksum))
+}
+
+// Unwrap returns v's original value if v is a wrapped value.
+// Otherwise, simply returns v itself.
+func Unwrap(v interface{}) interface{} {
+	if v == nil {
+		return v
+	}
+
+	val := reflect.ValueOf(v)
+
+	if !isWrapped(val) {
+		return v
+	}
+
+	origVal := origin(val)
+	return origVal.Interface()
+}
+
+func origin(val reflect.Value) reflect.Value {
+	pt := val.Type()
+	t := pt.Elem()
+	ptr := unsafe.Pointer(val.Pointer())
+	orig := getOrigin(t, ptr)
+	origVal := reflect.NewAt(t, orig)
+	return origVal
+}
+
+// Undo discards any change made in wrapped value.
+// If v is not a wrapped value, nothing happens.
+func Undo(v interface{}) {
+	if v == nil {
+		return
+	}
+
+	val := reflect.ValueOf(v)
+
+	if !isWrapped(val) {
+		return
+	}
+
+	origVal := origin(val)
+	elem := val.Elem()
+	elem.Set(heapCloneState.clone(origVal.Elem()))
+}
+
+func isWrapped(val reflect.Value) bool {
+	pt := val.Type()
+
+	if pt.Kind() != reflect.Ptr {
+		return false
+	}
+
+	t := pt.Elem()
+	ptr := unsafe.Pointer(val.Pointer())
+	return validateChecksum(t, ptr)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,6 +53,12 @@ github.com/golang/snappy
 # github.com/google/uuid v1.3.0
 ## explicit
 github.com/google/uuid
+# github.com/huandu/go-clone v1.6.0
+## explicit; go 1.13
+github.com/huandu/go-clone
+# github.com/huandu/go-clone/generic v1.7.2
+## explicit; go 1.18
+github.com/huandu/go-clone/generic
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go


### PR DESCRIPTION
When mongosync migrates capped collections it sets the collection limits during commit, which causes the destination to emit `modify` events in its change stream. These have caused migration-verifier to fail because of the “unrecognized” event type.

This changeset alters that logic so that migration-verifier will log `modify` events from the destination and ignore them rather than treating them as fatal.

Additionally, this updates the unknown-event error to include the change event in its bson.Raw form rather than a struct. This ensures that we show the entire event rather than just those parts that we parse.