### PR TITLE
Filter namespaces by string prefix rather than regexp.

### DIFF
--- a/internal/util/agg.go
+++ b/internal/util/agg.go
@@ -6,13 +6,19 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func ExcludePrefixesQuery(fieldSpec string, prefixes []string) bson.D {
+// ExcludePrefixesQuery returns a document that represents a query
+// (not aggregation!) that matches documents where the indicated field
+// DOES NOT have any of the indicated prefixes.
+//
+// This is useful, e.g., in $match aggregation phases to exclude change
+// events for system namespaces.
+func ExcludePrefixesQuery(fieldName string, prefixes []string) bson.D {
 	return bson.D{
 		{"$expr", bson.D{{"$not", bson.D{
 			{"$or", lo.Map(
 				prefixes,
 				func(prefix string, _ int) bson.D {
-					return mmongo.StartsWithAgg("$"+fieldSpec, prefix)
+					return mmongo.StartsWithAgg("$"+fieldName, prefix)
 				},
 			)},
 		}}}},

--- a/internal/util/agg.go
+++ b/internal/util/agg.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"github.com/10gen/migration-verifier/mmongo"
+	"github.com/samber/lo"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func ExcludePrefixesQuery(fieldSpec string, prefixes []string) bson.D {
+	return bson.D{
+		{"$expr", bson.D{{"$not", bson.D{
+			{"$or", lo.Map(
+				prefixes,
+				func(prefix string, _ int) bson.D {
+					return mmongo.StartsWithAgg("$"+fieldSpec, prefix)
+				},
+			)},
+		}}}},
+	}
+}

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -20,6 +20,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/exp/slices"
 )
 
 type modifyEventHandling string
@@ -272,7 +273,13 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 func (csr *ChangeStreamReader) GetChangeStreamFilter() (pipeline mongo.Pipeline) {
 	if len(csr.namespaces) == 0 {
 		pipeline = mongo.Pipeline{
-			{{"$match", util.ExcludePrefixesQuery("ns.db", MongosyncMetaDBPrefixes)}},
+			{{"$match", util.ExcludePrefixesQuery(
+				"ns.db",
+				append(
+					slices.Clone(MongosyncMetaDBPrefixes),
+					csr.metaDB.Name(),
+				),
+			)}},
 		}
 	} else {
 		filter := []bson.D{}

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -272,12 +272,7 @@ func (verifier *Verifier) HandleChangeStreamEvents(ctx context.Context, batch []
 func (csr *ChangeStreamReader) GetChangeStreamFilter() (pipeline mongo.Pipeline) {
 	if len(csr.namespaces) == 0 {
 		pipeline = mongo.Pipeline{
-			{{"$match", bson.D{
-				{"ns.db", bson.D{{"$nin", bson.A{
-					primitive.Regex{Pattern: MongosyncMetaDBsPattern},
-					csr.metaDB.Name(),
-				}}}},
-			}}},
+			{{"$match", util.ExcludePrefixesQuery("ns.db", MongosyncMetaDBPrefixes)}},
 		}
 	} else {
 		filter := []bson.D{}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -397,14 +397,16 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 
 func (verifier *Verifier) setupAllNamespaceList(ctx context.Context) error {
 	// We want to check all user collections on both source and dest.
-	srcNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.srcClient, verifier.metaDBName)
+	srcNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.srcClient,
+		true /* include views */, verifier.metaDBName)
 	if err != nil {
-		return errors.Wrap(err, "failed to list source collections")
+		return err
 	}
 
-	dstNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.dstClient, verifier.metaDBName)
+	dstNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.dstClient,
+		true /* include views */, verifier.metaDBName)
 	if err != nil {
-		return errors.Wrap(err, "failed to list destination collections")
+		return err
 	}
 
 	srcMap := map[string]bool{}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -397,12 +397,12 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 
 func (verifier *Verifier) setupAllNamespaceList(ctx context.Context) error {
 	// We want to check all user collections on both source and dest.
-	srcNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.srcClient, verifier.metaDBName)
+	srcNamespaces, err := ListAllUserNamespaces(ctx, verifier.logger, verifier.srcClient, verifier.metaDBName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list source collections")
 	}
 
-	dstNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.dstClient, verifier.metaDBName)
+	dstNamespaces, err := ListAllUserNamespaces(ctx, verifier.logger, verifier.dstClient, verifier.metaDBName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list destination collections")
 	}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -397,16 +397,14 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 
 func (verifier *Verifier) setupAllNamespaceList(ctx context.Context) error {
 	// We want to check all user collections on both source and dest.
-	srcNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.srcClient,
-		true /* include views */, verifier.metaDBName)
+	srcNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.srcClient, verifier.metaDBName)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to list source collections")
 	}
 
-	dstNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.dstClient,
-		true /* include views */, verifier.metaDBName)
+	dstNamespaces, err := ListAllUserCollections(ctx, verifier.logger, verifier.dstClient, verifier.metaDBName)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to list destination collections")
 	}
 
 	srcMap := map[string]bool{}

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -29,12 +29,8 @@ var (
 
 // Lists all the user collections on a cluster.  Unlike mongosync, we don't use the internal $listCatalog, since we need to
 // work on old versions without that command.  This means this does not run with read concern majority.
-func ListAllUserCollections(
-	ctx context.Context,
-	logger *logger.Logger,
-	client *mongo.Client,
-	additionalExcludedDBs ...string,
-) ([]string, error) {
+func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *mongo.Client, includeViews bool,
+	additionalExcludedDBs ...string) ([]string, error) {
 	excludedDBs := []string{}
 	excludedDBs = append(excludedDBs, additionalExcludedDBs...)
 	excludedDBs = append(excludedDBs, ExcludedSystemDBs...)
@@ -62,10 +58,17 @@ func ListAllUserCollections(
 	for _, dbName := range dbNames {
 		db := client.Database(dbName)
 
-		filter := util.ExcludePrefixesQuery(
-			"name",
-			mslices.Of(ExcludedSystemCollPrefix),
-		)
+		filterTerms := []bson.D{
+			util.ExcludePrefixesQuery("name", mslices.Of(ExcludedSystemCollPrefix)),
+		}
+		if !includeViews {
+			filterTerms = append(
+				filterTerms,
+				bson.D{{"type", bson.D{{"$ne", "view"}}}},
+			)
+		}
+
+		filter := bson.D{{"$and", filterTerms}}
 
 		specifications, err := db.ListCollectionSpecifications(ctx, filter, options.ListCollections().SetNameOnly(true))
 		if err != nil {

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -29,7 +29,7 @@ var (
 
 // Lists all the user collections on a cluster.  Unlike mongosync, we don't use the internal $listCatalog, since we need to
 // work on old versions without that command.  This means this does not run with read concern majority.
-func ListAllUserCollections(
+func ListAllUserNamespaces(
 	ctx context.Context,
 	logger *logger.Logger,
 	client *mongo.Client,

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -57,12 +57,19 @@ func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *
 	collectionNamespaces := []string{}
 	for _, dbName := range dbNames {
 		db := client.Database(dbName)
-		filter := bson.D{{"$and", []bson.D{
+
+		filterTerms := []bson.D{
 			util.ExcludePrefixesQuery("name", mslices.Of(ExcludedSystemCollPrefix)),
-		}}}
-		if !includeViews {
-			filter = append(filter, bson.E{"type", bson.D{{"$ne", "view"}}})
 		}
+		if !includeViews {
+			filterTerms = append(
+				filterTerms,
+				bson.D{{"type", bson.D{{"$ne", "view"}}}},
+			)
+		}
+
+		filter := bson.D{{"$and", filterTerms}}
+
 		specifications, err := db.ListCollectionSpecifications(ctx, filter, options.ListCollections().SetNameOnly(true))
 		if err != nil {
 			return nil, err

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -22,7 +22,8 @@ var (
 	// ExcludedSystemDBs are system databases that are excluded from verification.
 	ExcludedSystemDBs = []string{"admin", "config", "local"}
 
-	// ExcludedSystemCollRegex is the regular expression representation of the excluded system collections.
+	// ExcludedSystemCollPrefix is the prefix of system collections,
+	// which we ignore.
 	ExcludedSystemCollPrefix = "system."
 )
 
@@ -56,7 +57,6 @@ func ListAllUserCollections(ctx context.Context, logger *logger.Logger, client *
 	collectionNamespaces := []string{}
 	for _, dbName := range dbNames {
 		db := client.Database(dbName)
-		//filter := bson.D{{"name", bson.D{{"$nin", bson.A{ExcludedSystemCollRegex}}}}}
 		filter := bson.D{{"$and", []bson.D{
 			util.ExcludePrefixesQuery("name", mslices.Of(ExcludedSystemCollPrefix)),
 		}}}

--- a/mmongo/agg.go
+++ b/mmongo/agg.go
@@ -2,9 +2,10 @@ package mmongo
 
 import "go.mongodb.org/mongo-driver/bson"
 
-// StartsWithAgg indicates whether the referent field begins with the
-// “besought” string. Equivalent to String.prototype.startsWith(besought)
-// in JavaScript.
+// StartsWithAgg returns an aggregation expression that indicates whether
+// the referent field begins with the “besought” string.
+//
+// Equivalent to JavaScript String.prototype.startsWith(besought).
 func StartsWithAgg(fieldRef string, besought string) bson.D {
 	return bson.D{
 		{"$eq", bson.A{

--- a/mmongo/agg.go
+++ b/mmongo/agg.go
@@ -1,0 +1,20 @@
+package mmongo
+
+import "go.mongodb.org/mongo-driver/bson"
+
+// StartsWithAgg indicates whether the referent field begins with the
+// “besought” string. Equivalent to String.prototype.startsWith(besought)
+// in JavaScript.
+func StartsWithAgg(fieldRef string, besought string) bson.D {
+	return bson.D{
+		{"$eq", bson.A{
+			0,
+			bson.D{{"$indexOfCP", bson.A{
+				fieldRef,
+				besought,
+				0, // start scanning at index 0
+				1, // stop scanning at index 1
+			}}},
+		}},
+	}
+}


### PR DESCRIPTION
Pure string operations generally outperform regular expressions. This changeset alters the relevant paths accordingly.

During testing it was observed that ListAllUserCollections() (which calls the altered logic) has an unused flag. This changeset removes that flag and renames the function. Related error messaging is also augmented.