### PR TITLE
Switch to annotated tags for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build
         run: |
+          set -o errexit
+          git tag -l
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           set -o errexit
           git tag -l
+          echo ------
           git describe
-          git show
-          git show v0.0.3-alpha7
+          echo "github-ref=$GITHUB_REF"
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -o errexit
           git tag -l
-          git show v0.0.3-alpha3
+          git describe
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
+
+      - name: Get tag name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -35,7 +35,7 @@ jobs:
           echo ------
           git describe
           echo "github-ref=$GITHUB_REF"
-          git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
+          git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}
             export GOARCH=${target#*/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -o errexit
           TAG_NAME=$(git describe --exact-match)
-          git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
+          git tag --list --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}
             export GOARCH=${target#*/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           set -o errexit
           git tag -l
           git describe
+          git show
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Get tag name
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Get tag name
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -33,6 +36,7 @@ jobs:
           set -o errexit
           echo "github-ref=$GITHUB_REF"
           git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
+          cat RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}
             export GOARCH=${target#*/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           set -o errexit
           git tag -l
+          git show v0.0.3-alpha3
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,20 +27,13 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
-      - name: Get tag name
-        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Show tag type
-        run: git cat-file -t "refs/tags/$TAG_NAME"
-
       - name: Set up Go
         uses: actions/setup-go@v4
 
       - name: Build
         run: |
           set -o errexit
-          echo "github-ref=$GITHUB_REF"
-          echo "tag-name=$TAG_NAME"
+          TAG_NAME=$(git describe --exact-match)
           git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
           cat RELEASE-NOTES
           for target in $TARGETS; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Get tag name
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
+      - name: Show tag type
+        run: git cat-file -t "refs/tags/$TAG_NAME"
+
       - name: Set up Go
         uses: actions/setup-go@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           set -o errexit
           echo "github-ref=$GITHUB_REF"
+          echo "tag-name=$TAG_NAME"
           git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
           cat RELEASE-NOTES
           for target in $TARGETS; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           git tag -l
           git describe
           git show
+          git show v0.0.3-alpha6
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
           set -o errexit
           TAG_NAME=$(git describe --exact-match)
           git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
-          cat RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}
             export GOARCH=${target#*/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Build
         run: |
+          git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}
             export GOARCH=${target#*/}
@@ -39,4 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          body_path: RELEASE-NOTES
           files: migration_verifier_*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,8 @@ jobs:
           fetch-depth: 0
 
       # NB: actions/checkout quietly fetches all tags as lightweight tags,
-      # even if they’re annotated upstream. This works around that.
+      # even if they’re annotated upstream. That, of course, prevents use
+      # of the tag message as release notes. This works around that.
       #
       # See https://github.com/actions/checkout/issues/290 for details.
       - name: Fetch tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      # NB: actions/checkout quietly fetches all tags as lightweight tags,
+      # even if they’re annotated upstream. This works around that.
+      #
+      # See https://github.com/actions/checkout/issues/290 for details.
       - name: Fetch tags
         run: git fetch --tags --force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Build
         run: |
           set -o errexit
-          git tag -l
-          echo ------
-          git describe
           echo "github-ref=$GITHUB_REF"
           git tag -l --format='%(contents)' "$TAG_NAME" > RELEASE-NOTES
           for target in $TARGETS; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -33,7 +34,7 @@ jobs:
           git tag -l
           git describe
           git show
-          git show v0.0.3-alpha6
+          git show v0.0.3-alpha7
           git tag -l --format='%(contents)' $(git describe --exact-match) > RELEASE-NOTES
           for target in $TARGETS; do
             export GOOS=${target%/*}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,12 @@
 # Releasing Migration Verifier
 
-To release Migration Verifier, just create a lightweight git tag, thus:
+To release Migration Verifier, create an annotated git tag, thus:
 ```
-git tag v0.0.2
+git tag -a v0.0.2
 ```
-… and push it to upstream.
+The tag contents will be the release notes. See prior releases for the format.
+Once you’re done, push your tag to upstream. A pre-configured GitHub Action
+will create the release.
 
-Versions **MUST** start with a `v` and follow
+**IMPORTANT:** Versions **MUST** start with a `v` and follow
 [semantic versioning](https://semver.org/).
-
-An automated release process will build binaries and make them available
-for download. Check GitHub Actions for progress.
-
-Note that this process **DOES NOT** create release notes. Users should peruse
-the repository’s commit history for changes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 To release Migration Verifier, create an annotated git tag, thus:
 ```
-git tag -a v0.0.2
+git tag --annotate v0.0.2
 ```
 The tag contents will be the release notes. See prior releases for the format.
 Once you’re done, push your tag to upstream. A pre-configured GitHub Action


### PR DESCRIPTION
Annotated tags conveniently facilitate bundling release notes. This changes the build process to require an annotated tag.