### PR TITLE
REP-5963 Migrate recheck queue to per-generation collections

### DIFF
--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -271,10 +271,9 @@ func (suite *IntegrationTestSuite) TestChangeStreamResumability() {
 
 	suite.Assert().Equal(
 		bson.M{
-			"db":         suite.DBNameForTest(),
-			"coll":       "testColl",
-			"generation": int32(0),
-			"docID":      "heyhey",
+			"db":    suite.DBNameForTest(),
+			"coll":  "testColl",
+			"docID": "heyhey",
 		},
 		recheckDocs[0]["_id"],
 		"recheck doc should have expected ID",

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -296,8 +296,7 @@ func (suite *IntegrationTestSuite) getClusterTime(ctx context.Context, client *m
 func (suite *IntegrationTestSuite) fetchVerifierRechecks(ctx context.Context, verifier *Verifier) []bson.M {
 	recheckDocs := []bson.M{}
 
-	recheckColl := verifier.verificationDatabase().
-		Collection(getRecheckQueueCollectionName(verifier.generation))
+	recheckColl := verifier.getRecheckQueueCollection(verifier.generation)
 	cursor, err := recheckColl.Find(ctx, bson.D{})
 
 	if !errors.Is(err, mongo.ErrNoDocuments) {
@@ -839,8 +838,7 @@ func (suite *IntegrationTestSuite) TestRecheckDocsWithDstChangeEvents() {
 	require.Eventually(
 		suite.T(),
 		func() bool {
-			recheckColl := verifier.verificationDatabase().
-				Collection(getRecheckQueueCollectionName(0))
+			recheckColl := verifier.getRecheckQueueCollection(verifier.generation)
 			cursor, err := recheckColl.Find(ctx, bson.D{})
 			if errors.Is(err, mongo.ErrNoDocuments) {
 				return false

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -297,7 +297,8 @@ func (suite *IntegrationTestSuite) getClusterTime(ctx context.Context, client *m
 func (suite *IntegrationTestSuite) fetchVerifierRechecks(ctx context.Context, verifier *Verifier) []bson.M {
 	recheckDocs := []bson.M{}
 
-	recheckColl := verifier.verificationDatabase().Collection(recheckQueue)
+	recheckColl := verifier.verificationDatabase().
+		Collection(getRecheckQueueCollectionName(verifier.generation))
 	cursor, err := recheckColl.Find(ctx, bson.D{})
 
 	if !errors.Is(err, mongo.ErrNoDocuments) {
@@ -839,7 +840,8 @@ func (suite *IntegrationTestSuite) TestRecheckDocsWithDstChangeEvents() {
 	require.Eventually(
 		suite.T(),
 		func() bool {
-			recheckColl := verifier.verificationDatabase().Collection(recheckQueue)
+			recheckColl := verifier.verificationDatabase().
+				Collection(getRecheckQueueCollectionName(0))
 			cursor, err := recheckColl.Find(ctx, bson.D{})
 			if errors.Is(err, mongo.ErrNoDocuments) {
 				return false

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -390,7 +390,7 @@ func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any
 			return err
 		}
 
-		err = verifier.ClearRecheckDocsWhileLocked(ctx)
+		err = verifier.DropOldRecheckQueueWhileLocked(ctx)
 		if err != nil {
 			verifier.logger.Warn().
 				Err(err).

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -339,11 +339,7 @@ func (verifier *Verifier) SetMetaURI(ctx context.Context, uri string) error {
 func (verifier *Verifier) AddMetaIndexes(ctx context.Context) error {
 	model := mongo.IndexModel{Keys: bson.M{"generation": 1}}
 	_, err := verifier.verificationTaskCollection().Indexes().CreateOne(ctx, model)
-	if err != nil {
-		return err
-	}
-	model = mongo.IndexModel{Keys: bson.D{{"_id.generation", 1}}}
-	_, err = verifier.verificationDatabase().Collection(recheckQueue).Indexes().CreateOne(ctx, model)
+
 	return err
 }
 

--- a/internal/verifier/migration_verifier_bench_test.go
+++ b/internal/verifier/migration_verifier_bench_test.go
@@ -72,11 +72,7 @@ func BenchmarkGeneric(t *testing.B) {
 		t.Fatal(err)
 	}
 	verifier.SetMetaDBName(metaDBName)
-	err = verifier.verificationTaskCollection().Drop(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = verifier.verificationDatabase().Collection(recheckQueue).Drop(context.Background())
+	err = verifier.verificationDatabase().Drop(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1591,9 +1591,9 @@ func (suite *IntegrationTestSuite) TestVerifierWithFilter() {
 	<-checkDoneChan
 }
 
-func (suite *IntegrationTestSuite) waitForRecheckDocs(verifier *Verifier, generation int) {
+func (suite *IntegrationTestSuite) waitForRecheckDocs(verifier *Verifier) {
 	suite.Eventually(func() bool {
-		cursor, err := verifier.getRecheckQueueCollection(generation).
+		cursor, err := verifier.getRecheckQueueCollection(verifier.generation).
 			Find(suite.Context(), bson.D{})
 		var docs []bson.D
 		suite.Require().NoError(err)
@@ -1628,7 +1628,7 @@ func (suite *IntegrationTestSuite) TestChangesOnDstBeforeSrc() {
 	_, err = dstDB.Collection(collName).InsertOne(ctx, bson.D{{"_id", 2}})
 	suite.Require().NoError(err)
 	suite.Require().NoError(runner.AwaitGenerationEnd())
-	suite.waitForRecheckDocs(verifier, 1)
+	suite.waitForRecheckDocs(verifier)
 
 	// Run generation 2 and get verification status.
 	suite.Require().NoError(runner.StartNextGeneration())
@@ -1645,7 +1645,7 @@ func (suite *IntegrationTestSuite) TestChangesOnDstBeforeSrc() {
 	_, err = srcDB.Collection(collName).InsertOne(ctx, bson.D{{"_id", 1}})
 	suite.Require().NoError(err)
 	suite.Require().NoError(runner.AwaitGenerationEnd())
-	suite.waitForRecheckDocs(verifier, 3)
+	suite.waitForRecheckDocs(verifier)
 
 	status, err = verifier.GetVerificationStatus(ctx)
 	suite.Require().NoError(err)
@@ -1661,7 +1661,7 @@ func (suite *IntegrationTestSuite) TestChangesOnDstBeforeSrc() {
 	_, err = srcDB.Collection(collName).InsertOne(ctx, bson.D{{"_id", 2}})
 	suite.Require().NoError(err)
 	suite.Require().NoError(runner.AwaitGenerationEnd())
-	suite.waitForRecheckDocs(verifier, 4)
+	suite.waitForRecheckDocs(verifier)
 
 	// Everything should match by the end of it.
 	status, err = verifier.GetVerificationStatus(ctx)

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1593,8 +1593,7 @@ func (suite *IntegrationTestSuite) TestVerifierWithFilter() {
 
 func (suite *IntegrationTestSuite) waitForRecheckDocs(verifier *Verifier, generation int) {
 	suite.Eventually(func() bool {
-		cursor, err := suite.metaMongoClient.Database(verifier.metaDBName).
-			Collection(getRecheckQueueCollectionName(generation)).
+		cursor, err := verifier.getRecheckQueueCollection(generation).
 			Find(suite.Context(), bson.D{})
 		var docs []bson.D
 		suite.Require().NoError(err)

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -187,11 +187,11 @@ func (verifier *Verifier) insertRecheckDocs(
 	return nil
 }
 
-// ClearRecheckDocsWhileLocked deletes the previous generation’s recheck
+// DropOldRecheckQueueWhileLocked deletes the previous generation’s recheck
 // documents from the verifier’s metadata.
 //
 // The verifier **MUST** be locked when this function is called (or panic).
-func (verifier *Verifier) ClearRecheckDocsWhileLocked(ctx context.Context) error {
+func (verifier *Verifier) DropOldRecheckQueueWhileLocked(ctx context.Context) error {
 	prevGeneration := verifier.getPreviousGenerationWhileLocked()
 
 	verifier.logger.Debug().

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	recheckQueueBase = "recheckQueue"
-	maxBSONObjSize   = 16 * 1024 * 1024
+	recheckQueueCollectionNameBase = "recheckQueue"
+
+	maxBSONObjSize = 16 * 1024 * 1024
 
 	// This is the upper limit on the BSON-encoded length of document IDs
 	// per recheck task.
@@ -377,5 +378,5 @@ func (verifier *Verifier) GenerateRecheckTasksWhileLocked(ctx context.Context) e
 
 func (v *Verifier) getRecheckQueueCollection(generation int) *mongo.Collection {
 	return v.verificationDatabase().
-		Collection(fmt.Sprintf("%s_gen%d", recheckQueueBase, generation))
+		Collection(fmt.Sprintf("%s_gen%d", recheckQueueCollectionNameBase, generation))
 }

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -19,8 +19,6 @@ import (
 const (
 	recheckQueueCollectionNameBase = "recheckQueue"
 
-	maxBSONObjSize = 16 * 1024 * 1024
-
 	// This is the upper limit on the BSON-encoded length of document IDs
 	// per recheck task.
 	maxRecheckIdsLen = 12 * 1024 * 1024

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -448,8 +448,6 @@ func (suite *IntegrationTestSuite) TestGenerationalClear() {
 	err := insertRecheckDocs(ctx, verifier, "testDB", "testColl", ids, dataSizes)
 	suite.Require().NoError(err)
 
-	verifier.generation++
-
 	d1 := RecheckDoc{
 		PrimaryKey: RecheckPrimaryKey{
 			SrcDatabaseName:   "testDB",
@@ -465,8 +463,13 @@ func (suite *IntegrationTestSuite) TestGenerationalClear() {
 
 	verifier.mux.Lock()
 
-	err = verifier.ClearRecheckDocsWhileLocked(ctx)
+	verifier.generation++
+
+	err = verifier.DropOldRecheckQueueWhileLocked(ctx)
 	suite.Require().NoError(err)
+
+	// This never happens in real life but is needed for this test.
+	verifier.generation--
 
 	results = suite.fetchRecheckDocs(ctx, verifier)
 	suite.Assert().ElementsMatch([]any{}, results)

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -85,8 +85,7 @@ func (suite *IntegrationTestSuite) TestFailedCompareThenReplace() {
 }
 
 func (suite *IntegrationTestSuite) fetchRecheckDocs(ctx context.Context, verifier *Verifier) []RecheckDoc {
-	metaColl := suite.metaMongoClient.Database(verifier.metaDBName).
-		Collection(getRecheckQueueCollectionName(verifier.generation))
+	metaColl := verifier.getRecheckQueueCollection(verifier.generation)
 
 	cursor, err := metaColl.Find(
 		ctx,


### PR DESCRIPTION
Previously we stored the entire recheck queue in a single collection. This meant that, when we finished a generation, we had to “surgically” delete all rechecks for the old generation.

This changeset alters the metadata so that, rather than a storing rechecks in a single collection, we store them in generation-specific collections like `recheckQueue_gen0`, `recheckQueue_gen1`, etc. That way, when we want to clean out a prior generation’s recheck queue, we just drop a collection, which is much faster than deleting 100s of millions of individual recheck documents.