### PR TITLE
Migrate to contextplus for more informative “context canceled” errors.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - errcheck
+    - forbidigo
     - gosimple
     - govet
     - ineffassign
@@ -22,3 +23,11 @@ linters-settings:
         # Unkeyed primitive.E and timestamp fields are used extensively in code taken from
         # mongosync.
         - composites
+  forbidigo:
+    forbid:
+      - p: context\.WithCancel(?:Cause)?
+        msg: Use contextplus.
+      - p: context\.WithTimeout(?:Cause)?
+        msg: Use contextplus.
+      - p: context\.WithDeadline(?:Cause)?
+        msg: Use contextplus.

--- a/contextplus/c.go
+++ b/contextplus/c.go
@@ -1,0 +1,63 @@
+package contextplus
+
+import (
+	"context"
+	"time"
+
+	"github.com/10gen/migration-verifier/internal/util"
+)
+
+// C stores a `context.Context`. This is the concrete type of the contexts that
+// this package’s static functions return.
+//
+// This type is exported so that you can “upgrade” a stdlib context to have
+// this type’s `Err()`. To avoid interoperability problems, this type
+// *MUST NOT* be used in signatures of functions meant for external use.
+//
+// We explicitly _don't_ embed the `context.Context`. We don't want to
+// encourage using an embedded context directly by accident.
+type C struct {
+	ctx context.Context
+}
+
+var _ context.Context = &C{}
+
+// New returns a context from this package. See its `Err()` for why that’s
+// useful.
+func New(ctx context.Context) *C {
+	return &C{ctx}
+}
+
+// Deadline returns the wrapped context’s deadline.
+func (c *C) Deadline() (deadline time.Time, ok bool) {
+	return c.ctx.Deadline()
+}
+
+// Done returns the wrapped context’s Done channel.
+func (c *C) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+// Value returns the requested value from the wrapped context.
+func (c *C) Value(key any) any {
+	return c.ctx.Value(key)
+}
+
+// Err returns the error from the given context.
+//
+// Unlike in the standard library, this Err() is a wrapper around both:
+// - the underlying context’s Err(), and
+// - the cancellation or expiry’s “cause”
+//
+// This usefully ensures that all cancellation error messages include the
+// cancellation cause, which can simplify debugging.
+//
+// Unlike with the standard library’s context.Context’s `Err()`,
+// you *MUST* use errors.Is() or errors.As() to introspect this method’s
+// returned error. Simple equality checks against, e.g., `context.Canceled`
+// will fail where they succeed against the standard library’s Context.
+// Linters generally forbid simple equality checks against errors anyway,
+// though, so this shouldn’t affect actively-maintained Go code.
+func (c *C) Err() error {
+	return util.WrapCtxErrWithCause(c.ctx)
+}

--- a/contextplus/cause_test.go
+++ b/contextplus/cause_test.go
@@ -1,0 +1,99 @@
+package contextplus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// TestCancelCause verifies a number of things:
+// - Err() includes the cancellation cause.
+// - Err() includes Canceled.
+// - context.Cause()’s return includes the cancellation cause.
+//
+// … and all of the above pertain both for “normal” cancellation
+// causes as well as a cause that includes Canceled.
+func (s *UnitTestSuite) ParallelTestCancelCause() {
+	for _, cause := range []error{
+		fmt.Errorf("just because"),
+		errors.Wrap(context.Canceled, "just because"),
+	} {
+		ctx, canceller := WithCancelCause(context.Background())
+
+		canceller(cause)
+
+		canceledErr := ctx.Err()
+
+		s.Assert().ErrorIs(canceledErr, context.Canceled)
+		s.Assert().ErrorIs(canceledErr, cause)
+
+		fromCause := context.Cause(ctx)
+		s.Assert().ErrorIs(fromCause, cause)
+	}
+}
+
+func (s *UnitTestSuite) ParallelTestUncanceled() {
+	ctx, cancel := WithCancelCause(context.Background())
+
+	s.Require().NotNil(ctx.Err())
+
+	cancel(errors.New(""))
+}
+
+func (s *UnitTestSuite) ParallelTestTimeoutCause() {
+	for _, cause := range []error{
+		fmt.Errorf("just because"),
+		errors.Wrap(context.DeadlineExceeded, "just because"),
+	} {
+		negativeDuration := -1 * time.Nanosecond
+
+		ctx, canceller := WithTimeoutCause(
+			context.Background(),
+			negativeDuration,
+			cause,
+		)
+		defer canceller()
+
+		ctxErr := ctx.Err()
+
+		s.Assert().ErrorIs(ctxErr, context.DeadlineExceeded)
+		s.Assert().ErrorIs(ctxErr, cause)
+		s.Assert().ErrorContains(
+			ctxErr,
+			negativeDuration.String(),
+		)
+
+		fromCause := context.Cause(ctx)
+		s.Assert().ErrorIs(fromCause, cause)
+	}
+}
+
+func (s *UnitTestSuite) ParallelTestDeadlineCause() {
+	for _, cause := range []error{
+		fmt.Errorf("just because"),
+		errors.Wrap(context.DeadlineExceeded, "just because"),
+	} {
+		pastTime := time.Now().Add(-1 * time.Minute)
+
+		ctx, canceller := WithDeadlineCause(
+			context.Background(),
+			pastTime,
+			cause,
+		)
+		defer canceller()
+
+		ctxErr := ctx.Err()
+
+		s.Assert().ErrorIs(ctxErr, context.DeadlineExceeded)
+		s.Assert().ErrorIs(ctxErr, cause)
+		s.Assert().ErrorContains(
+			ctxErr,
+			pastTime.String(),
+		)
+
+		fromCause := context.Cause(ctx)
+		s.Assert().ErrorIs(fromCause, cause)
+	}
+}

--- a/contextplus/cause_test.go
+++ b/contextplus/cause_test.go
@@ -15,7 +15,7 @@ import (
 //
 // … and all of the above pertain both for “normal” cancellation
 // causes as well as a cause that includes Canceled.
-func (s *UnitTestSuite) ParallelTestCancelCause() {
+func (s *UnitTestSuite) TestCancelCause() {
 	for _, cause := range []error{
 		fmt.Errorf("just because"),
 		errors.Wrap(context.Canceled, "just because"),
@@ -34,15 +34,15 @@ func (s *UnitTestSuite) ParallelTestCancelCause() {
 	}
 }
 
-func (s *UnitTestSuite) ParallelTestUncanceled() {
+func (s *UnitTestSuite) TestUncanceled() {
 	ctx, cancel := WithCancelCause(context.Background())
 
-	s.Require().NotNil(ctx.Err())
+	s.Assert().Nil(ctx.Err())
 
 	cancel(errors.New(""))
 }
 
-func (s *UnitTestSuite) ParallelTestTimeoutCause() {
+func (s *UnitTestSuite) TestTimeoutCause() {
 	for _, cause := range []error{
 		fmt.Errorf("just because"),
 		errors.Wrap(context.DeadlineExceeded, "just because"),
@@ -70,7 +70,7 @@ func (s *UnitTestSuite) ParallelTestTimeoutCause() {
 	}
 }
 
-func (s *UnitTestSuite) ParallelTestDeadlineCause() {
+func (s *UnitTestSuite) TestDeadlineCause() {
 	for _, cause := range []error{
 		fmt.Errorf("just because"),
 		errors.Wrap(context.DeadlineExceeded, "just because"),

--- a/contextplus/contextplus.go
+++ b/contextplus/contextplus.go
@@ -1,0 +1,83 @@
+// contextplus provides wrappers around the standard library’s context
+// cancellation & expiry functions. These wrappers do some nice things:
+//
+// - They mandate cancellation/expiry causes.
+// - Expiry causes contain the timeout/deadline.
+// - The returned Context’s Err() will include both Canceled/DeadlineExceeded
+//   AND the Cause.
+//
+// The standard library would ideally do all of the above for us, but that
+// would break Go’s backward compatibility with code that does strict
+// equal comparison on Canceled or DeadlineExceeded.
+//
+// # Interoperability Note
+//
+// Go’s style guide, as of this writing, categorically forbids custom
+// context.Context implementations like this one. The rationale given, though,
+// concerns interoperabililty between code bases: avoiding a state where calls
+// to library A *must* use that library’s context implementation, while calls
+// to library B need to use B’s context.
+//
+// contextplus doesn’t create that problem, though, because its changes to
+// the standard library’s Context are purely informational. It goes without
+// saying, of course, that publicly-accessible functions *SHOULD NOT*
+// require a *contextplus.C, but should instead accept a context.Context.
+// Internal functions *MAY* require a *contextplus.C for consistency.
+//
+// See mongo-go/ctxutil for additional related functionality.
+
+package contextplus
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// WithCancelCause works just like the standard library’s function of the
+// same name, but the returned Context’s Err() will include both
+// `context.Canceled` and the Cause.
+func WithCancelCause(ctx context.Context) (*C, context.CancelCauseFunc) {
+	//nolint:gocritic
+	newCtx, cancel := context.WithCancelCause(ctx)
+	return New(newCtx), cancel
+}
+
+// WithDeadlineCause works just like the standard library’s function of the
+// same name, but the returned context’s Err() will include both
+// `context.DeadlineExceeded` and the Cause.
+//
+// The Cause will also be wrapped with the (stringified) deadline.
+func WithDeadlineCause(
+	ctx context.Context,
+	deadline time.Time,
+	cause error,
+) (*C, context.CancelFunc) {
+	wrappedCause := errors.Wrapf(cause, "deadline (%s) passed", deadline)
+	//nolint:gocritic
+	newCtx, cancel := context.WithDeadlineCause(ctx, deadline, wrappedCause)
+	return New(newCtx), cancel
+}
+
+// WithTimeoutCause is like WithDeadlineCause but for timeouts.
+func WithTimeoutCause(
+	ctx context.Context,
+	timeout time.Duration,
+	cause error,
+) (*C, context.CancelFunc) {
+	wrappedCause := errors.Wrapf(cause, "timed out after %s", timeout)
+	//nolint:gocritic
+	newCtx, cancel := context.WithTimeoutCause(ctx, timeout, wrappedCause)
+	return New(newCtx), cancel
+}
+
+// ErrGroup is like the standard library’s `errgroup.WithContext()`, but
+// it returns a context from this package.
+func ErrGroup(ctx context.Context) (*errgroup.Group, *C) {
+	//nolint:gocritic
+	group, ctx2 := errgroup.WithContext(ctx)
+
+	return group, New(ctx2)
+}

--- a/contextplus/contextplus.go
+++ b/contextplus/contextplus.go
@@ -76,7 +76,7 @@ func WithTimeoutCause(
 // ErrGroup is like the standard library’s `errgroup.WithContext()`, but
 // it returns a context from this package.
 func ErrGroup(ctx context.Context) (*errgroup.Group, *C) {
-	//nolint:gocritic
+	//nolint:forbidigo
 	group, ctx2 := errgroup.WithContext(ctx)
 
 	return group, New(ctx2)

--- a/contextplus/contextplus.go
+++ b/contextplus/contextplus.go
@@ -40,7 +40,7 @@ import (
 // same name, but the returned Context’s Err() will include both
 // `context.Canceled` and the Cause.
 func WithCancelCause(ctx context.Context) (*C, context.CancelCauseFunc) {
-	//nolint:gocritic
+	//nolint:forbidigo
 	newCtx, cancel := context.WithCancelCause(ctx)
 	return New(newCtx), cancel
 }
@@ -56,7 +56,7 @@ func WithDeadlineCause(
 	cause error,
 ) (*C, context.CancelFunc) {
 	wrappedCause := errors.Wrapf(cause, "deadline (%s) passed", deadline)
-	//nolint:gocritic
+	//nolint:forbidigo
 	newCtx, cancel := context.WithDeadlineCause(ctx, deadline, wrappedCause)
 	return New(newCtx), cancel
 }
@@ -68,7 +68,7 @@ func WithTimeoutCause(
 	cause error,
 ) (*C, context.CancelFunc) {
 	wrappedCause := errors.Wrapf(cause, "timed out after %s", timeout)
-	//nolint:gocritic
+	//nolint:forbidigo
 	newCtx, cancel := context.WithTimeoutCause(ctx, timeout, wrappedCause)
 	return New(newCtx), cancel
 }

--- a/contextplus/unit_test.go
+++ b/contextplus/unit_test.go
@@ -1,0 +1,45 @@
+package contextplus
+
+import (
+	"reflect"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	ts := new(UnitTestSuite)
+	suite.Run(t, ts)
+}
+
+func (s *UnitTestSuite) TestParallel() {
+	methodFinder := reflect.TypeOf(s)
+
+	for i := range methodFinder.NumMethod() {
+		method := methodFinder.Method(i)
+
+		if !strings.HasPrefix(method.Name, "ParallelTest") {
+			continue
+		}
+	}
+}
+
+func recoverAndFailOnPanic(t *testing.T) {
+	t.Helper()
+	r := recover()
+	failOnPanic(t, r)
+}
+
+func failOnPanic(t *testing.T, r interface{}) {
+	t.Helper()
+	if r != nil {
+		t.Errorf("test panicked: %v\n%s", r, debug.Stack())
+		t.FailNow()
+	}
+}

--- a/contextplus/unit_test.go
+++ b/contextplus/unit_test.go
@@ -1,9 +1,6 @@
 package contextplus
 
 import (
-	"reflect"
-	"runtime/debug"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -16,30 +13,4 @@ type UnitTestSuite struct {
 func TestUnitTestSuite(t *testing.T) {
 	ts := new(UnitTestSuite)
 	suite.Run(t, ts)
-}
-
-func (s *UnitTestSuite) TestParallel() {
-	methodFinder := reflect.TypeOf(s)
-
-	for i := range methodFinder.NumMethod() {
-		method := methodFinder.Method(i)
-
-		if !strings.HasPrefix(method.Name, "ParallelTest") {
-			continue
-		}
-	}
-}
-
-func recoverAndFailOnPanic(t *testing.T) {
-	t.Helper()
-	r := recover()
-	failOnPanic(t, r)
-}
-
-func failOnPanic(t *testing.T, r interface{}) {
-	t.Helper()
-	if r != nil {
-		t.Errorf("test panicked: %v\n%s", r, debug.Stack())
-		t.FailNow()
-	}
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/util"
@@ -13,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
-	"golang.org/x/sync/errgroup"
 )
 
 type RetryCallback = func(context.Context, *FuncInfo) error
@@ -95,7 +95,7 @@ func (r *Retryer) runRetryLoop(
 			beforeFunc()
 		}
 
-		eg, egCtx := errgroup.WithContext(ctx)
+		eg, egCtx := contextplus.ErrGroup(ctx)
 
 		for i, curCbInfo := range r.callbacks {
 			curFunc := curCbInfo.callback

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/option"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -157,11 +158,11 @@ func (suite *UnitTestSuite) TestCancelViaContext() {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(suite.Context())
+	ctx, cancel := contextplus.WithCancelCause(suite.Context())
 
 	// We need to cancel before we allow the f() func to do any work. This ensures that the
 	// retry code will see the cancel before the timer it sets expires.
-	cancel()
+	cancel(errors.New("immediate cancel"))
 	go func() {
 		err := retryer.WithCallback(f, "f").Run(ctx, logger)
 		suite.ErrorIs(err, context.Canceled)

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -36,5 +36,12 @@ func WrapCtxErrWithCause(ctx context.Context) error {
 		return cause
 	}
 
+	// This can happen if the given ctx is a contextplus, or some other
+	// context.Context immplementation that includes the cause in the
+	// context’s Err().
+	if errors.Is(err, cause) {
+		return err
+	}
+
 	return fmt.Errorf("%w: %w", err, cause)
 }

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"golang.org/x/sync/errgroup"
 )
 
 type GenerationStatus string
@@ -86,7 +85,7 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 	verifier.writeStringBuilder(genStartReport)
 
 	cancelableCtx, canceler := contextplus.WithCancelCause(ctxIn)
-	eg, ctx := errgroup.WithContext(cancelableCtx)
+	eg, ctx := contextplus.ErrGroup(cancelableCtx)
 
 	// If the change stream fails, everything should stop.
 	eg.Go(func() error {
@@ -250,7 +249,7 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 		verifier.phase = Idle
 	}()
 
-	ceHandlerGroup, groupCtx := errgroup.WithContext(ctx)
+	ceHandlerGroup, groupCtx := contextplus.ErrGroup(ctx)
 	for _, csReader := range []*ChangeStreamReader{verifier.srcChangeStreamReader, verifier.dstChangeStreamReader} {
 		if csReader.changeStreamRunning {
 			verifier.logger.Debug().Msgf("Check: %s already running.", csReader)

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/util"
@@ -84,7 +85,7 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 
 	verifier.writeStringBuilder(genStartReport)
 
-	cancelableCtx, canceler := context.WithCancelCause(ctxIn)
+	cancelableCtx, canceler := contextplus.WithCancelCause(ctxIn)
 	eg, ctx := errgroup.WithContext(cancelableCtx)
 
 	// If the change stream fails, everything should stop.

--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/types"
 	"github.com/10gen/migration-verifier/internal/util"
@@ -12,7 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
 )
 
 const readTimeout = 10 * time.Minute
@@ -173,7 +173,7 @@ func (verifier *Verifier) compareDocsFromChannels(
 
 		var srcDoc, dstDoc bson.Raw
 
-		eg, egCtx := errgroup.WithContext(ctx)
+		eg, egCtx := contextplus.ErrGroup(ctx)
 
 		if !srcClosed {
 			eg.Go(func() error {

--- a/internal/verifier/compare_test.go
+++ b/internal/verifier/compare_test.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/mslices"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ func (s *IntegrationTestSuite) TestFetchAndCompareDocuments_Context() {
 	verifier := s.BuildVerifier()
 
 	for range 100 {
-		cancelableCtx, cancel := context.WithCancelCause(ctx)
+		cancelableCtx, cancel := contextplus.WithCancelCause(ctx)
 
 		var done atomic.Bool
 		go func() {

--- a/internal/verifier/integration_test_suite.go
+++ b/internal/verifier/integration_test_suite.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/util"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pkg/errors"
@@ -78,7 +79,7 @@ func (suite *IntegrationTestSuite) SetupSuite() {
 }
 
 func (suite *IntegrationTestSuite) SetupTest() {
-	ctx, canceller := context.WithCancelCause(context.Background())
+	ctx, canceller := contextplus.WithCancelCause(context.Background())
 	suite.testContext, suite.contextCanceller = ctx, canceller
 	suite.zerologGlobalLogLevel = zerolog.GlobalLevel()
 

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/types"
@@ -12,7 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -98,7 +98,7 @@ func (verifier *Verifier) insertRecheckDocs(
 	docIDIndexes := lo.Range(len(documentIDs))
 	indexesPerThread := splitToChunks(docIDIndexes, verifier.numWorkers)
 
-	eg, groupCtx := errgroup.WithContext(ctx)
+	eg, groupCtx := contextplus.ErrGroup(ctx)
 
 	for _, curThreadIndexes := range indexesPerThread {
 		curThreadIndexes := curThreadIndexes

--- a/internal/verifier/web_server.go
+++ b/internal/verifier/web_server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -34,7 +35,7 @@ type WebServer struct {
 	logger             *logger.Logger
 	srv                *http.Server
 	operationalAPILock *semaphore.Weighted
-	signalShutdown     context.CancelFunc
+	signalShutdown     context.CancelCauseFunc
 	mongosyncError     error
 }
 
@@ -166,7 +167,7 @@ func (server *WebServer) Run(ctx context.Context) error {
 		Handler: server.setupRouter(),
 	}
 
-	webServerCtx, shutDownWebServer := context.WithCancel(ctx)
+	webServerCtx, shutDownWebServer := contextplus.WithCancelCause(ctx)
 
 	server.signalShutdown = shutDownWebServer
 
@@ -177,7 +178,7 @@ func (server *WebServer) Run(ctx context.Context) error {
 		// Shut down the server manually if needed.
 		if !errors.Is(err, http.ErrServerClosed) {
 			server.logger.Error().Err(err).Msg("Web server failed check")
-			shutDownWebServer()
+			shutDownWebServer(err)
 		}
 	}()
 
@@ -266,7 +267,7 @@ func (server *WebServer) operationalErrorResponse(c *gin.Context, err error) {
 
 	server.logger.Error().Err(err).Msg("Un-recoverable error during operational API handler, shutting down.")
 	server.mongosyncError = err
-	server.signalShutdown()
+	server.signalShutdown(err)
 
 	errorDescription := err.Error()
 	c.JSON(http.StatusOK, APIResponse{false, &errorName, &errorDescription})


### PR DESCRIPTION
```
2025-03-27T08:52:49-04:00 DBG Non-retryable error occurred. error="context canceled" description=["finding next task to do in generation 0"] error code=0
```
^^ The above doesn’t tell us _why_ the context was canceled.

This changeset causes all contexts’ Err() to show their cancellation causes, e.g:
```
2025-03-27T08:52:49-04:00 DBG Non-retryable error occurred. error="context canceled: generation 0 finished" description=["finding next task to do in generation 0"] error code=0
```

Note the addition of `generation 0 finished`, which lets us know why the context was canceled.