### PR TITLE
Avoid CGO when building.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,8 @@ buildTime=$(date -u)
 goos=$(go env GOOS)
 goarch=$(go env GOARCH)
 
+export CGO_ENABLED=0
+
 printf 'Building migration-verifier for %s/%s …\n' "$goos" "$goarch"
 printf '\tRevision: %s\n' "$revision"
 printf '\tBuild Time: %s\n' "$buildTime"


### PR DESCRIPTION
This prevents problems when running migration-verifier on older OSes like Amazon Linux 2 (that remain in use).