### PR TITLE
Further change stream optimizations

### DIFF
--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -318,7 +318,7 @@ func (csr *ChangeStreamReader) GetChangeStreamFilter() (pipeline mongo.Pipeline)
 		pipeline,
 		bson.D{
 			{"$addFields", bson.D{
-				{"_docID", bson.D{{"_id", "$documentKey._id"}}},
+				{"_docID", "$documentKey._id"},
 
 				{"updateDescription", "$$REMOVE"},
 				{"wallTime", "$$REMOVE"},

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -41,7 +41,6 @@ var supportedEventOpTypes = mapset.NewSet(
 
 // ParsedEvent contains the fields of an event that we have parsed from 'bson.Raw'.
 type ParsedEvent struct {
-	ID           any                            `bson:"_id"`
 	OpType       string                         `bson:"operationType"`
 	Ns           *Namespace                     `bson:"ns,omitempty"`
 	DocID        any                            `bson:"_docID,omitempty"`

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -620,8 +620,7 @@ func (csr *ChangeStreamReader) createChangeStream(
 ) (*mongo.ChangeStream, mongo.Session, primitive.Timestamp, error) {
 	pipeline := csr.GetChangeStreamFilter()
 	opts := options.ChangeStream().
-		SetMaxAwaitTime(maxChangeStreamAwaitTime).
-		SetFullDocument(options.UpdateLookup)
+		SetMaxAwaitTime(maxChangeStreamAwaitTime)
 
 	if csr.clusterInfo.VersionArray[0] >= 6 {
 		opts = opts.SetCustomPipeline(bson.M{"showExpandedEvents": true})

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -124,16 +124,17 @@ func (suite *IntegrationTestSuite) TestChangeStreamFilter_BsonSize() {
 
 	suite.Require().True(cs.Next(ctx), "should get event")
 
-	suite.Require().Equal(
-		"abc",
-		cs.Current.Lookup("documentKey", "_id").StringValue(),
-		"event should reference expected document",
-	)
 	suite.Assert().Less(len(cs.Current), 10_000, "event should not be large")
 
 	parsed := ParsedEvent{}
 	suite.Require().NoError(cs.Decode(&parsed))
 	suite.Require().Equal("insert", parsed.OpType)
+
+	suite.Require().Equal(
+		"abc",
+		parsed.DocID,
+		"event should reference expected document",
+	)
 
 	suite.Require().True(parsed.FullDocLen.IsSome(), "full doc len should be in event")
 	suite.Assert().Greater(parsed.FullDocLen.MustGet(), types.ByteCount(10_000))

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -312,7 +312,8 @@ func (suite *IntegrationTestSuite) TestChangeStreamResumability() {
 			"docID": "heyhey",
 		},
 		recheckDocs[0]["_id"],
-		"recheck doc should have expected ID",
+		"recheck doc (%v) should have expected ID",
+		recheckDocs[0],
 	)
 }
 

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -108,7 +108,6 @@ func (suite *IntegrationTestSuite) TestChangeStreamFilter_BsonSize() {
 	cs, err := suite.srcMongoClient.Watch(
 		ctx,
 		filter,
-		options.ChangeStream().SetFullDocument("updateLookup"),
 	)
 	suite.Require().NoError(err)
 	defer cs.Close(ctx)

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -591,9 +591,6 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Recheck()
 		ctx,
 		changeEventBatch{
 			events: []ParsedEvent{{
-				ID: bson.M{
-					"docID": "ID/docID",
-				},
 				OpType: "insert",
 				Ns:     &Namespace{DB: "mydb", Coll: "coll1"},
 				DocID:  "hoohoo",

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -577,9 +577,7 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Recheck()
 			events: []ParsedEvent{{
 				OpType: "insert",
 				Ns:     &Namespace{DB: "mydb", Coll: "coll2"},
-				DocKey: DocKey{
-					ID: "heyhey",
-				},
+				DocID:  "heyhey",
 				ClusterTime: &primitive.Timestamp{
 					T: uint32(time.Now().Unix()),
 				},
@@ -598,9 +596,7 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Recheck()
 				},
 				OpType: "insert",
 				Ns:     &Namespace{DB: "mydb", Coll: "coll1"},
-				DocKey: DocKey{
-					ID: "hoohoo",
-				},
+				DocID:  "hoohoo",
 				ClusterTime: &primitive.Timestamp{
 					T: uint32(time.Now().Unix()),
 				},
@@ -842,7 +838,7 @@ func (suite *IntegrationTestSuite) TestFailedVerificationTaskInsertions() {
 	err = verifier.InsertFailedCompareRecheckDocs(ctx, "foo.bar2", []any{42}, []int{100})
 	suite.Require().NoError(err)
 	event := ParsedEvent{
-		DocKey: DocKey{ID: int32(55)},
+		DocID:  int32(55),
 		OpType: "delete",
 		Ns: &Namespace{
 			DB:   "foo",

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -48,9 +48,7 @@ func (suite *IntegrationTestSuite) TestFailedCompareThenReplace() {
 
 	event := ParsedEvent{
 		OpType: "insert",
-		DocKey: DocKey{
-			ID: "theDocID",
-		},
+		DocID:  "theDocID",
 		Ns: &Namespace{
 			DB:   "the",
 			Coll: "namespace",


### PR DESCRIPTION
This optimizes the change stream by:
- Removing `updateLookup`. It’s there so that we can group rechecks into more evenly-sized tasks, but the overhead of fetching the document on every change event almost certainly outweighs the more equitable distribution of document sizes across recheck tasks.
- Removing `wallTime`. When change events are small, this uselessly inflates the event.
- Replacing `documentKey` with a new `_docID` field that just contains the document ID, which is the only part of the document key that we actually need.

This also removes the internal ParsedEvent.ID field, which nothing actually needs.