### PR TITLE
REP-5996 Allow users to reduce the max size of recheck tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ The migration-verifier is also rather resource-hungry. To mitigate this, try lim
 
 - The verifier conflates “missing” documents with change events: if it finds a document missing and receives a change event for another document, the verifier records those together in its metadata. As a result, the verifier’s reporting can cause confusion: what its log calls “missing or changed” documents aren’t, in fact, necessarily failures; they could all just be change events that are pending a recheck.
 
+- If the server’s memory usage rises after generation 0, try reducing `recheckMaxSizeMB`. This will shrink the queries that the verifier sends, which in turn should reduce the server’s memory usage. (The number of actual queries sent will rise, of course.)
+
 # Limitations
 
 - The verifier’s iterative process can handle data changes while it is running, until you hit the writesOff endpoint.  However, it cannot handle DDL commands.  If the verifier receives a DDL change stream event (drop, dropDatabase, rename), the verification will fail.  If an untracked DDL event (create, createIndexes, dropIndexes, modify) occurs, the verifier may miss the change.

--- a/internal/util/bson.go
+++ b/internal/util/bson.go
@@ -41,8 +41,11 @@ func (b *BSONArraySizer) Len() int {
 
 // SplitArrayByBSONMaxSize takes an array of arbitrary Go values and
 // groups them so that, when built into a BSON array, each group exceeds
-// maxSize by the smallest length possible.
-func SplitArrayByBSONMaxSize(ids []any, maxSize int) ([][]any, error) {
+// softMaxSize by the smallest length possible.
+//
+// (The max is a “soft” max because we need to accommodate the chance
+// that a single item can exceed the limit.)
+func SplitArrayByBSONMaxSize(ids []any, softMaxSize int) ([][]any, error) {
 	ids = slices.Clone(ids)
 
 	groups := [][]any{}
@@ -59,7 +62,7 @@ func SplitArrayByBSONMaxSize(ids []any, maxSize int) ([][]any, error) {
 		sizer.Add(rawVal)
 		ids = ids[1:]
 
-		if sizer.Len() >= maxSize {
+		if sizer.Len() >= softMaxSize {
 			groups = append(groups, curGroup)
 			curGroup = []any{}
 			sizer = &BSONArraySizer{}

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -620,6 +620,16 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 		}
 
 		for _, ids := range idGroups {
+			if len(idGroups) != 1 {
+				verifier.logger.Info().
+					Int("workerNum", workerNum).
+					Any("task", task.PrimaryKey).
+					Str("namespace", task.QueryFilter.Namespace).
+					Int("subsetDocs", len(ids)).
+					Int("totalTaskDocs", len(task.Ids)).
+					Msg("Comparing subset of recheck task’s documents.")
+			}
+
 			miniTask := *task
 			miniTask.Ids = ids
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -371,7 +371,7 @@ func (verifier *Verifier) SetPartitionSizeMB(partitionSizeMB uint32) {
 }
 
 func (verifier *Verifier) SetRecheckMaxSizeMB(size uint) {
-	verifier.recheckMaxSizeInBytes = types.ByteCount(size)
+	verifier.recheckMaxSizeInBytes = types.ByteCount(size) * 1024 * 1024
 }
 
 func (verifier *Verifier) SetSrcNamespaces(arg []string) {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -73,7 +73,8 @@ const (
 
 	progressReportTimeWarnThreshold = 10 * time.Second
 
-	DefaultRecheckMaxSizeMB = 12
+	DefaultRecheckMaxSizeMB = 8
+	MaxRecheckMaxSizeMB     = 12
 )
 
 type whichCluster string

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -23,6 +23,7 @@ import (
 	"github.com/10gen/migration-verifier/mbson"
 	"github.com/10gen/migration-verifier/option"
 	"github.com/dustin/go-humanize"
+	clone "github.com/huandu/go-clone/generic"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -631,7 +632,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 					Msg("Comparing subset of recheck task’s documents.")
 			}
 
-			miniTask := *task
+			miniTask := clone.Clone(*task)
 			miniTask.Ids = ids
 
 			var curProblems []VerificationResult

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -72,6 +72,8 @@ const (
 	clientAppName = "Migration Verifier"
 
 	progressReportTimeWarnThreshold = 10 * time.Second
+
+	DefaultRecheckMaxSizeMB = 12
 )
 
 type whichCluster string
@@ -119,6 +121,8 @@ type Verifier struct {
 	// trigger several other similar type changes, and that’s not really
 	// worthwhile for now.
 	partitionSizeInBytes int64
+
+	recheckMaxSizeInBytes types.ByteCount
 
 	readPreference *readpref.ReadPref
 
@@ -201,11 +205,12 @@ func NewVerifier(settings VerifierSettings, logPath string) *Verifier {
 		logger: logger,
 		writer: logWriter,
 
-		phase:                Idle,
-		numWorkers:           NumWorkers,
-		readPreference:       readpref.Primary(),
-		partitionSizeInBytes: 400 * 1024 * 1024,
-		failureDisplaySize:   DefaultFailureDisplaySize,
+		phase:                 Idle,
+		numWorkers:            NumWorkers,
+		readPreference:        readpref.Primary(),
+		partitionSizeInBytes:  400 * 1024 * 1024,
+		recheckMaxSizeInBytes: DefaultRecheckMaxSizeMB * 1024 * 1024,
+		failureDisplaySize:    DefaultFailureDisplaySize,
 
 		readConcernSetting: readConcern,
 
@@ -362,6 +367,10 @@ func (verifier *Verifier) SetWorkerSleepDelay(arg time.Duration) {
 // SetPartitionSizeMB sets the verifier’s maximum partition size in MiB.
 func (verifier *Verifier) SetPartitionSizeMB(partitionSizeMB uint32) {
 	verifier.partitionSizeInBytes = int64(partitionSizeMB) * 1024 * 1024
+}
+
+func (verifier *Verifier) SetRecheckMaxSizeMB(size uint) {
+	verifier.recheckMaxSizeInBytes = types.ByteCount(size)
 }
 
 func (verifier *Verifier) SetSrcNamespaces(arg []string) {

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -18,10 +18,6 @@ import (
 
 const (
 	recheckQueueCollectionNameBase = "recheckQueue"
-
-	// This is the upper limit on the BSON-encoded length of document IDs
-	// per recheck task.
-	maxRecheckIdsLen = 12 * 1024 * 1024
 )
 
 // RecheckPrimaryKey stores the implicit type of recheck to perform
@@ -333,7 +329,7 @@ func (verifier *Verifier) GenerateRecheckTasksWhileLocked(ctx context.Context) e
 		if doc.PrimaryKey.SrcDatabaseName != prevDBName ||
 			doc.PrimaryKey.SrcCollectionName != prevCollName ||
 			len(idAccum) > maxDocsPerTask ||
-			idsSizer.Len() >= maxRecheckIdsLen ||
+			types.ByteCount(idsSizer.Len()) >= verifier.recheckMaxSizeInBytes ||
 			dataSizeAccum >= verifier.partitionSizeInBytes {
 
 			err := persistBufferedRechecks()

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -98,6 +98,10 @@ func (t *VerificationTask) augmentLogWithDetails(evt *zerolog.Event) {
 	}
 }
 
+func (t *VerificationTask) IsRecheck() bool {
+	return len(t.Ids) > 0
+}
+
 // VerificationRange stores ID ranges for tasks that can be re-used between runs
 type VerificationRange struct {
 	PrimaryKey primitive.ObjectID `bson:"_id"`

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -91,7 +91,7 @@ func main() {
 		altsrc.NewUintFlag(cli.UintFlag{
 			Name:  recheckMaxSizeMB,
 			Value: verifier.DefaultRecheckMaxSizeMB,
-			Usage: "Maximum size of a recheck task. Reduce this to constrain server memory usage after generation 0.",
+			Usage: "Maximum size of a recheck query. Reduce this to constrain server memory usage after generation 0.",
 		}),
 		altsrc.NewInt64Flag(cli.Int64Flag{
 			Name:  generationPauseDelay,

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -35,6 +35,7 @@ const (
 	startClean            = "clean"
 	readPreference        = "readPreference"
 	partitionSizeMB       = "partitionSizeMB"
+	recheckMaxSizeMB      = "recheckMaxSizeMB"
 	checkOnly             = "checkOnly"
 	debugFlag             = "debug"
 	failureDisplaySize    = "failureDisplaySize"
@@ -86,6 +87,11 @@ func main() {
 			Name:  numWorkers,
 			Value: 10,
 			Usage: "`number` of worker threads to use for verification",
+		}),
+		altsrc.NewUintFlag(cli.UintFlag{
+			Name:  recheckMaxSizeMB,
+			Value: verifier.DefaultRecheckMaxSizeMB,
+			Usage: "Maximum size of a recheck task. Reduce this to constrain server memory usage after generation 0.",
 		}),
 		altsrc.NewInt64Flag(cli.Int64Flag{
 			Name:  generationPauseDelay,
@@ -241,6 +247,15 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 		}
 
 		v.SetPartitionSizeMB(uint32(partitionSizeMB))
+	}
+
+	recheckMaxSizeMBVal := cCtx.Uint(recheckMaxSizeMB)
+	if recheckMaxSizeMBVal != 0 {
+		if recheckMaxSizeMBVal > verifier.DefaultRecheckMaxSizeMB {
+			return nil, fmt.Errorf("%#q may not exceed %d", recheckMaxSizeMB, verifier.DefaultRecheckMaxSizeMB)
+		}
+
+		v.SetRecheckMaxSizeMB(recheckMaxSizeMBVal)
 	}
 
 	v.SetStartClean(cCtx.Bool(startClean))

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -91,7 +91,7 @@ func main() {
 		altsrc.NewUintFlag(cli.UintFlag{
 			Name:  recheckMaxSizeMB,
 			Value: verifier.DefaultRecheckMaxSizeMB,
-			Usage: "Maximum size of a recheck query. Reduce this to constrain server memory usage after generation 0.",
+			Usage: "Maximum size of a recheck query. Reduce this to limit server memory usage after generation 0.",
 		}),
 		altsrc.NewInt64Flag(cli.Int64Flag{
 			Name:  generationPauseDelay,
@@ -251,8 +251,8 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 
 	recheckMaxSizeMBVal := cCtx.Uint(recheckMaxSizeMB)
 	if recheckMaxSizeMBVal != 0 {
-		if recheckMaxSizeMBVal > verifier.DefaultRecheckMaxSizeMB {
-			return nil, fmt.Errorf("%#q may not exceed %d", recheckMaxSizeMB, verifier.DefaultRecheckMaxSizeMB)
+		if recheckMaxSizeMBVal > verifier.MaxRecheckMaxSizeMB {
+			return nil, fmt.Errorf("%#q may not exceed %d", recheckMaxSizeMB, verifier.MaxRecheckMaxSizeMB)
 		}
 
 		v.SetRecheckMaxSizeMB(recheckMaxSizeMBVal)


### PR DESCRIPTION
This allows users to set a custom maximum size for recheck tasks. The verifier observes this setting in 2 ways:
1. When creating recheck tasks, it will move onto the next task if the list of IDs has reached the maximum size.
2. When running recheck tasks, it splits the list of IDs into groups and runs each group separately (i.e., in series). This is so that, if a verification finishes generation 0 then hits problems in generation 1, the user can adjust the recheck size and have it take effect without restarting verification.

The reason for this change is that, as seen in HELP-73941, if the verifier sends many large queries to the server at once, it can deplete the server’s available memory, which can cause OOMs and elections. By throttling this new setting, customers can (hopefully) mitigate that problem.

This also reduces the default recheck size from 12 MiB to 8 MiB.