### PR TITLE
Add build time to help & first log

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 commit=$(git show --no-patch --format='%H')
+buildTime=$(date -u)
 
-go build -ldflags="-X 'main.Revision=$commit'" main/migration_verifier.go
+go build -ldflags="-X 'main.Revision=$commit' -X 'main.BuildTime=$buildTime'" main/migration_verifier.go

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -42,10 +42,13 @@ const (
 	ignoreReadConcernFlag = "ignoreReadConcern"
 	configFileFlag        = "configFile"
 	pprofInterval         = "pprofInterval"
+
+	buildVarDefaultStr = "Unknown; build with build.sh."
 )
 
-// This gets set at build time.
-var Revision = "Unknown; build with build.sh."
+// These get set at build time, assuming use of build.sh.
+var Revision = buildVarDefaultStr
+var BuildTime = buildVarDefaultStr
 
 func main() {
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
@@ -165,7 +168,7 @@ func main() {
 	app := &cli.App{
 		Name:    "migration-verifier",
 		Usage:   "verify migration correctness",
-		Version: Revision,
+		Version: fmt.Sprintf("%s, built at %s", Revision, BuildTime),
 		Flags:   flags,
 		Before: func(cCtx *cli.Context) error {
 			confFile := cCtx.String(configFileFlag)
@@ -215,6 +218,7 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 
 	v.GetLogger().Info().
 		Str("revision", Revision).
+		Str("buildTime", BuildTime).
 		Int("processID", os.Getpid()).
 		Msg("migration-verifier started.")
 


### PR DESCRIPTION
This adds the build time to log files and `--help` output.

Help output looks like:
```
VERSION:
   cd3d78ce84c3310eefb4ee11672c7b8f517bb374, built at Tue 27 May 2025 16:16:44 UTC
```