### PR TITLE
REP-6000 Add a “Detail” column to the worker-thread table.

### DIFF
--- a/internal/verifier/compare_test.go
+++ b/internal/verifier/compare_test.go
@@ -58,6 +58,7 @@ func (s *IntegrationTestSuite) TestFetchAndCompareDocuments_Context() {
 		go func() {
 			_, _, _, err := verifier.FetchAndCompareDocuments(
 				cancelableCtx,
+				0,
 				&task,
 			)
 			if err != nil {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -640,6 +640,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 			var curBytesCount types.ByteCount
 			curProblems, curDocsCount, curBytesCount, err = verifier.FetchAndCompareDocuments(
 				ctx,
+				workerNum,
 				&miniTask,
 			)
 
@@ -654,6 +655,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 	} else {
 		problems, docsCount, bytesCount, err = verifier.FetchAndCompareDocuments(
 			ctx,
+			workerNum,
 			task,
 		)
 	}

--- a/internal/verifier/migration_verifier_bench_test.go
+++ b/internal/verifier/migration_verifier_bench_test.go
@@ -83,7 +83,7 @@ func BenchmarkGeneric(t *testing.B) {
 		qfilter := QueryFilter{Namespace: namespace}
 		task := VerificationTask{QueryFilter: qfilter}
 		// TODO: is this safe?
-		mismatchedIds, docsCount, bytesCount, err := verifier.FetchAndCompareDocuments(context.Background(), &task)
+		mismatchedIds, docsCount, bytesCount, err := verifier.FetchAndCompareDocuments(context.Background(), 0, &task)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -100,7 +100,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 
 	// Test fetchDocuments without global filter.
 	verifier.globalFilter = nil
-	results, docCount, byteCount, err := verifier.FetchAndCompareDocuments(ctx, task)
+	results, docCount, byteCount, err := verifier.FetchAndCompareDocuments(ctx, 0, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(2, docCount, "should find source docs")
 	suite.Assert().NotZero(byteCount, "should tally docs' size")
@@ -112,7 +112,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	// Test fetchDocuments for ids with a global filter.
 
 	verifier.globalFilter = map[string]any{"num": map[string]any{"$lt": 100}}
-	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, task)
+	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, 0, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")
 	suite.Assert().NotZero(byteCount, "should tally docs' size")
@@ -129,7 +129,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 		Ns: &partitions.Namespace{DB: "keyhole", Coll: "dealers"},
 	}
 	verifier.globalFilter = map[string]any{"num": map[string]any{"$lt": 100}}
-	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, task)
+	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, 0, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")
 	suite.Assert().NotZero(byteCount, "should tally docs' size")
@@ -655,6 +655,7 @@ func TestVerifierCompareDocs(t *testing.T) {
 
 						results, docCount, byteCount, err = verifier.compareDocsFromChannels(
 							ctx,
+							0,
 							fi,
 							&fauxTask,
 							srcChannel,

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -483,7 +483,7 @@ func (verifier *Verifier) printChangeEventStatistics(builder *strings.Builder, n
 func (verifier *Verifier) printWorkerStatus(builder *strings.Builder, now time.Time) {
 
 	table := tablewriter.NewWriter(builder)
-	table.SetHeader([]string{"Thread #", "Namespace", "Task", "Time Elapsed"})
+	table.SetHeader([]string{"Thread #", "Namespace", "Task", "Time Elapsed", "Detail"})
 
 	wsmap := verifier.workerTracker.Load()
 
@@ -512,6 +512,7 @@ func (verifier *Verifier) printWorkerStatus(builder *strings.Builder, now time.T
 				wsmap[w].Namespace,
 				taskIdStr,
 				reportutils.DurationToHMS(now.Sub(wsmap[w].StartTime)),
+				wsmap[w].Detail,
 			},
 		)
 	}

--- a/internal/verifier/worker_tracker.go
+++ b/internal/verifier/worker_tracker.go
@@ -24,6 +24,7 @@ type WorkerStatus struct {
 	TaskType  verificationTaskType
 	Namespace string
 	StartTime time.Time
+	Detail    string
 }
 
 // NewWorkerTracker creates and returns a WorkerTracker.
@@ -46,6 +47,16 @@ func (wt *WorkerTracker) Set(workerNum int, task VerificationTask) {
 			Namespace: task.QueryFilter.Namespace,
 			StartTime: time.Now(),
 		}
+
+		return m
+	})
+}
+
+func (wt *WorkerTracker) SetDetail(workerNum int, detail string) {
+	wt.guard.Store(func(m WorkerStatusMap) WorkerStatusMap {
+		status := m[workerNum]
+		status.Detail = detail
+		m[workerNum] = status
 
 		return m
 	})


### PR DESCRIPTION
This will make it easier to confirm, at a glance, that a given worker thread is still doing useful work.

Sample output:
```
Active worker threads (24 of 30):
+----------+---------------------+--------------------------+--------------+--------------------------+
| THREAD # |      NAMESPACE      |           TASK           | TIME ELAPSED |          DETAIL          |
+----------+---------------------+--------------------------+--------------+--------------------------+
|        0 | mmsdbjobs.data.jobs | 680a8636d968b0b72db5ae6f | 2m 12.05s    | read 228,176 documents   |
|        1 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae20 | 19m 16.15s   | read 184,025 documents   |
|        2 | mmsdbjobs.data.jobs | 680a8626d968b0b72db5ae59 | 9m 23.05s    | read 319,682 documents   |
|        3 | mmsdbjobs.data.jobs | 680a8626d968b0b72db5ae5b | 8m 32.19s    | read 119,675 documents   |
|        4 | mmsdbjobs.data.jobs | 680a8626d968b0b72db5ae5c | 8m 19.98s    | read 772,206 documents   |
|        5 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae22 | 19m 16.11s   | read 360,654 documents   |
|        7 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae21 | 19m 16.11s   | read 655,567 documents   |
|        8 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae2d | 19m 15.02s   | read 412,040 documents   |
|        9 | mmsdbjobs.data.jobs | 680a8634d968b0b72db5ae69 | 4m 16.92s    | read 356,065 documents   |
|       11 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae2e | 19m 15s      | read 652,112 documents   |
|       12 | mmsdbjobs.data.jobs | 680a8631d968b0b72db5ae68 | 4m 30.78s    | read 190,391 documents   |
|       13 | mmsdbjobs.data.jobs | 680a8628d968b0b72db5ae62 | 5m 15.16s    | read 341,443 documents   |
|       14 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae32 | 19m 14.96s   | read 1,275,880 documents |
|       15 | mmsdbjobs.data.jobs | 680a8621d968b0b72db5ae30 | 19m 14.96s   | read 416,037 documents   |
|       16 | mmsdbjobs.data.jobs | 680a8636d968b0b72db5ae6e | 2m 30.34s    | read 237,879 documents   |
|       18 | mmsdbjobs.data.jobs | 680a8622d968b0b72db5ae40 | 16m 46.99s   | read 534,701 documents   |
|       19 | mmsdbjobs.data.jobs | 680a8636d968b0b72db5ae70 | 2m 5.68s     | read 237,377 documents   |
|       21 | mmsdbjobs.data.jobs | 680a8634d968b0b72db5ae6b | 3m 32.16s    | read 354,357 documents   |
|       22 | mmsdbjobs.data.jobs | 680a8635d968b0b72db5ae6d | 3m 18.42s    | read 216,583 documents   |
|       24 | mmsdbjobs.data.jobs | 680a8624d968b0b72db5ae53 | 10m 7.77s    | read 645,053 documents   |
|       25 | mmsdbjobs.data.jobs | 680a8627d968b0b72db5ae5f | 7m 37.17s    | read 174,812 documents   |
|       26 | mmsdbjobs.data.jobs | 680a8627d968b0b72db5ae61 | 6m 31.1s     | read 55,576 documents    |
|       27 | mmsdbjobs.data.jobs | 680a8624d968b0b72db5ae50 | 11m 20.83s   | read 386,301 documents   |
|       29 | mmsdbjobs.data.jobs | 680a8625d968b0b72db5ae57 | 9m 26.7s     | read 181,016 documents   |
+----------+---------------------+--------------------------+--------------+--------------------------+
```