### PR TITLE
Update to golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.4.1
+        uses: golangci/golangci-lint-action@v7.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,45 @@
+version: "2"
 linters:
   enable:
-    - errcheck
     - forbidigo
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-
+    - gomodguard
   disable:
-    - gofumpt
     - depguard
-
-  presets:
-    - format
-    - import
-
-linters-settings:
-  govet:
-    disable:
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: context\.WithCancel(?:Cause)?
+          msg: Use contextplus.
+        - pattern: context\.WithTimeout(?:Cause)?
+          msg: Use contextplus.
+        - pattern: context\.WithDeadline(?:Cause)?
+          msg: Use contextplus.
+        - pattern: errgroup.WithContext
+          msg: Use contextplus.
+    govet:
+      disable:
         # Unkeyed primitive.E and timestamp fields are used extensively in code taken from
         # mongosync.
         - composites
-  forbidigo:
-    forbid:
-      - p: context\.WithCancel(?:Cause)?
-        msg: Use contextplus.
-      - p: context\.WithTimeout(?:Cause)?
-        msg: Use contextplus.
-      - p: context\.WithDeadline(?:Cause)?
-        msg: Use contextplus.
-      - p: errgroup.WithContext
-        msg: Use contextplus.
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,9 +24,6 @@ linters:
   exclusions:
     generated: lax
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
     paths:
       - third_party$

--- a/internal/keystring/keystring_decoder.go
+++ b/internal/keystring/keystring_decoder.go
@@ -103,7 +103,7 @@ func (bc bufferConsumer) hasUint8() bool {
 
 func (bc *bufferConsumer) readUint8() (uint8, error) {
 	if bc.index >= len(bc.buf) {
-		return 0, errors.New("Unexpected end of input")
+		return 0, errors.New("unexpected end of input")
 	}
 	bc.index++
 	return bc.buf[bc.index-1], nil
@@ -544,7 +544,7 @@ func readValue(ctype cType, version KeyStringVersion, buf *bufferConsumer) (inte
 		}
 		return bin, nil
 	default:
-		return nil, fmt.Errorf("Unknown keystring ctype %v", ctype)
+		return nil, fmt.Errorf("unknown keystring ctype %v", ctype)
 	}
 }
 

--- a/internal/partitions/unit_test.go
+++ b/internal/partitions/unit_test.go
@@ -31,7 +31,7 @@ func (suite *UnitTestSuite) SetupSuite() {
 
 // Context returns a new context with the logger set in it.
 func (suite *UnitTestSuite) Context() context.Context {
-	return suite.logger.Logger.WithContext(context.Background())
+	return suite.logger.WithContext(context.Background())
 }
 
 // Logger returns the logger for the suite.

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -18,7 +18,7 @@ var someNetworkError = &mongo.CommandError{
 	Name:   "NetworkError",
 }
 
-var badError = errors.New("I am fatal!")
+var errBad = errors.New("i am fatal")
 
 func (suite *UnitTestSuite) TestRetryer() {
 	retryer := New()
@@ -239,19 +239,19 @@ func (suite *UnitTestSuite) TestMulti_NonTransient() {
 		"slow",
 	).WithCallback(
 		func(_ context.Context, _ *FuncInfo) error {
-			return badError
+			return errBad
 		},
 		"fails quickly",
 	).Run(ctx, logger)
 
-	suite.Assert().ErrorIs(err, badError)
+	suite.Assert().ErrorIs(err, errBad)
 }
 
 func (suite *UnitTestSuite) TestMulti_Transient() {
 	ctx := suite.Context()
 	logger := suite.Logger()
 
-	for _, finalErr := range []error{nil, badError} {
+	for _, finalErr := range []error{nil, errBad} {
 		suite.Run(
 			fmt.Sprintf("final error: %v", finalErr),
 			func() {

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -18,7 +18,7 @@ var someNetworkError = &mongo.CommandError{
 	Name:   "NetworkError",
 }
 
-var errBad = errors.New("i am fatal")
+var errBad = errors.New("fatal am I")
 
 func (suite *UnitTestSuite) TestRetryer() {
 	retryer := New()

--- a/internal/retry/unit_test.go
+++ b/internal/retry/unit_test.go
@@ -37,7 +37,7 @@ func (suite *UnitTestSuite) SetupSuite() {
 
 // Context returns a new context with the logger set in it.
 func (suite *UnitTestSuite) Context() context.Context {
-	return suite.logger.Logger.WithContext(context.Background())
+	return suite.logger.WithContext(context.Background())
 }
 
 // Logger returns the logger for the suite.

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -434,7 +434,7 @@ func getErrorRaw(err error) bson.Raw {
 	// A bulk write error, consisting
 	// of a single write error.
 	case mongo.BulkWriteError:
-		return e.WriteError.Raw
+		return e.Raw
 
 	// An error with 1 or more bulk write errors.
 	// We return the first bulk write error's Raw error.

--- a/internal/verifier/bson_compare.go
+++ b/internal/verifier/bson_compare.go
@@ -131,7 +131,7 @@ func bsonUnorderedCompareRawArray(srcRaw, dstRaw bson.Raw) (bool, error) {
 	for i, srcElement := range srcElements {
 		dstElement := dstElements[i]
 		if srcElement.Key() != dstElement.Key() {
-			return false, fmt.Errorf("Array keys differ: %s %s", srcElement.Key(), dstElement.Key())
+			return false, fmt.Errorf("array keys differ: %s %s", srcElement.Key(), dstElement.Key())
 		}
 		matches, err := bsonUnorderedCompareRawValue(srcElement.Value(), dstElement.Value())
 		if err != nil || !matches {

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -755,7 +755,7 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		logBuffer,
 	)
 
-	zlog := verifier.logger.Logger.Output(multiOut)
+	zlog := verifier.logger.Output(multiOut)
 	verifier.logger = logger.NewLogger(&zlog, multiOut)
 
 	// start verifier

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -322,7 +322,7 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 			verifier.logger.Debug().
 				Msg("Received test's signal. Continuing.")
 		}
-		time.Sleep(verifier.generationPauseDelay * time.Millisecond)
+		time.Sleep(verifier.generationPauseDelay)
 		verifier.mux.Lock()
 		if verifier.lastGeneration {
 			verifier.mux.Unlock()
@@ -537,7 +537,7 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 
 		task, gotTask := taskOpt.Get()
 		if !gotTask {
-			duration := verifier.workerSleepDelay * time.Millisecond
+			duration := verifier.workerSleepDelay
 
 			if duration > 0 {
 				time.Sleep(duration)

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -322,7 +322,7 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 			verifier.logger.Debug().
 				Msg("Received test's signal. Continuing.")
 		}
-		time.Sleep(verifier.generationPauseDelayMillis * time.Millisecond)
+		time.Sleep(verifier.generationPauseDelay * time.Millisecond)
 		verifier.mux.Lock()
 		if verifier.lastGeneration {
 			verifier.mux.Unlock()
@@ -537,7 +537,7 @@ func (verifier *Verifier) work(ctx context.Context, workerNum int) error {
 
 		task, gotTask := taskOpt.Get()
 		if !gotTask {
-			duration := verifier.workerSleepDelayMillis * time.Millisecond
+			duration := verifier.workerSleepDelay * time.Millisecond
 
 			if duration > 0 {
 				time.Sleep(duration)

--- a/internal/verifier/integration_test_suite.go
+++ b/internal/verifier/integration_test_suite.go
@@ -156,8 +156,8 @@ func (suite *IntegrationTestSuite) BuildVerifier() *Verifier {
 	verifier := NewVerifier(VerifierSettings{}, "stderr")
 	//verifier.SetStartClean(true)
 	verifier.SetNumWorkers(3)
-	verifier.SetGenerationPauseDelayMillis(0)
-	verifier.SetWorkerSleepDelayMillis(0)
+	verifier.SetGenerationPauseDelay(0)
+	verifier.SetWorkerSleepDelay(0)
 
 	verifier.verificationStatusCheckInterval = 10 * time.Millisecond
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -353,11 +353,11 @@ func (verifier *Verifier) SetNumWorkers(arg int) {
 	verifier.numWorkers = arg
 }
 
-func (verifier *Verifier) SetGenerationPauseDelayMillis(arg time.Duration) {
+func (verifier *Verifier) SetGenerationPauseDelay(arg time.Duration) {
 	verifier.generationPauseDelay = arg
 }
 
-func (verifier *Verifier) SetWorkerSleepDelayMillis(arg time.Duration) {
+func (verifier *Verifier) SetWorkerSleepDelay(arg time.Duration) {
 	verifier.workerSleepDelay = arg
 }
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -106,12 +106,12 @@ type Verifier struct {
 	// every collection.
 	gen0PendingCollectionTasks atomic.Int32
 
-	generationStartTime        time.Time
-	generationPauseDelayMillis time.Duration
-	workerSleepDelayMillis     time.Duration
-	ignoreBSONFieldOrder       bool
-	verifyAll                  bool
-	startClean                 bool
+	generationStartTime  time.Time
+	generationPauseDelay time.Duration
+	workerSleepDelay     time.Duration
+	ignoreBSONFieldOrder bool
+	verifyAll            bool
+	startClean           bool
 
 	// This would seem more ideal as uint64, but changing it would
 	// trigger several other similar type changes, and that’s not really
@@ -354,11 +354,11 @@ func (verifier *Verifier) SetNumWorkers(arg int) {
 }
 
 func (verifier *Verifier) SetGenerationPauseDelayMillis(arg time.Duration) {
-	verifier.generationPauseDelayMillis = arg
+	verifier.generationPauseDelay = arg
 }
 
 func (verifier *Verifier) SetWorkerSleepDelayMillis(arg time.Duration) {
-	verifier.workerSleepDelayMillis = arg
+	verifier.workerSleepDelay = arg
 }
 
 // SetPartitionSizeMB sets the verifier’s maximum partition size in MiB.
@@ -1464,9 +1464,10 @@ func startReport() *strings.Builder {
 	timestampAndSpace := time.Now().Format(timeFormat) + " "
 	divider := strings.Repeat(dividerChar, dividerWidth-len(timestampAndSpace))
 
-	strBuilder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		strBuilder,
 		"\n%s%s\n\n", timestampAndSpace, divider,
-	))
+	)
 
 	return strBuilder
 }
@@ -1497,10 +1498,11 @@ func (verifier *Verifier) PrintVerificationSummary(ctx context.Context, genstatu
 	now := time.Now()
 	elapsedSinceGenStart := now.Sub(verifier.generationStartTime)
 
-	strBuilder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		strBuilder,
 		"Generation time elapsed: %s\n",
 		reportutils.DurationToHMS(elapsedSinceGenStart),
-	))
+	)
 
 	metadataMismatches, anyCollsIncomplete, err := verifier.reportCollectionMetadataMismatches(ctx, strBuilder)
 	if err != nil {

--- a/internal/verifier/migration_verifier_bench_test.go
+++ b/internal/verifier/migration_verifier_bench_test.go
@@ -56,8 +56,8 @@ func BenchmarkGeneric(t *testing.B) {
 
 	verifier := NewVerifier(VerifierSettings{}, "stderr")
 	verifier.SetNumWorkers(numWorkers)
-	verifier.SetGenerationPauseDelayMillis(0)
-	verifier.SetWorkerSleepDelayMillis(0)
+	verifier.SetGenerationPauseDelay(0)
+	verifier.SetWorkerSleepDelay(0)
 	fmt.Printf("meta uri %s\n", metaUri)
 	err := verifier.SetMetaURI(context.Background(), metaUri)
 	if err != nil {

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -131,7 +131,7 @@ OUTA:
 		if printAll {
 			strBuilder.WriteString("All documents in tasks in failed status due to differing content:\n")
 		} else {
-			strBuilder.WriteString(fmt.Sprintf("First %d documents in tasks in failed status due to differing content:\n", verifier.failureDisplaySize))
+			fmt.Fprintf(strBuilder, "First %d documents in tasks in failed status due to differing content:\n", verifier.failureDisplaySize)
 		}
 		mismatchedDocsTable.Render()
 	}
@@ -162,7 +162,7 @@ OUTB:
 		if printAll {
 			strBuilder.WriteString("All documents marked missing or changed:\n")
 		} else {
-			strBuilder.WriteString(fmt.Sprintf("First %d documents marked missing or changed:\n", verifier.failureDisplaySize))
+			fmt.Fprintf(strBuilder, "First %d documents marked missing or changed:\n", verifier.failureDisplaySize)
 		}
 		missingOrChangedDocsTable.Render()
 	}
@@ -204,11 +204,12 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 
 	strBuilder.WriteString("\n")
 
-	strBuilder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		strBuilder,
 		"Namespaces completed: %d of %d (%s%%)\n",
 		completedNss, totalNss,
 		reportutils.FmtPercent(completedNss, totalNss),
-	))
+	)
 
 	elapsed := now.Sub(verifier.generationStartTime)
 
@@ -217,25 +218,28 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 	perSecondDataUnit := reportutils.FindBestUnit(bytesPerSecond)
 
 	if totalDocs > 0 {
-		strBuilder.WriteString(fmt.Sprintf(
+		fmt.Fprintf(
+			strBuilder,
 			"Total source documents compared: %d of %d (%s%%, %s/sec)\n",
 			comparedDocs,
 			totalDocs,
 			reportutils.FmtPercent(comparedDocs, totalDocs),
 			reportutils.FmtFloat(docsPerSecond),
-		))
+		)
 	} else {
-		strBuilder.WriteString(fmt.Sprintf(
+		fmt.Fprintf(
+			strBuilder,
 			"Total source documents compared: %d (%s/sec)\n",
 			comparedDocs,
 			reportutils.FmtFloat(docsPerSecond),
-		))
+		)
 	}
 
 	if totalBytes > 0 {
 		dataUnit := reportutils.FindBestUnit(totalBytes)
 
-		strBuilder.WriteString(fmt.Sprintf(
+		fmt.Fprintf(
+			strBuilder,
 			"Total size of those documents: %s of %s %s (%s%%, %s %s/sec)\n",
 			reportutils.BytesToUnit(comparedBytes, dataUnit),
 			reportutils.BytesToUnit(totalBytes, dataUnit),
@@ -243,17 +247,18 @@ func (verifier *Verifier) printNamespaceStatistics(ctx context.Context, strBuild
 			reportutils.FmtPercent(comparedBytes, totalBytes),
 			reportutils.BytesToUnit(bytesPerSecond, perSecondDataUnit),
 			perSecondDataUnit,
-		))
+		)
 	} else {
 		dataUnit := reportutils.FindBestUnit(comparedBytes)
 
-		strBuilder.WriteString(fmt.Sprintf(
+		fmt.Fprintf(
+			strBuilder,
 			"Total size of those documents: %s %s (%s %s/sec)\n",
 			reportutils.BytesToUnit(comparedBytes, dataUnit),
 			dataUnit,
 			reportutils.BytesToUnit(bytesPerSecond, perSecondDataUnit),
 			perSecondDataUnit,
-		))
+		)
 	}
 
 	table := tablewriter.NewWriter(strBuilder)
@@ -337,10 +342,11 @@ func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, st
 
 	strBuilder.WriteString("\n")
 
-	strBuilder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		strBuilder,
 		"Namespaces compared: %d\n",
 		completedNss,
-	))
+	)
 
 	dataUnit := reportutils.FindBestUnit(comparedBytes)
 
@@ -350,18 +356,20 @@ func (verifier *Verifier) printEndOfGenerationStatistics(ctx context.Context, st
 	bytesPerSecond := float64(comparedBytes) / elapsed.Seconds()
 	perSecondDataUnit := reportutils.FindBestUnit(bytesPerSecond)
 
-	strBuilder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		strBuilder,
 		"Source documents compared: %d (%s/sec)\n",
 		comparedDocs,
 		reportutils.FmtFloat(docsPerSecond),
-	))
-	strBuilder.WriteString(fmt.Sprintf(
+	)
+	fmt.Fprintf(
+		strBuilder,
 		"Total size of those documents: %s %s (%s %s/sec)\n",
 		reportutils.BytesToUnit(comparedBytes, dataUnit),
 		dataUnit,
 		reportutils.BytesToUnit(bytesPerSecond, perSecondDataUnit),
 		perSecondDataUnit,
-	))
+	)
 
 	return true, nil
 }
@@ -415,13 +423,11 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, n
 			)
 		}
 
-		builder.WriteString(fmt.Sprintf("\n%s change events this generation: %s\n", cluster.title, eventsDescr))
+		fmt.Fprintf(builder, "\n%s change events this generation: %s\n", cluster.title, eventsDescr)
 
 		lag, hasLag := cluster.csReader.GetLag().Get()
 		if hasLag {
-			builder.WriteString(
-				fmt.Sprintf("%s change stream lag: %s\n", cluster.title, reportutils.DurationToHMS(lag)),
-			)
+			fmt.Fprintf(builder, "%s change stream lag: %s\n", cluster.title, reportutils.DurationToHMS(lag))
 		}
 
 		// We only print event breakdowns for the source because we assume that
@@ -503,11 +509,12 @@ func (verifier *Verifier) printWorkerStatus(builder *strings.Builder, now time.T
 		)
 	}
 
-	builder.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		builder,
 		"\nActive worker threads (%d of %d):\n",
 		activeThreadCount,
 		verifier.numWorkers,
-	))
+	)
 
 	table.Render()
 }

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -115,7 +115,7 @@ func (verifier *Verifier) insertCollectionVerificationTask(
 		var ok bool
 		dstNamespace, ok = verifier.nsMap.GetDstNamespace(srcNamespace)
 		if !ok {
-			return nil, fmt.Errorf("Could not find Namespace %s", srcNamespace)
+			return nil, fmt.Errorf("could not find Namespace %s", srcNamespace)
 		}
 	}
 
@@ -211,7 +211,7 @@ func (verifier *Verifier) InsertDocumentRecheckTask(
 		var ok bool
 		dstNamespace, ok = verifier.nsMap.GetDstNamespace(srcNamespace)
 		if !ok {
-			return nil, fmt.Errorf("Could not find Namespace %s", srcNamespace)
+			return nil, fmt.Errorf("could not find namespace %s", srcNamespace)
 		}
 	}
 

--- a/internal/verifier/web_server.go
+++ b/internal/verifier/web_server.go
@@ -59,7 +59,7 @@ func NewWebServer(port int, mapi MigrationVerifierAPI, logger *logger.Logger) *W
 func (server *WebServer) operationalAPILockMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !server.operationalAPILock.TryAcquire(1) {
-			err := fmt.Errorf("Request in progress")
+			err := fmt.Errorf("request in progress")
 			server.operationalErrorResponse(c, err)
 			c.Abort()
 			return

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -226,8 +226,8 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	}
 	v.SetServerPort(cCtx.Int(serverPort))
 	v.SetNumWorkers(cCtx.Int(numWorkers))
-	v.SetGenerationPauseDelayMillis(time.Duration(cCtx.Int64(generationPauseDelay)))
-	v.SetWorkerSleepDelayMillis(time.Duration(cCtx.Int64(workerSleepDelay)))
+	v.SetGenerationPauseDelay(time.Duration(cCtx.Int64(generationPauseDelay)) * time.Millisecond)
+	v.SetWorkerSleepDelay(time.Duration(cCtx.Int64(workerSleepDelay)) * time.Millisecond)
 
 	err = v.SetPprofInterval(cCtx.String(pprofInterval))
 	if err != nil {


### PR DESCRIPTION
This also renames a couple of internal methods for better clarity, thanks to helpful pointers from the new linter version.