### PR TITLE
Accelerate change stream handling

### DIFF
--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -446,9 +446,9 @@ func (verifier *Verifier) getGenerationWhileLocked() (int, bool) {
 
 	// As long as no other goroutine has locked the mux this will
 	// usefully panic if the caller neglected the lock.
-	wasUnlocked := verifier.mux.TryRLock()
+	wasUnlocked := verifier.mux.TryLock()
 	if wasUnlocked {
-		verifier.mux.RUnlock()
+		verifier.mux.Unlock()
 		panic("getGenerationWhileLocked() while unlocked")
 	}
 


### PR DESCRIPTION
This makes 2 optimizations to change stream handling:
1. `fullDocument` is replaced, in v4.4+, with just the size of that BSON document. (v4.2 & prior lack the required `$bsonSize` aggregation operator.)
2. Both change streams can now enqueue rechecks concurrently.

In local testing these changes allowed a verification that consistently lagged the change stream (and eventually fell off the oplog) to keep up.