### PR TITLE
Add shell script parameters to support build for different architectures and operating systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,38 @@
 #!/bin/sh
 
+usage() {
+cat << EOF
+Usage: ./build.sh [-a <386|amd64|arm|arm64>] [-o <linux|darwin|windows>]
+Build migration-verifier for mongosync.
+
+-a          Specify the target architecture for the build, if not specified, it will use the current architecture.
+-o          Specify the target operating system for the build, if not specified, it will use the current OS.
+-h          Display this help message.
+EOF
+exit 1;
+}
+
+while getopts "o:a:" option; do
+    case "$option" in
+        a)
+            arch=${OPTARG}
+            test "$arch" = "386" -o "$arch" = amd64 -o "$arch" = "arm" -o "$arch" = "arm64" || usage
+            ;;
+        o)
+            os=${OPTARG}
+            test "$os" = "linux" -o "$os" = "darwin" -o "$os" = "windows" || usage
+            ;;
+        h)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
 commit=$(git show --no-patch --format='%H')
 buildTime=$(date -u)
 
-go build -ldflags="-X 'main.Revision=$commit' -X 'main.BuildTime=$buildTime'" main/migration_verifier.go
+GOARCH=${arch:=$(go env GOARCH)} GOOS=${os:=$(go env GOOS)} go build -ldflags="-X 'main.Revision=$commit' -X 'main.BuildTime=$buildTime'" main/migration_verifier.go

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ EOF
 exit 1;
 }
 
-while getopts "o:a:" option; do
+while getopts "o:a:h" option; do
     case "$option" in
         a)
             arch=${OPTARG}


### PR DESCRIPTION
## Description
I've modified the shell script to be able to build for different architectures and operating systems.
For fallback options, if the user didn't provide any parameters, it will build for the current environment using `go env` to get essential variables.
## Screenshot
Usage prompt
<img width="808" alt="image" src="https://github.com/user-attachments/assets/1c6c1bce-0cc0-4d22-9d76-8e284bf8ccb8" />
