### PR TITLE
REP-5806 Parse document filter as extended JSON

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -126,7 +126,7 @@ func PartitionCollectionWithSize(
 	replicatorList []Replicator,
 	subLogger *logger.Logger,
 	partitionSizeInBytes int64,
-	globalFilter map[string]any,
+	globalFilter bson.D,
 ) ([]*Partition, types.DocumentCount, types.ByteCount, error) {
 	if partitionSizeInBytes < 0 {
 		subLogger.Warn().
@@ -186,7 +186,7 @@ func PartitionCollectionWithParameters(
 	sampleMinNumDocs int,
 	partitionSizeInBytes int64,
 	subLogger *logger.Logger,
-	globalFilter map[string]any,
+	globalFilter bson.D,
 ) ([]*Partition, types.DocumentCount, types.ByteCount, error) {
 	subLogger.Debug().
 		Str("namespace", uuidEntry.DBName+"."+uuidEntry.CollName).
@@ -426,7 +426,7 @@ func GetSizeAndDocumentCount(ctx context.Context, logger *logger.Logger, srcColl
 //
 // This function could take a long time, especially if the collection does not have an index
 // on the filtered fields.
-func GetDocumentCountAfterFiltering(ctx context.Context, logger *logger.Logger, srcColl *mongo.Collection, filter map[string]any) (int64, error) {
+func GetDocumentCountAfterFiltering(ctx context.Context, logger *logger.Logger, srcColl *mongo.Collection, filter bson.D) (int64, error) {
 	srcDB := srcColl.Database()
 	collName := srcColl.Name()
 
@@ -514,7 +514,7 @@ func getOuterIDBound(
 	minOrMaxBound minOrMaxBound,
 	srcDB *mongo.Database,
 	collName string,
-	globalFilter map[string]any,
+	globalFilter bson.D,
 ) (any, error) {
 	// Choose a sort direction based on the minOrMaxBound.
 	var sortDirection int
@@ -590,7 +590,7 @@ func getMidIDBounds(
 	collDocCount int64,
 	numPartitions, sampleMinNumDocs int,
 	sampleRate float64,
-	globalFilter map[string]any,
+	globalFilter bson.D,
 ) ([]any, bool, error) {
 	// We entirely avoid sampling for mid bounds if we don't meet the criteria for the number of documents or partitions.
 	if collDocCount < int64(sampleMinNumDocs) || numPartitions < 2 {

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -36,7 +36,7 @@ var failedStatuses = mapset.NewSet(
 // testChan is a pair of channels for coordinating generations in tests.
 // testChan[0] is a channel signalled when when a generation is complete
 // testChan[1] is a channel signalled when Check should continue with the next generation.
-func (verifier *Verifier) Check(ctx context.Context, filter map[string]any) {
+func (verifier *Verifier) Check(ctx context.Context, filter bson.D) {
 	go func() {
 		err := verifier.CheckDriver(ctx, filter)
 		if err != nil {
@@ -174,7 +174,7 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 	)
 }
 
-func (verifier *Verifier) CheckDriver(ctx context.Context, filter map[string]any, testChan ...chan struct{}) error {
+func (verifier *Verifier) CheckDriver(ctx context.Context, filter bson.D, testChan ...chan struct{}) error {
 	verifier.mux.Lock()
 	if verifier.running {
 		verifier.mux.Unlock()

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -146,7 +146,7 @@ type Verifier struct {
 	// A user-defined $match-compatible document-level query filter.
 	// The filter is applied to all namespaces in both initial checking and iterative checking.
 	// The verifier only checks documents within the filter.
-	globalFilter map[string]any
+	globalFilter bson.D
 
 	pprofInterval time.Duration
 
@@ -154,6 +154,8 @@ type Verifier struct {
 
 	verificationStatusCheckInterval time.Duration
 }
+
+var _ MigrationVerifierAPI = &Verifier{}
 
 // VerificationStatus holds the Verification Status
 type VerificationStatus struct {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -552,7 +552,7 @@ func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDo
 	for _, field := range mismatch.fieldContentsDiffer {
 		srcClientValue := srcClientDoc.Lookup(field)
 		dstClientValue := dstClientDoc.Lookup(field)
-		details := Mismatch + fmt.Sprintf(" : Document %s failed comparison on field %s between srcClient (Type: %s) and dstClient (Type: %s)", id, fieldPrefix+field, srcClientValue.Type, dstClientValue.Type)
+		details := Mismatch + fmt.Sprintf(" : Document %s failed comparison on field %#q between srcClient (Type: %s) and dstClient (Type: %s)", id, fieldPrefix+field, srcClientValue.Type, dstClientValue.Type)
 		result := VerificationResult{
 			Field:     fieldPrefix + field,
 			Details:   details,

--- a/internal/verifier/webserver/binding_extjson.go
+++ b/internal/verifier/webserver/binding_extjson.go
@@ -1,0 +1,47 @@
+package webserver
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin/binding"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type extJSONBindingType struct{}
+
+var ExtJSONBinding = extJSONBindingType{}
+
+var _ binding.Binding = extJSONBindingType{}
+var _ binding.BindingBody = extJSONBindingType{}
+
+func (extJSONBindingType) Name() string {
+	return "extJSON"
+}
+
+func (ejb extJSONBindingType) Bind(req *http.Request, obj any) error {
+	if req == nil || req.Body == nil {
+		return errors.New("invalid request")
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return fmt.Errorf("reading HTTP request body: %w", err)
+	}
+
+	return ejb.BindBody(body, obj)
+}
+
+func (extJSONBindingType) BindBody(body []byte, obj any) error {
+	err := bson.UnmarshalExtJSON(body, false, obj)
+
+	// This validation logic is written out manually in gin’s bindings.
+	// We duplicate it here.
+	if err == nil && binding.Validator != nil {
+		err = binding.Validator.ValidateStruct(obj)
+	}
+
+	return err
+}

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -222,14 +222,24 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.SetDstURI(ctx, cCtx.String(dstURI))
+
+	dstConnStr := cCtx.String(dstURI)
+	err = v.SetDstURI(ctx, dstConnStr)
 	if err != nil {
 		return nil, err
 	}
-	err = v.SetMetaURI(ctx, cCtx.String(metaURI))
+
+	metaConnStr := cCtx.String(metaURI)
+	err = v.SetMetaURI(ctx, metaConnStr)
 	if err != nil {
 		return nil, err
 	}
+
+	if dstConnStr == metaConnStr {
+		v.GetLogger().Warn().
+			Msg("Storing migration-verifier’s metadata on the destination can significantly impede performance. Use a dedicated cluster for the metadata if you can.")
+	}
+
 	v.SetServerPort(cCtx.Int(serverPort))
 	v.SetNumWorkers(cCtx.Int(numWorkers))
 	v.SetGenerationPauseDelay(time.Duration(cCtx.Int64(generationPauseDelay)) * time.Millisecond)


### PR DESCRIPTION
Previously we parsed the document filter as plain JSON, which made it impossible to filter on ObjectID or other BSON-specific types.

This changeset fixes that by parsing the document filter as MongoDB’s extended JSON.

I’m going to merge the commits as-is rather than squashing. Note that there are two unrelated UX improvements here, as well as a fix for a race condition in an unrelated test, in discrete commits.