### PR TITLE
Fix $size error in statistics computation.

### DIFF
--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -567,6 +567,34 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	)
 }
 
+func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Metadata() {
+	ctx := suite.Context()
+	verifier := suite.BuildVerifier()
+	verifier.SetVerifyAll(true)
+
+	dbName := suite.DBNameForTest()
+	suite.Require().NoError(
+		verifier.srcClient.Database(dbName).CreateCollection(ctx, "foo"),
+	)
+
+	runner := RunVerifierCheck(ctx, suite.T(), verifier)
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	suite.Require().NoError(runner.StartNextGeneration())
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	stats, err := verifier.GetPersistedNamespaceStatistics(ctx)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(
+		mslices.Of(NamespaceStats{
+			Namespace: dbName + ".foo",
+		}),
+		stats,
+		"stats should be as expected",
+	)
+}
+
 func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Recheck() {
 	ctx := suite.Context()
 	verifier := suite.BuildVerifier()

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -633,12 +633,15 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_OneDoc() 
 	stats, err := verifier.GetPersistedNamespaceStatistics(ctx)
 	suite.Require().NoError(err)
 
+	suite.Require().NotEmpty(stats)
+	suite.Assert().NotZero(stats[0].BytesCompared, "bytes compared should be set")
+
 	suite.Assert().Equal(
 		mslices.Of(NamespaceStats{
 			Namespace:      dbName + ".foo",
 			DocsCompared:   1,
 			TotalDocs:      1,
-			BytesCompared:  types.ByteCount(len(bsonDoc)),
+			BytesCompared:  stats[0].BytesCompared,
 			TotalBytes:     types.ByteCount(len(bsonDoc)),
 			PartitionsDone: 1,
 		}),
@@ -652,12 +655,15 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_OneDoc() 
 	stats, err = verifier.GetPersistedNamespaceStatistics(ctx)
 	suite.Require().NoError(err)
 
+	suite.Require().NotEmpty(stats)
+	suite.Assert().NotZero(stats[0].BytesCompared, "bytes compared should be set")
+
 	suite.Assert().Equal(
 		mslices.Of(NamespaceStats{
 			Namespace:      dbName + ".foo",
 			DocsCompared:   1,
 			TotalDocs:      1,
-			BytesCompared:  types.ByteCount(len(bsonDoc)),
+			BytesCompared:  stats[0].BytesCompared,
 			PartitionsDone: 1,
 
 			// NB: TotalBytes is 0 because we can’t compute that from the

--- a/internal/verifier/statistics.go
+++ b/internal/verifier/statistics.go
@@ -114,7 +114,7 @@ const perNsStatsPipelineTemplate = `[
 				In generation 0 we can get the total docs from the
 				verify-collection tasks.
 
-				In later generations we don’t have verify-collection tasks,
+				In later generations we may not have verify-collection tasks,
 				so we add up the individual recheck batch tasks. Note that,
 				in these tasks source_documents_count refers to the actual
 				number of docs found on the source, not all the documents
@@ -122,13 +122,17 @@ const perNsStatsPipelineTemplate = `[
 			*/}}
 			"totalDocs": {
 				"$cond": {
-					"if": { "$eq": [ "$type", "{{.VerifyDocsType}}" ] },
+					"if": {"$eq": [ "$generation", 0 ]},
 					"then": { "$cond": {
-						"if": {"$eq": [ "$generation", 0 ]},
+						"if": { "$eq": [ "$type", "{{.VerifyCollType}}" ] },
 						"then": "$source_documents_count",
-						"else": { "$size": "$_ids" }
+						"else": 0
 					} },
-					"else": 0
+					"else": { "$cond": {
+						"if": { "$eq": [ "$type", "{{.VerifyDocsType}}" ] },
+						"then": { "$size": "$_ids" },
+						"else": 0
+					} }
 				}
 			},
 

--- a/internal/verifier/statistics.go
+++ b/internal/verifier/statistics.go
@@ -122,20 +122,11 @@ const perNsStatsPipelineTemplate = `[
 			*/}}
 			"totalDocs": {
 				"$cond": {
-					"if": { "$or": [
-						{ "$eq": [ "$type", "{{.VerifyCollType}}" ] },
-						{ "$and": [
-							{ "$eq": [ "$type", "{{.VerifyDocsType}}" ] },
-							{ "$ne": [ "$generation", 0 ] }
-						] }
-					] },
+					"if": { "$eq": [ "$type", "{{.VerifyDocsType}}" ] },
 					"then": { "$cond": {
-						"if": { "$and": [
-							{ "$gt": [ "$generation", 0 ] },
-							{ "$eq": [ "array", { "$type": "$_ids" } ] }
-						] },
-						"then": { "$size": "$_ids" },
-						"else": "$source_documents_count"
+						"if": {"$eq": [ "$generation", 0 ]},
+						"then": "$source_documents_count",
+						"else": { "$size": "$_ids" }
 					} },
 					"else": 0
 				}

--- a/internal/verifier/statistics.go
+++ b/internal/verifier/statistics.go
@@ -121,21 +121,24 @@ const perNsStatsPipelineTemplate = `[
 				checked.
 			*/}}
 			"totalDocs": {
-				"$cond": [
-					{ "$or": [
+				"$cond": {
+					"if": { "$or": [
 						{ "$eq": [ "$type", "{{.VerifyCollType}}" ] },
 						{ "$and": [
 							{ "$eq": [ "$type", "{{.VerifyDocsType}}" ] },
 							{ "$ne": [ "$generation", 0 ] }
 						] }
 					] },
-					{ "$cond": [
-						{"$eq": [ "$generation", 0 ]},
-						"$source_documents_count",
-						{ "$size": "$_ids" }
-					] },
-					0
-				]
+					"then": { "$cond": {
+						"if": { "$and": [
+							{ "$gt": [ "$generation", 0 ] },
+							{ "$eq": [ "array", { "$type": "$_ids" } ] }
+						] },
+						"then": { "$size": "$_ids" },
+						"else": "$source_documents_count"
+					} },
+					"else": 0
+				}
 			},
 
 			{{/*


### PR DESCRIPTION
Commit b4467f7a broke statistics computation when a recheck generation includes a collection-metadata task, e.g., if an index or collection attribute mismatches.

This fixes that by refining the aggregation logic. Tests are added to shore up this functionality.