### PR TITLE
Fix handling of non-transient errors when processing doc-compare tasks.

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -528,9 +528,9 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 	var bytesCount types.ByteCount
 	var err error
 
-	// Recheck tasks
 	if task.IsRecheck() {
-		idGroups, err := util.SplitArrayByBSONMaxSize(task.Ids, int(verifier.recheckMaxSizeInBytes))
+		var idGroups [][]any
+		idGroups, err = util.SplitArrayByBSONMaxSize(task.Ids, int(verifier.recheckMaxSizeInBytes))
 		if err != nil {
 			return errors.Wrapf(err, "failed to split recheck task %v document IDs", task.PrimaryKey)
 		}


### PR DESCRIPTION
Task failures weren’t being reported “up the chain” because of a scoping bug in the task-execution code. This changeset fixes that bug, so now non-transient task errors will crash the verifier.