### PR TITLE
Add data size to thread details

### DIFF
--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -204,8 +204,9 @@ func (verifier *Verifier) compareDocsFromChannels(
 					verifier.workerTracker.SetDetail(
 						workerNum,
 						fmt.Sprintf(
-							"read %s documents",
+							"%s documents (%s)",
 							reportutils.FmtReal(srcDocCount),
+							reportutils.FmtBytes(srcByteCount),
 						),
 					)
 				}


### PR DESCRIPTION
This changeset makes the worker threads table’s “Detail” column show:
> 20,000 documents (2.34 GiB)

… rather than just “read 20,000 documents”. This will (slightly) better indicate that thread’s progress.