### PR TITLE
REP-6461 Allow arbitrary DDL on the destination

### DIFF
--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -784,6 +784,20 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		"should alter capped size",
 	)
 
+	_, err = suite.dstMongoClient.
+		Database(suite.DBNameForTest()).
+		Collection("mycoll").
+		Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys: bson.D{
+				{"foo", 1},
+				{"barbar", 1},
+			},
+		},
+	)
+	suite.Require().NoError(err, "should create index")
+
 	err = verifier.WritesOff(ctx)
 	if err == nil {
 		err = verifierRunner.Await()
@@ -795,6 +809,12 @@ func (suite *IntegrationTestSuite) TestTolerateDestinationCollMod() {
 		logBuffer.String(),
 		"cappedSize",
 		"modify event should be recorded in log",
+	)
+
+	suite.Assert().Contains(
+		logBuffer.String(),
+		"barbar_1",
+		"createIndexes event should be recorded in log",
 	)
 }
 


### PR DESCRIPTION
Some DDL operations are internal to a migration. We currently allow `modify` events for so that capped collections can have their limits set at the end of a migration. We also need to allow `createIndexes` to accommodate migrations where the destination’s indexes are created after initial sync.

Rather than allowing specific events, though, this changeset generalizes tolerance of all unknown events—which should be DDL—on the destination. Any time such an event appears in the destination’s change stream, we now log about it then discard it. We still fail if a DDL event happens on the source. This allows migrator tools flexibility in when they create collections or indexes while still making verification fail if an unsupported event happens on the source.