### PR TITLE
Fix ConvertToRawValue, which is necessary if _id is BSON null.

### DIFF
--- a/mbson/bson_raw.go
+++ b/mbson/bson_raw.go
@@ -3,6 +3,7 @@ package mbson
 import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -30,6 +31,10 @@ func RawContains(doc bson.Raw, keys ...string) (bool, error) {
 
 // ConvertToRawValue converts the specified argument to a bson.RawValue.
 func ConvertToRawValue(thing any) (bson.RawValue, error) {
+	if thing == nil {
+		thing = primitive.Null{}
+	}
+
 	t, val, err := bson.MarshalValue(thing)
 	if err != nil {
 		return bson.RawValue{}, errors.Wrapf(err, "failed to encode value (%T) to BSON (%v)", thing, thing)

--- a/mbson/unit_test.go
+++ b/mbson/unit_test.go
@@ -86,3 +86,10 @@ func (s *UnitTestSuite) Test_RawContains() {
 	_, err = RawContains(myRaw, "not there")
 	s.Assert().ErrorAs(err, &bsoncore.InsufficientBytesError{})
 }
+
+func (s *UnitTestSuite) Test_ConvertToRawValue() {
+	rv, err := ConvertToRawValue(nil)
+	s.Require().NoError(err, "nil should convert")
+
+	s.Assert().Equal(bson.TypeNull, rv.Type, "type should be correct")
+}


### PR DESCRIPTION
This fixes a small issue that arose in mongosync testing: if a document’s `_id` is BSON null—which can happen!—then the logic to chunk a slice of document `_id`s failed because apparently bson.MarshalValue() fails if given Go’s nil.