### PR TITLE
REP-6088 Tolerate high numbers of mismatches

### DIFF
--- a/chanutil/io.go
+++ b/chanutil/io.go
@@ -1,0 +1,39 @@
+package chanutil
+
+import (
+	"context"
+
+	"github.com/10gen/migration-verifier/internal/util"
+	"github.com/10gen/migration-verifier/option"
+)
+
+// ReadWithDoneCheck takes a context and a channel to read from. It will read
+// from `ctx.Done()` and the given channel in a select. If it reads an error
+// from the `ctx.Done()` channel, it returns the value of `Err(ctx)`, which
+// includes the cancellation cause. If it reads a value from that channel, it
+// returns the value. If the channel was closed, the return value is None.
+func ReadWithDoneCheck[T any](ctx context.Context, ch <-chan T) (option.Option[T], error) {
+	select {
+	case <-ctx.Done():
+		return option.None[T](), util.WrapCtxErrWithCause(ctx)
+	case val, ok := <-ch:
+		if ok {
+			return option.Some(val), nil
+		}
+
+		return option.None[T](), nil
+	}
+}
+
+// WriteWithDoneCheck takes a context, a channel to write to, and a value to write to that
+// channel. It will read from `ctx.Done()` and write to the given channel in a select. If it reads
+// an error from the `ctx.Done()` channel, it returns the value of `Err(ctx)`, which includes the
+// cancellation cause. If it writes a value to that channel, it returns `nil`.
+func WriteWithDoneCheck[T any](ctx context.Context, ch chan<- T, val T) error {
+	select {
+	case <-ctx.Done():
+		return util.WrapCtxErrWithCause(ctx)
+	case ch <- val:
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/10gen/migration-verifier
 
-go 1.22
+go 1.24
 
 require (
 	github.com/cespare/permute/v2 v2.0.0-beta2

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -30,24 +30,21 @@ func SortByListAgg[T any](
 	fieldName string,
 	values []T,
 ) []bson.D {
+	fieldRef := "$" + fieldName
+
 	sortField := generateRandomFieldName("sortOrder")
-	sortFieldRef := "$" + sortField
 
 	branches := lo.Map(
 		values,
 		func(v T, i int) bson.D {
 			return bson.D{
-				{"case", bson.D{{"$eq", bson.A{sortFieldRef, v}}}},
+				{"case", bson.D{{"$eq", bson.A{fieldRef, v}}}},
 				{"then", i},
 			}
 		},
 	)
 
 	return mongo.Pipeline{
-		// Match only types we're interested in
-		{{"$match", bson.D{
-			{"type", bson.D{{"$in", values}}},
-		}}},
 		{{"$addFields", bson.D{
 			{sortField, bson.D{{"$switch", bson.D{
 				{"branches", branches},

--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -212,6 +212,8 @@ func (verifier *Verifier) compareDocsFromChannels(
 						break
 					}
 
+					fmt.Printf("\n=== received from src: %v\n", srcDocWithTs)
+
 					fi.NoteSuccess("received document from source")
 
 					srcDocCount++
@@ -328,6 +330,8 @@ func (verifier *Verifier) compareDocsFromChannels(
 		)
 	}
 
+	fmt.Printf("\n=== returning %v %v %v\n", results, srcDocCount, srcByteCount)
+
 	return results, srcDocCount, srcByteCount, nil
 }
 
@@ -428,6 +432,8 @@ func iterateCursorToChannel(
 	defer close(writer)
 
 	for cursor.Next(sctx) {
+		fmt.Printf("\n=== received document: %+v\n", cursor.Current)
+
 		state.NoteSuccess("received a document")
 
 		clusterTime, err := util.GetClusterTimeFromSession(sctx)
@@ -443,6 +449,8 @@ func iterateCursorToChannel(
 				ts:  clusterTime,
 			},
 		)
+
+		fmt.Printf("\n=== sent document: %+v\n", cursor.Current)
 
 		if err != nil {
 			return errors.Wrapf(err, "sending document to compare thread")

--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -212,8 +212,6 @@ func (verifier *Verifier) compareDocsFromChannels(
 						break
 					}
 
-					fmt.Printf("\n=== received from src: %v\n", srcDocWithTs)
-
 					fi.NoteSuccess("received document from source")
 
 					srcDocCount++
@@ -330,8 +328,6 @@ func (verifier *Verifier) compareDocsFromChannels(
 		)
 	}
 
-	fmt.Printf("\n=== returning %v %v %v\n", results, srcDocCount, srcByteCount)
-
 	return results, srcDocCount, srcByteCount, nil
 }
 
@@ -432,8 +428,6 @@ func iterateCursorToChannel(
 	defer close(writer)
 
 	for cursor.Next(sctx) {
-		fmt.Printf("\n=== received document: %+v\n", cursor.Current)
-
 		state.NoteSuccess("received a document")
 
 		clusterTime, err := util.GetClusterTimeFromSession(sctx)
@@ -449,8 +443,6 @@ func iterateCursorToChannel(
 				ts:  clusterTime,
 			},
 		)
-
-		fmt.Printf("\n=== sent document: %+v\n", cursor.Current)
 
 		if err != nil {
 			return errors.Wrapf(err, "sending document to compare thread")

--- a/internal/verifier/compare.go
+++ b/internal/verifier/compare.go
@@ -384,7 +384,7 @@ func (verifier *Verifier) getFetcherChannelsAndCallbacks(
 	}
 
 	readDstCallback := func(ctx context.Context, state *retry.FuncInfo) error {
-		sess, err := verifier.srcClient.StartSession()
+		sess, err := verifier.dstClient.StartSession()
 		if err != nil {
 			return errors.Wrapf(err, "starting session")
 		}

--- a/internal/verifier/discrepancies.go
+++ b/internal/verifier/discrepancies.go
@@ -106,7 +106,11 @@ func recordDiscrepancies(
 
 			return &mongo.ReplaceOneModel{
 				Upsert: lo.ToPtr(true),
-				Filter: Discrepancy{
+				Filter: bson.D{
+					{"task", taskID},
+					{"detail.id", r.ID},
+				},
+				Replacement: Discrepancy{
 					Task:   taskID,
 					Detail: r,
 				},

--- a/internal/verifier/discrepancies.go
+++ b/internal/verifier/discrepancies.go
@@ -84,8 +84,6 @@ func getDiscrepanciesForTasks(
 		}
 	}
 
-	fmt.Printf("=====\ndiscrepancies: %+v\n\n", result)
-
 	return result, nil
 }
 
@@ -98,8 +96,6 @@ func recordDiscrepancies(
 	if option.IfNotZero(taskID).IsNone() {
 		panic("empty task ID given")
 	}
-
-	fmt.Printf("\n=======\nrecording discrepancies for %v:\n%+v\n", taskID, problems)
 
 	models := lo.Map(
 		problems,

--- a/internal/verifier/discrepancies.go
+++ b/internal/verifier/discrepancies.go
@@ -26,10 +26,8 @@ func createDiscrepanciesCollection(ctx context.Context, db *mongo.Database) erro
 		ctx,
 		[]mongo.IndexModel{
 			{
-				Keys: []bson.D{
-					{
-						{"task", 1},
-					},
+				Keys: bson.D{
+					{"task", 1},
 				},
 			},
 		},

--- a/internal/verifier/integration_test_suite.go
+++ b/internal/verifier/integration_test_suite.go
@@ -130,6 +130,9 @@ func (suite *IntegrationTestSuite) TearDownTest() {
 		dbNames, err := client.ListDatabaseNames(ctx, bson.D{})
 		suite.Require().NoError(err)
 		for _, dbName := range dbNames {
+			if dbName == "VERIFIER_TEST_META" {
+				continue
+			}
 			if !suite.initialDbNames.Contains(dbName) {
 				suite.T().Logf("Dropping database %#q, which seems to have been created during test %#q.", dbName, suite.T().Name())
 

--- a/internal/verifier/metadata.go
+++ b/internal/verifier/metadata.go
@@ -1,3 +1,7 @@
 package verifier
 
-const verifierMetadataVersion = 1
+// Metadata version history:
+// 1: Defined metadata version.
+// 2: Split failed-task discrepancies into separate collection.
+
+const verifierMetadataVersion = 2

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -328,7 +328,7 @@ func (verifier *Verifier) AddMetaIndexes(ctx context.Context) error {
 		return errors.Wrapf(err, "creating generation index")
 	}
 
-	err = createDiscrepanciesCollection(
+	err = createMismatchesCollection(
 		ctx,
 		verifier.verificationDatabase(),
 	)
@@ -660,7 +660,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 			}
 		}
 
-		err = recordDiscrepancies(
+		err = recordMismatches(
 			ctx,
 			verifier.metaClient.Database(verifier.metaDBName),
 			task.PrimaryKey,
@@ -1168,7 +1168,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		)
 	}
 	if specificationProblems != nil {
-		err := recordDiscrepancies(
+		err := recordMismatches(
 			ctx,
 			verifier.verificationDatabase(),
 			task.PrimaryKey,
@@ -1216,7 +1216,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 			}
 		}
 
-		err := recordDiscrepancies(
+		err := recordMismatches(
 			ctx,
 			verifier.verificationDatabase(),
 			task.PrimaryKey,
@@ -1246,7 +1246,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 			}
 		}
 
-		err := recordDiscrepancies(
+		err := recordMismatches(
 			ctx,
 			verifier.verificationDatabase(),
 			task.PrimaryKey,

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -651,21 +651,21 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 				)
 			}
 		}
-	}
 
-	err = recordDiscrepancies(
-		ctx,
-		verifier.metaClient.Database(verifier.metaDBName),
-		task.PrimaryKey,
-		problems,
-	)
-	if err != nil {
-		return errors.Wrapf(
-			err,
-			"recording task %s's %d discrepancies",
+		err = recordDiscrepancies(
+			ctx,
+			verifier.metaClient.Database(verifier.metaDBName),
 			task.PrimaryKey,
-			len(problems),
+			problems,
 		)
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"recording task %s's %d discrepancies",
+				task.PrimaryKey,
+				len(problems),
+			)
+		}
 	}
 
 	err = verifier.UpdateVerificationTask(ctx, task)

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -455,8 +455,7 @@ func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A)
 	return append(predicates, verifier.globalFilter)
 }
 
-func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDoc, dstClientDoc bson.Raw, namespace string, idOpt option.Option[bson.RawValue], fieldPrefix string) (results []VerificationResult) {
-	id := idOpt.OrZero()
+func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDoc, dstClientDoc bson.Raw, namespace string, id any, fieldPrefix string) (results []VerificationResult) {
 
 	for _, field := range mismatch.missingFieldOnSrc {
 		result := VerificationResult{
@@ -529,7 +528,7 @@ func (verifier *Verifier) compareOneDocument(srcClientDoc, dstClientDoc bson.Raw
 			dataSize:  dataSize,
 		}}, nil
 	}
-	results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, option.Some(srcClientDoc.Lookup("_id")), "" /* fieldPrefix */)
+	results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, srcClientDoc.Lookup("_id"), "" /* fieldPrefix */)
 	return results, nil
 }
 
@@ -887,7 +886,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 				Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Options, dstSpec.Options),
 			})
 		} else {
-			results = append(results, mismatchResultsToVerificationResults(mismatchDetails, srcSpec.Options, dstSpec.Options, srcNs, option.None[bson.RawValue](), "Options.")...)
+			results = append(results, mismatchResultsToVerificationResults(mismatchDetails, srcSpec.Options, dstSpec.Options, srcNs, "spec", "Options.")...)
 		}
 	}
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -324,7 +324,16 @@ func (verifier *Verifier) AddMetaIndexes(ctx context.Context) error {
 	model := mongo.IndexModel{Keys: bson.M{"generation": 1}}
 	_, err := verifier.verificationTaskCollection().Indexes().CreateOne(ctx, model)
 
-	return err
+	if err != nil {
+		return errors.Wrapf(err, "creating generation index")
+	}
+
+	err = createDiscrepanciesCollection(
+		ctx,
+		verifier.verificationDatabase(),
+	)
+
+	return errors.Wrapf(err, "creating discrepancies collection")
 }
 
 func (verifier *Verifier) SetServerPort(port int) {
@@ -879,7 +888,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 		}
 		if mismatchDetails == nil {
 			results = append(results, VerificationResult{
-				ID:        "spec",
+				ID:        "collSpec",
 				NameSpace: dstNs,
 				Cluster:   ClusterTarget,
 				Field:     "Options (Field Order Only)",

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -42,7 +42,6 @@ type ReadConcernSetting string
 
 const (
 	//TODO: add comments for each of these so the warnings will stop :)
-	Missing           = "Missing"
 	Failed            = "Failed"
 	Mismatch          = "Mismatch"
 	ClusterTarget     = "dstClient"
@@ -165,30 +164,6 @@ type VerificationStatus struct {
 	FailedTasks           int `json:"failedTasks"`
 	CompletedTasks        int `json:"completedTasks"`
 	MetadataMismatchTasks int `json:"metadataMismatchTasks"`
-}
-
-// VerificationResult holds the Verification Results.
-type VerificationResult struct {
-
-	// This field gets used differently depending on whether this result
-	// came from a document comparison or something else. If it’s from a
-	// document comparison, it *MUST* be a document ID, not a
-	// documentmap.MapKey, because we query on this to populate verification
-	// tasks for rechecking after a document mismatch. Thus, in sharded
-	// clusters with duplicate document IDs in the same collection, multiple
-	// VerificationResult instances might share the same ID. That’s OK,
-	// though; it’ll just make the recheck include all docs with that ID,
-	// regardless of which ones actually need the recheck.
-	ID any
-
-	Field     string
-	Details   string
-	Cluster   string
-	NameSpace string
-	// The data size of the largest of the mismatched objects.
-	// Note this is not persisted; it is used only to ensure recheck tasks
-	// don't get too large.
-	dataSize int
 }
 
 // VerifierSettings is NewVerifier’s argument.
@@ -480,60 +455,18 @@ func (verifier *Verifier) maybeAppendGlobalFilterToPredicates(predicates bson.A)
 	return append(predicates, verifier.globalFilter)
 }
 
-func (verifier *Verifier) getDocumentsCursor(ctx context.Context, collection *mongo.Collection, clusterInfo *util.ClusterInfo,
-	startAtTs *primitive.Timestamp, task *VerificationTask) (*mongo.Cursor, error) {
-	var findOptions bson.D
-	runCommandOptions := options.RunCmd()
-	var andPredicates bson.A
+func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDoc, dstClientDoc bson.Raw, namespace string, idOpt option.Option[bson.RawValue], fieldPrefix string) (results []VerificationResult) {
+	id := idOpt.OrZero()
 
-	if task.IsRecheck() {
-		andPredicates = append(andPredicates, bson.D{{"_id", bson.M{"$in": task.Ids}}})
-		andPredicates = verifier.maybeAppendGlobalFilterToPredicates(andPredicates)
-		findOptions = bson.D{
-			bson.E{"filter", bson.D{{"$and", andPredicates}}},
-		}
-	} else {
-		findOptions = task.QueryFilter.Partition.GetFindOptions(clusterInfo, verifier.maybeAppendGlobalFilterToPredicates(andPredicates))
-	}
-	if verifier.readPreference.Mode() != readpref.PrimaryMode {
-		runCommandOptions = runCommandOptions.SetReadPreference(verifier.readPreference)
-		if startAtTs != nil {
-
-			// We never want to read before the change stream start time,
-			// or for the last generation, the change stream end time.
-			findOptions = append(
-				findOptions,
-				bson.E{"readConcern", bson.D{
-					{"afterClusterTime", *startAtTs},
-				}},
-			)
-		}
-	}
-	findCmd := append(bson.D{{"find", collection.Name()}}, findOptions...)
-
-	// Suppress this log for recheck tasks because the list of IDs can be
-	// quite long.
-	if !task.IsRecheck() {
-		verifier.logger.Debug().
-			Any("task", task.PrimaryKey).
-			Str("findCmd", fmt.Sprintf("%s", findCmd)).
-			Str("options", fmt.Sprintf("%v", *runCommandOptions)).
-			Msg("getDocuments findCmd.")
-	}
-
-	return collection.Database().RunCommandCursor(ctx, findCmd, runCommandOptions)
-}
-
-func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDoc, dstClientDoc bson.Raw, namespace string, id any, fieldPrefix string) (results []VerificationResult) {
 	for _, field := range mismatch.missingFieldOnSrc {
 		result := VerificationResult{
 			Field:     fieldPrefix + field,
 			Details:   Missing,
 			Cluster:   ClusterSource,
-			NameSpace: namespace}
-		if id != nil {
-			result.ID = id
+			NameSpace: namespace,
+			ID:        id,
 		}
+
 		results = append(results, result)
 	}
 
@@ -542,10 +475,10 @@ func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDo
 			Field:     fieldPrefix + field,
 			Details:   Missing,
 			Cluster:   ClusterTarget,
-			NameSpace: namespace}
-		if id != nil {
-			result.ID = id
+			NameSpace: namespace,
+			ID:        id,
 		}
+
 		results = append(results, result)
 	}
 
@@ -557,12 +490,13 @@ func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDo
 			Field:     fieldPrefix + field,
 			Details:   details,
 			Cluster:   ClusterTarget,
-			NameSpace: namespace}
-		if id != nil {
-			result.ID = id
+			NameSpace: namespace,
+			ID:        id,
 		}
+
 		results = append(results, result)
 	}
+
 	return
 }
 
@@ -595,7 +529,7 @@ func (verifier *Verifier) compareOneDocument(srcClientDoc, dstClientDoc bson.Raw
 			dataSize:  dataSize,
 		}}, nil
 	}
-	results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, srcClientDoc.Lookup("_id"), "" /* fieldPrefix */)
+	results := mismatchResultsToVerificationResults(mismatch, srcClientDoc, dstClientDoc, namespace, option.Some(srcClientDoc.Lookup("_id")), "" /* fieldPrefix */)
 	return results, nil
 }
 
@@ -695,8 +629,6 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 				Int("mismatchesCount", len(problems)).
 				Msg("Discrepancies found. Will recheck in the next generation.")
 
-			var mismatches []VerificationResult
-			var missingIds []any
 			var dataSizes []int
 
 			// This stores all IDs for the next generation to check.
@@ -706,19 +638,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 			for _, mismatch := range problems {
 				idsToRecheck = append(idsToRecheck, mismatch.ID)
 				dataSizes = append(dataSizes, mismatch.dataSize)
-
-				if mismatch.Details == Missing {
-					missingIds = append(missingIds, mismatch.ID)
-				} else {
-					mismatches = append(mismatches, mismatch)
-				}
 			}
-
-			// Update ids of the failed task so that only mismatches and
-			// missing are reported. Matching documents are thus hidden
-			// from the progress report.
-			task.Ids = missingIds
-			task.FailedDocs = mismatches
 
 			// Create a task for the next generation to recheck the
 			// mismatched & missing docs.
@@ -731,6 +651,21 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 				)
 			}
 		}
+	}
+
+	err = recordDiscrepancies(
+		ctx,
+		verifier.metaClient.Database(verifier.metaDBName),
+		task.PrimaryKey,
+		problems,
+	)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"recording task %s's %d discrepancies",
+			task.PrimaryKey,
+			len(problems),
+		)
 	}
 
 	err = verifier.UpdateVerificationTask(ctx, task)
@@ -900,31 +835,39 @@ func (verifier *Verifier) compareCollectionSpecifications(
 
 	if !hasSrcSpec {
 		return []VerificationResult{{
+			ID:        "spec",
 			NameSpace: srcNs,
 			Cluster:   ClusterSource,
-			Details:   Missing}}, false, nil
+			Details:   Missing,
+		}}, false, nil
 	}
 	if !hasDstSpec {
 		return []VerificationResult{{
+			ID:        "spec",
 			NameSpace: dstNs,
 			Cluster:   ClusterTarget,
-			Details:   Missing}}, false, nil
+			Details:   Missing,
+		}}, false, nil
 	}
 	if srcSpec.Type != dstSpec.Type {
 		return []VerificationResult{{
+			ID:        "spec",
 			NameSpace: srcNs,
 			Cluster:   ClusterTarget,
 			Field:     "Type",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Type, dstSpec.Type)}}, false, nil
+			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Type, dstSpec.Type),
+		}}, false, nil
 		// If the types differ, the rest is not important.
 	}
 	var results []VerificationResult
 	if srcSpec.Info.ReadOnly != dstSpec.Info.ReadOnly {
 		results = append(results, VerificationResult{
+			ID:        "spec",
 			NameSpace: dstNs,
 			Cluster:   ClusterTarget,
 			Field:     "ReadOnly",
-			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Info.ReadOnly, dstSpec.Info.ReadOnly)})
+			Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Info.ReadOnly, dstSpec.Info.ReadOnly),
+		})
 	}
 	if !bytes.Equal(srcSpec.Options, dstSpec.Options) {
 		mismatchDetails, err := BsonUnorderedCompareRawDocumentWithDetails(srcSpec.Options, dstSpec.Options)
@@ -937,12 +880,14 @@ func (verifier *Verifier) compareCollectionSpecifications(
 		}
 		if mismatchDetails == nil {
 			results = append(results, VerificationResult{
+				ID:        "spec",
 				NameSpace: dstNs,
 				Cluster:   ClusterTarget,
 				Field:     "Options (Field Order Only)",
-				Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Options, dstSpec.Options)})
+				Details:   Mismatch + fmt.Sprintf(" : src: %v, dst: %v", srcSpec.Options, dstSpec.Options),
+			})
 		} else {
-			results = append(results, mismatchResultsToVerificationResults(mismatchDetails, srcSpec.Options, dstSpec.Options, srcNs, nil /* id */, "Options.")...)
+			results = append(results, mismatchResultsToVerificationResults(mismatchDetails, srcSpec.Options, dstSpec.Options, srcNs, option.None[bson.RawValue](), "Options.")...)
 		}
 	}
 
@@ -1117,15 +1062,15 @@ func (verifier *Verifier) verifyIndexes(
 
 			if !theyMatch {
 				results = append(results, VerificationResult{
+					ID:        "index:" + indexName,
 					NameSpace: FullName(dstColl),
 					Cluster:   ClusterTarget,
-					ID:        indexName,
 					Details:   Mismatch + fmt.Sprintf(": src: %v, dst: %v", srcSpec, dstSpec),
 				})
 			}
 		} else {
 			results = append(results, VerificationResult{
-				ID:        indexName,
+				ID:        "index:" + indexName,
 				Details:   Missing,
 				Cluster:   ClusterSource,
 				NameSpace: FullName(srcColl),
@@ -1137,7 +1082,7 @@ func (verifier *Verifier) verifyIndexes(
 	for indexName := range srcMap {
 		if !srcMapUsed[indexName] {
 			results = append(results, VerificationResult{
-				ID:        indexName,
+				ID:        "index:indexName",
 				Details:   Missing,
 				Cluster:   ClusterTarget,
 				NameSpace: FullName(dstColl)})
@@ -1212,12 +1157,21 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		)
 	}
 	if specificationProblems != nil {
-		err := insertFailedCollection()
+		err := recordDiscrepancies(
+			ctx,
+			verifier.verificationDatabase(),
+			task.PrimaryKey,
+			specificationProblems,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "recording %#q spec discrepancies", srcNs)
+		}
+
+		err = insertFailedCollection()
 		if err != nil {
 			return err
 		}
 
-		task.FailedDocs = specificationProblems
 		if !verifyData {
 			task.Status = verificationTaskFailed
 			return nil
@@ -1250,7 +1204,17 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 				return err
 			}
 		}
-		task.FailedDocs = append(task.FailedDocs, indexProblems...)
+
+		err := recordDiscrepancies(
+			ctx,
+			verifier.verificationDatabase(),
+			task.PrimaryKey,
+			indexProblems,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "recording %#q index discrepancies", srcNs)
+		}
+
 		task.Status = verificationTaskMetadataMismatch
 	}
 
@@ -1271,7 +1235,16 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 			}
 		}
 
-		task.FailedDocs = append(task.FailedDocs, shardingProblems...)
+		err := recordDiscrepancies(
+			ctx,
+			verifier.verificationDatabase(),
+			task.PrimaryKey,
+			shardingProblems,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "recording %#q sharding discrepancies", srcNs)
+		}
+
 		task.Status = verificationTaskMetadataMismatch
 	}
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -835,7 +835,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 
 	if !hasSrcSpec {
 		return []VerificationResult{{
-			ID:        "spec",
+			ID:        "collSpec",
 			NameSpace: srcNs,
 			Cluster:   ClusterSource,
 			Details:   Missing,
@@ -843,7 +843,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 	}
 	if !hasDstSpec {
 		return []VerificationResult{{
-			ID:        "spec",
+			ID:        "collSpec",
 			NameSpace: dstNs,
 			Cluster:   ClusterTarget,
 			Details:   Missing,
@@ -851,7 +851,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 	}
 	if srcSpec.Type != dstSpec.Type {
 		return []VerificationResult{{
-			ID:        "spec",
+			ID:        "collSpec",
 			NameSpace: srcNs,
 			Cluster:   ClusterTarget,
 			Field:     "Type",
@@ -862,7 +862,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 	var results []VerificationResult
 	if srcSpec.Info.ReadOnly != dstSpec.Info.ReadOnly {
 		results = append(results, VerificationResult{
-			ID:        "spec",
+			ID:        "collSpec",
 			NameSpace: dstNs,
 			Cluster:   ClusterTarget,
 			Field:     "ReadOnly",
@@ -1062,7 +1062,8 @@ func (verifier *Verifier) verifyIndexes(
 
 			if !theyMatch {
 				results = append(results, VerificationResult{
-					ID:        "index:" + indexName,
+					ID:        indexName,
+					Field:     "index",
 					NameSpace: FullName(dstColl),
 					Cluster:   ClusterTarget,
 					Details:   Mismatch + fmt.Sprintf(": src: %v, dst: %v", srcSpec, dstSpec),
@@ -1070,7 +1071,8 @@ func (verifier *Verifier) verifyIndexes(
 			}
 		} else {
 			results = append(results, VerificationResult{
-				ID:        "index:" + indexName,
+				ID:        indexName,
+				Field:     "index",
 				Details:   Missing,
 				Cluster:   ClusterSource,
 				NameSpace: FullName(srcColl),
@@ -1082,7 +1084,8 @@ func (verifier *Verifier) verifyIndexes(
 	for indexName := range srcMap {
 		if !srcMapUsed[indexName] {
 			results = append(results, VerificationResult{
-				ID:        "index:indexName",
+				ID:        indexName,
+				Field:     "index",
 				Details:   Missing,
 				Cluster:   ClusterTarget,
 				NameSpace: FullName(dstColl)})

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -181,10 +181,10 @@ type VerificationResult struct {
 	// regardless of which ones actually need the recheck.
 	ID any
 
-	Field     any
-	Details   any
-	Cluster   any
-	NameSpace any
+	Field     string
+	Details   string
+	Cluster   string
+	NameSpace string
 	// The data size of the largest of the mismatched objects.
 	// Note this is not persisted; it is used only to ensure recheck tasks
 	// don't get too large.

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -909,7 +909,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	err := suite.srcMongoClient.Database("testDb").CreateCollection(ctx, "testColl")
 	suite.Require().NoError(err)
 	task := &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testColl"}}
@@ -928,7 +929,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "testColl")
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testCollTo"}}
@@ -947,7 +949,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "destOnlyColl")
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.destOnlyColl",
 			To:        "testDb.destOnlyColl"}}
@@ -968,7 +971,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "viewOnSrc")
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.viewOnSrc",
 			To:        "testDb.viewOnSrc"}}
@@ -989,7 +993,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "cappedOnDst", options.CreateCollection().SetCapped(true).SetSizeInBytes(1024*1024*100))
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.cappedOnDst",
 			To:        "testDb.cappedOnDst"}}
@@ -1010,7 +1015,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 
 	// Default success case
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl",
 			To:        "testDb.testColl"}}
@@ -1021,7 +1027,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 
 	// Neither collection exists success case
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testCollDNE",
 			To:        "testDb.testCollDNE"}}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1090,6 +1090,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 	suite.Equal(verificationTaskMetadataMismatch, task.Status)
 
 	failures = suite.getFailuresForTask(verifier, task.PrimaryKey)
+	suite.T().Logf("failures: %+v", failures)
+
 	if suite.Equal(1, len(failures)) {
 		suite.Equal(dstIndexNames[1], failures[0].ID)
 		suite.Equal(Missing, failures[0].Details)

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -186,6 +186,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	verifier.globalFilter = bson.D{
 		{"num", map[string]any{"$lt": 100}},
 	}
+	fmt.Printf("............ before test\n")
 	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, 0, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -91,7 +91,8 @@ func (suite *IntegrationTestSuite) TestVerifier_DocFilter_ObjectID() {
 	namespace := dbName + "." + collName
 
 	task := &VerificationTask{
-		Ids: []any{id1, id2},
+		PrimaryKey: primitive.NewObjectID(),
+		Ids:        []any{id1, id2},
 		QueryFilter: QueryFilter{
 			Namespace: namespace,
 			To:        namespace,
@@ -144,7 +145,11 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 		bson.D{{"_id", id + 1}, {"num", 101}, {"name", "dstTest"}},
 	})
 	suite.Require().NoError(err)
-	task := &VerificationTask{Ids: []any{id, id + 1}, QueryFilter: basicQueryFilter("keyhole.dealers")}
+	task := &VerificationTask{
+		PrimaryKey:  primitive.NewObjectID(),
+		Ids:         []any{id, id + 1},
+		QueryFilter: basicQueryFilter("keyhole.dealers"),
+	}
 
 	// Test fetchDocuments without global filter.
 	verifier.globalFilter = nil
@@ -695,6 +700,7 @@ func TestVerifierCompareDocs(t *testing.T) {
 				dstChannel := makeDocChannel(dstDocs)
 
 				fauxTask := VerificationTask{
+					PrimaryKey: primitive.NewObjectID(),
 					QueryFilter: QueryFilter{
 						Namespace: namespace,
 						ShardKeys: indexFields,
@@ -776,7 +782,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "sameView", "testColl", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}})
 	suite.Require().NoError(err)
 	task := &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.sameView",
 			To:        "testDb.sameView"}}
@@ -792,7 +799,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "wrongColl", "testColl2", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}})
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.wrongColl",
 			To:        "testDb.wrongColl"}}
@@ -814,7 +822,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "wrongPipeline", "testColl1", bson.A{bson.D{{"$project", bson.D{{"_id", 1}, {"a", 0}}}}})
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.wrongPipeline",
 			To:        "testDb.wrongPipeline"}}
@@ -841,7 +850,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "missingOptionsSrc", "testColl1", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}}, options.CreateView().SetCollation(&collation2))
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.missingOptionsSrc",
 			To:        "testDb.missingOptionsSrc"}}
@@ -863,7 +873,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "missingOptionsDst", "testColl1", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}})
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.missingOptionsDst",
 			To:        "testDb.missingOptionsDst"}}
@@ -884,7 +895,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareViews() {
 	err = suite.dstMongoClient.Database("testDb").CreateView(ctx, "differentOptions", "testColl1", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}}, options.CreateView().SetCollation(&collation2))
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.differentOptions",
 			To:        "testDb.differentOptions"}}
@@ -1055,7 +1067,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 	_, err = dstColl.Indexes().CreateMany(ctx, []mongo.IndexModel{{Keys: bson.D{{"a", 1}, {"b", -1}}}})
 	suite.Require().NoError(err)
 	task := &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl1",
 			To:        "testDb.testColl1",
@@ -1087,7 +1100,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 	dstIndexNames, err := dstColl.Indexes().CreateMany(ctx, []mongo.IndexModel{{Keys: bson.D{{"a", 1}, {"b", -1}}}, {Keys: bson.D{{"x", 1}}}})
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl2",
 			To:        "testDb.testColl2"}}
@@ -1119,7 +1133,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 	dstIndexNames, err = dstColl.Indexes().CreateMany(ctx, []mongo.IndexModel{{Keys: bson.D{{"a", 1}, {"b", -1}}}, {Keys: bson.D{{"x", 1}}}})
 	suite.Require().NoError(err)
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl3",
 			To:        "testDb.testColl3"}}
@@ -1158,7 +1173,8 @@ func (suite *IntegrationTestSuite) TestVerifierCompareIndexes() {
 	suite.Require().NoError(err)
 	suite.Require().Equal("wrong", dstIndexNames[1])
 	task = &VerificationTask{
-		Status: verificationTaskProcessing,
+		PrimaryKey: primitive.NewObjectID(),
+		Status:     verificationTaskProcessing,
 		QueryFilter: QueryFilter{
 			Namespace: "testDb.testColl4",
 			To:        "testDb.testColl4"}}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -963,7 +963,7 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	// Capped and size should differ
 	var wrongFields []string
 	for _, result := range task.FailedDocs {
-		field := result.Field.(string)
+		field := result.Field
 		suite.Require().NotNil(field)
 		wrongFields = append(wrongFields, field)
 	}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -147,6 +147,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	suite.Require().NoError(err)
 	task := &VerificationTask{
 		PrimaryKey:  primitive.NewObjectID(),
+		Generation:  1,
 		Ids:         []any{id, id + 1},
 		QueryFilter: basicQueryFilter("keyhole.dealers"),
 	}

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -187,7 +187,6 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	verifier.globalFilter = bson.D{
 		{"num", map[string]any{"$lt": 100}},
 	}
-	fmt.Printf("............ before test\n")
 	results, docCount, byteCount, err = verifier.FetchAndCompareDocuments(ctx, 0, task)
 	suite.Require().NoError(err)
 	suite.Assert().EqualValues(1, docCount, "should find source docs")

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -763,7 +763,7 @@ func (suite *IntegrationTestSuite) getFailuresForTask(
 	verifier *Verifier,
 	taskID primitive.ObjectID,
 ) []VerificationResult {
-	discrepancies, err := getDiscrepanciesForTasks(
+	discrepancies, err := getMismatchesForTasks(
 		suite.Context(),
 		verifier.verificationDatabase(),
 		mslices.Of(taskID),

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -527,8 +527,8 @@ func (suite *IntegrationTestSuite) TestFailedVerificationTaskInsertions() {
 		err = cur.Decode(&doc)
 		suite.Require().NoError(err)
 		suite.Require().Equal(expectedIds, doc["_ids"])
-		suite.Require().Equal("added", doc["status"])
-		suite.Require().Equal("verify", doc["type"])
+		suite.Require().EqualValues(verificationTaskAdded, doc["status"])
+		suite.Require().EqualValues(verificationTaskVerifyDocuments, doc["type"])
 		suite.Require().Equal(expectedNamespace, doc["query_filter"].(bson.M)["namespace"])
 	}
 	verifyTask(bson.A{int32(42), int32(43), int32(44)}, "foo.bar")
@@ -1412,11 +1412,31 @@ func (suite *IntegrationTestSuite) TestVerificationStatus() {
 
 	metaColl := verifier.verificationDatabase().Collection(verificationTasksCollection)
 	_, err := metaColl.InsertMany(ctx, []any{
-		bson.M{"generation": 0, "status": "added", "type": "verify"},
-		bson.M{"generation": 0, "status": "processing", "type": "verify"},
-		bson.M{"generation": 0, "status": "failed", "type": "verify"},
-		bson.M{"generation": 0, "status": "mismatch", "type": "verify"},
-		bson.M{"generation": 0, "status": "completed", "type": "verify"},
+		bson.M{
+			"generation": 0,
+			"status":     verificationTaskAdded,
+			"type":       verificationTaskVerifyDocuments,
+		},
+		bson.M{
+			"generation": 0,
+			"status":     verificationTaskProcessing,
+			"type":       verificationTaskVerifyDocuments,
+		},
+		bson.M{
+			"generation": 0,
+			"status":     verificationTaskFailed,
+			"type":       verificationTaskVerifyDocuments,
+		},
+		bson.M{
+			"generation": 0,
+			"status":     verificationTaskMetadataMismatch,
+			"type":       verificationTaskVerifyDocuments,
+		},
+		bson.M{
+			"generation": 0,
+			"status":     verificationTaskCompleted,
+			"type":       verificationTaskVerifyDocuments,
+		},
 	})
 	suite.Require().NoError(err)
 

--- a/internal/verifier/mongos_refresh.go
+++ b/internal/verifier/mongos_refresh.go
@@ -115,7 +115,7 @@ func refreshMongoses(
 						)
 					}
 
-					return errors.Wrapf(err, desc)
+					return errors.Wrapf(err, "%s", desc)
 				}
 
 				// We could alternatively run `flushRouterConfig: <dbName>` for each db, but that requires a

--- a/internal/verifier/result.go
+++ b/internal/verifier/result.go
@@ -1,0 +1,41 @@
+package verifier
+
+import (
+	"github.com/10gen/migration-verifier/option"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+const (
+	Missing = "Missing"
+)
+
+// VerificationResult holds the Verification Results.
+type VerificationResult struct {
+
+	// This field gets used differently depending on whether this result
+	// came from a document comparison or something else. If it’s from a
+	// document comparison, it *MUST* be a document ID, not a
+	// documentmap.MapKey, because we query on this to populate verification
+	// tasks for rechecking after a document mismatch. Thus, in sharded
+	// clusters with duplicate document IDs in the same collection, multiple
+	// VerificationResult instances might share the same ID. That’s OK,
+	// though; it’ll just make the recheck include all docs with that ID,
+	// regardless of which ones actually need the recheck.
+	ID any
+
+	Field     string
+	Details   string
+	Cluster   string
+	NameSpace string
+	// The data size of the largest of the mismatched objects.
+	// Note this is not persisted; it is used only to ensure recheck tasks
+	// don't get too large.
+	dataSize int
+
+	SrcTimestamp option.Option[primitive.Timestamp]
+	DstTimestamp option.Option[primitive.Timestamp]
+}
+
+func (vr VerificationResult) IsMissing() bool {
+	return vr.Details == Missing
+}

--- a/internal/verifier/sharding.go
+++ b/internal/verifier/sharding.go
@@ -55,6 +55,7 @@ func (verifier *Verifier) verifyShardingIfNeeded(
 
 	if srcIsSharded != dstIsSharded {
 		return []VerificationResult{{
+			ID:        "shardKey",
 			Field:     ShardKeyField,
 			Cluster:   lo.Ternary(srcIsSharded, ClusterTarget, ClusterSource),
 			Details:   Missing,
@@ -83,6 +84,7 @@ func (verifier *Verifier) verifyShardingIfNeeded(
 
 	if !areEqual {
 		return []VerificationResult{{
+			ID:        "shardKey",
 			Field:     ShardKeyField,
 			Details:   fmt.Sprintf("%s: src=%v; dst=%v", Mismatch, srcKey, dstKey),
 			NameSpace: FullName(srcColl),

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -15,6 +15,8 @@ import (
 	"github.com/10gen/migration-verifier/internal/types"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/exp/maps"
 )
@@ -47,8 +49,26 @@ func (verifier *Verifier) reportCollectionMetadataMismatches(ctx context.Context
 		table := tablewriter.NewWriter(strBuilder)
 		table.SetHeader([]string{"Index", "Cluster", "Field", "Namespace", "Details"})
 
+		taskDiscrepancies, err := getDiscrepanciesForTasks(
+			ctx,
+			verifier.verificationDatabase(),
+			lo.Map(
+				failedTasks,
+				func(ft VerificationTask, _ int) primitive.ObjectID {
+					return ft.PrimaryKey
+				},
+			),
+		)
+		if err != nil {
+			return false, false, errors.Wrapf(
+				err,
+				"fetching %d failed tasks' discrepancies",
+				len(failedTasks),
+			)
+		}
+
 		for _, v := range failedTasks {
-			for _, f := range v.FailedDocs {
+			for _, f := range taskDiscrepancies[v.PrimaryKey] {
 				table.Append([]string{fmt.Sprintf("%v", f.ID), fmt.Sprintf("%v", f.Cluster), fmt.Sprintf("%v", f.Field), fmt.Sprintf("%v", f.NameSpace), fmt.Sprintf("%v", f.Details)})
 			}
 		}
@@ -90,11 +110,46 @@ func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuild
 	failureTypesTable := tablewriter.NewWriter(strBuilder)
 	failureTypesTable.SetHeader([]string{"Failure Type", "Count"})
 
+	taskDiscrepancies, err := getDiscrepanciesForTasks(
+		ctx,
+		verifier.verificationDatabase(),
+		lo.Map(
+			failedTasks,
+			func(ft VerificationTask, _ int) primitive.ObjectID {
+				return ft.PrimaryKey
+			},
+		),
+	)
+	if err != nil {
+		return false, false, errors.Wrapf(
+			err,
+			"fetching %d failed tasks' discrepancies",
+			len(failedTasks),
+		)
+	}
+
 	contentMismatchCount := 0
 	missingOrChangedCount := 0
 	for _, task := range failedTasks {
-		contentMismatchCount += len(task.FailedDocs)
-		missingOrChangedCount += len(task.Ids)
+		discrepancies, hasDiscrepancies := taskDiscrepancies[task.PrimaryKey]
+		if !hasDiscrepancies {
+			return false, false, errors.Wrapf(
+				err,
+				"task %v is marked %#q but has no recorded discrepancies; internal error?",
+				task.PrimaryKey,
+				task.Status,
+			)
+		}
+
+		missingCount := lo.CountBy(
+			discrepancies,
+			func(d VerificationResult) bool {
+				return d.IsMissing()
+			},
+		)
+
+		contentMismatchCount += len(discrepancies) - missingCount
+		missingOrChangedCount += missingCount
 	}
 
 	failureTypesTable.Append([]string{
@@ -115,18 +170,22 @@ func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuild
 	printAll := int64(contentMismatchCount) < (verifier.failureDisplaySize + int64(0.25*float32(verifier.failureDisplaySize)))
 OUTA:
 	for _, task := range failedTasks {
-		for _, f := range task.FailedDocs {
+		for _, d := range taskDiscrepancies[task.PrimaryKey] {
+			if d.IsMissing() {
+				continue
+			}
+
 			if !printAll && mismatchedDocsTableRows >= verifier.failureDisplaySize {
 				break OUTA
 			}
 
 			mismatchedDocsTableRows++
 			mismatchedDocsTable.Append([]string{
-				fmt.Sprintf("%v", f.ID),
-				fmt.Sprintf("%v", f.Cluster),
-				fmt.Sprintf("%v", f.Field),
-				fmt.Sprintf("%v", f.NameSpace),
-				fmt.Sprintf("%v", f.Details),
+				fmt.Sprintf("%v", d.ID),
+				fmt.Sprintf("%v", d.Cluster),
+				fmt.Sprintf("%v", d.Field),
+				fmt.Sprintf("%v", d.NameSpace),
+				fmt.Sprintf("%v", d.Details),
 			})
 		}
 	}

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -49,7 +49,7 @@ func (verifier *Verifier) reportCollectionMetadataMismatches(ctx context.Context
 		table := tablewriter.NewWriter(strBuilder)
 		table.SetHeader([]string{"Index", "Cluster", "Field", "Namespace", "Details"})
 
-		taskDiscrepancies, err := getDiscrepanciesForTasks(
+		taskDiscrepancies, err := getMismatchesForTasks(
 			ctx,
 			verifier.verificationDatabase(),
 			lo.Map(
@@ -110,7 +110,7 @@ func (verifier *Verifier) reportDocumentMismatches(ctx context.Context, strBuild
 	failureTypesTable := tablewriter.NewWriter(strBuilder)
 	failureTypesTable.SetHeader([]string{"Failure Type", "Count"})
 
-	taskDiscrepancies, err := getDiscrepanciesForTasks(
+	taskDiscrepancies, err := getMismatchesForTasks(
 		ctx,
 		verifier.verificationDatabase(),
 		lo.Map(

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -66,13 +66,8 @@ type VerificationTask struct {
 	Status     verificationTaskStatus `bson:"status"`
 	Generation int                    `bson:"generation"`
 
-	// For failed tasks, this stores the document IDs missing on
-	// one cluster or the other.
+	// For recheck tasks, this stores the document IDs to check.
 	Ids []any `bson:"_ids"`
-
-	// For failed tasks, this stores details on documents that exist on
-	// both clusters but don’t match.
-	FailedDocs []VerificationResult `bson:"failed_docs,omitempty"`
 
 	QueryFilter QueryFilter `bson:"query_filter" json:"query_filter"`
 
@@ -304,10 +299,8 @@ func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *Veri
 				bson.M{
 					"$set": bson.M{
 						"status":                 task.Status,
-						"failed_docs":            task.FailedDocs,
 						"source_documents_count": task.SourceDocumentCount,
 						"source_bytes_count":     task.SourceByteCount,
-						"_ids":                   task.Ids,
 					},
 				},
 			)

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -61,7 +61,7 @@ const (
 
 // VerificationTask stores source cluster info
 type VerificationTask struct {
-	PrimaryKey any                    `bson:"_id"`
+	PrimaryKey primitive.ObjectID     `bson:"_id"`
 	Type       verificationTaskType   `bson:"type"`
 	Status     verificationTaskStatus `bson:"status"`
 	Generation int                    `bson:"generation"`

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -48,10 +48,10 @@ const (
 	// --------------------------------------------------
 
 	// The “workhorse” task type: verify a partition of documents.
-	verificationTaskVerifyDocuments verificationTaskType = "verify"
+	verificationTaskVerifyDocuments verificationTaskType = "verifyDocuments"
 
 	// A verifyCollection task verifies collection metadata
-	// and inserts verify-documents tasks to verify data ranges.
+	// and, in generation 0, inserts verify-documents tasks for _id ranges.
 	verificationTaskVerifyCollection verificationTaskType = "verifyCollection"
 
 	// The primary task creates a verifyCollection task for each
@@ -92,13 +92,6 @@ func (t *VerificationTask) augmentLogWithDetails(evt *zerolog.Event) {
 
 func (t *VerificationTask) IsRecheck() bool {
 	return t.Generation > 0
-}
-
-// VerificationRange stores ID ranges for tasks that can be re-used between runs
-type VerificationRange struct {
-	PrimaryKey primitive.ObjectID `bson:"_id"`
-	StartID    primitive.ObjectID `bson:"start_id"`
-	EndID      primitive.ObjectID `bson:"end_id"`
 }
 
 func (verifier *Verifier) insertCollectionVerificationTask(

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -70,9 +70,6 @@ type VerificationTask struct {
 	// one cluster or the other.
 	Ids []any `bson:"_ids"`
 
-	// Deprecated: VerificationTask ID field is ignored by the verifier.
-	ID int `bson:"id"`
-
 	// For failed tasks, this stores details on documents that exist on
 	// both clusters but don’t match.
 	FailedDocs []VerificationResult `bson:"failed_docs,omitempty"`

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -96,7 +96,7 @@ func (t *VerificationTask) augmentLogWithDetails(evt *zerolog.Event) {
 }
 
 func (t *VerificationTask) IsRecheck() bool {
-	return len(t.Ids) > 0
+	return t.Generation > 0
 }
 
 // VerificationRange stores ID ranges for tasks that can be re-used between runs

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -35,13 +35,24 @@ const (
 	// Task statuses:
 	// --------------------------------------------------
 
-	verificationTaskAdded     verificationTaskStatus = "added"
+	// This means the task is ready for work once a worker thread gets to it.
+	verificationTaskAdded verificationTaskStatus = "added"
+
+	// This means a worker thread is actively processing the task.
+	verificationTaskProcessing verificationTaskStatus = "processing"
+
+	// This means no mismatches were found. (Yay!)
 	verificationTaskCompleted verificationTaskStatus = "completed"
-	verificationTaskFailed    verificationTaskStatus = "failed"
-	// This is used for collection verification, and means the task successfully created the data tasks,
-	// but there were mismatches in the metadata/indexes
+
+	// This can mean a few different things. Generally it means that at least
+	// one mismatch was found. (It does *not* mean that the verifier failed to
+	// complete the verification task.)
+	verificationTaskFailed verificationTaskStatus = "failed"
+
+	// This is used for collection verification. It means the task successfully
+	// created the data tasks, but there were mismatches in the
+	// metadata/indexes.
 	verificationTaskMetadataMismatch verificationTaskStatus = "mismatch"
-	verificationTaskProcessing       verificationTaskStatus = "processing"
 
 	// --------------------------------------------------
 	// Task types:


### PR DESCRIPTION
Previously all document mismatches were recorded directly in the verification task. This meant, though, that if a task encompassed a large number of mismatched documents, the verifier could fail to persist all of the mismatches, which caused a crash.

This changeset makes the verifier save mismatches to a dedicated collection instead, one document per mismatch.

This change upends some familiar workflows for investigating mismatches: it’s no longer sufficient just to query the `verification_tasks` collection for mismatch information since the actual mismatches are recorded in a separate collection. To address this, the documentation now gives an aggregation pipeline that yields a similarly-useful result.