### PR TITLE
Add time-series support

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -98,9 +98,11 @@ jobs:
       - name: Install m and mtools
         run: |-
             {
-                echo npm install -g m
+                curl -fsSL https://raw.githubusercontent.com/aheckmann/m/master/bin/m > /usr/local/bin/m && chmod +x /usr/local/bin/m
                 echo pipx install 'mtools[all]'
             } | parallel
+
+      - run: export M_DEBUG=1
 
       - name: Install MongoDB ${{ matrix.mongodb_versions[0] }} (source)
         run: yes | m ${{ matrix.mongodb_versions[0] }} && dirname $(readlink $(which mongod)) > .srcpath

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         include:
 
-          # Testing fallback when `hello` isn’t implemented
-          # (but appendOplogNote is).
-          - mongodb_versions: [ '4.2.5', '6.0' ]
-            topology:
-              name: replset
-              srcConnStr: mongodb://localhost:27020,localhost:27021,localhost:27022
-              dstConnStr: mongodb://localhost:27030,localhost:27031,localhost:27032
+#          # Testing fallback when `hello` isn’t implemented
+#          # (but appendOplogNote is).
+#          - mongodb_versions: [ '4.2.5', '6.0' ]
+#            topology:
+#              name: replset
+#              srcConnStr: mongodb://localhost:27020,localhost:27021,localhost:27022
+#              dstConnStr: mongodb://localhost:27030,localhost:27031,localhost:27032
 
         exclude:
           - mongodb_versions: [ '4.2', '4.2' ]
@@ -34,10 +34,10 @@ jobs:
 
         # versions are: source, destination
         mongodb_versions:
-          - [ '4.2', '4.2' ]
-          - [ '4.2', '4.4' ]
-          - [ '4.2', '5.0' ]
-          - [ '4.2', '6.0' ]
+#          - [ '4.2', '4.2' ]
+#          - [ '4.2', '4.4' ]
+#          - [ '4.2', '5.0' ]
+#          - [ '4.2', '6.0' ]
 
           - [ '4.4', '4.4' ]
           - [ '4.4', '5.0' ]
@@ -98,11 +98,9 @@ jobs:
       - name: Install m and mtools
         run: |-
             {
-                curl -fsSL https://raw.githubusercontent.com/aheckmann/m/master/bin/m > /usr/local/bin/m && chmod +x /usr/local/bin/m
+                echo npm install -g m
                 echo pipx install 'mtools[all]'
             } | parallel
-
-      - run: export M_DEBUG=1
 
       - name: Install MongoDB ${{ matrix.mongodb_versions[0] }} (source)
         run: yes | m ${{ matrix.mongodb_versions[0] }} && dirname $(readlink $(which mongod)) > .srcpath

--- a/README.md
+++ b/README.md
@@ -357,8 +357,12 @@ Additionally, because the amount of data sent to migration-verifier doesn’t ac
 
 - If the server’s memory usage rises after generation 0, try reducing `recheckMaxSizeMB`. This will shrink the queries that the verifier sends, which in turn should reduce the server’s memory usage. (The number of actual queries sent will rise, of course.)
 
+## Time-Series Collections
+
+Because the verifier compares documents by `_id`, it cannot compare logical time-series measurements (i.e., the data that users actually insert). Instead it compares the server’s internal time-series “buckets”. Unfortunately, this makes mismatch details essentially useless with time-series since they will be details about time-series buckets, which users generally don’t see.
+
+NB: Given bucket documents’ size, hashed document comparison can be especially useful with time-series.
+
 # Limitations
 
-- The verifier’s iterative process can handle data changes while it is running, until you hit the writesOff endpoint.  However, it cannot handle DDL commands.  If the verifier receives a DDL change stream event, the verification will fail.
-
-- The verifier crashes if it tries to compare time-series collections. The error will include a phrase like “Collection has nil UUID (most probably is a view)” and also mention “timeseries”.
+- The verifier’s iterative process can handle data changes while it is running, until you hit the writesOff endpoint.  However, it cannot handle DDL commands.  If the verifier receives a DDL change stream event from the source, the verification will fail permanently.

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -619,11 +619,15 @@ func (csr *ChangeStreamReader) createChangeStream(
 ) (*mongo.ChangeStream, mongo.Session, primitive.Timestamp, error) {
 	pipeline := csr.GetChangeStreamFilter()
 	opts := options.ChangeStream().
-		SetMaxAwaitTime(maxChangeStreamAwaitTime).
-		SetCustom(bson.M{"showSystemEvents": true})
+		SetMaxAwaitTime(maxChangeStreamAwaitTime)
 
 	if csr.clusterInfo.VersionArray[0] >= 6 {
-		opts = opts.SetCustomPipeline(bson.M{"showExpandedEvents": true})
+		opts = opts.SetCustomPipeline(
+			bson.M{
+				"showSystemEvents":   true,
+				"showExpandedEvents": true,
+			},
+		)
 	}
 
 	savedResumeToken, err := csr.loadChangeStreamResumeToken(ctx)

--- a/internal/verifier/change_stream.go
+++ b/internal/verifier/change_stream.go
@@ -619,7 +619,8 @@ func (csr *ChangeStreamReader) createChangeStream(
 ) (*mongo.ChangeStream, mongo.Session, primitive.Timestamp, error) {
 	pipeline := csr.GetChangeStreamFilter()
 	opts := options.ChangeStream().
-		SetMaxAwaitTime(maxChangeStreamAwaitTime)
+		SetMaxAwaitTime(maxChangeStreamAwaitTime).
+		SetCustom(bson.M{"showSystemEvents": true})
 
 	if csr.clusterInfo.VersionArray[0] >= 6 {
 		opts = opts.SetCustomPipeline(bson.M{"showExpandedEvents": true})

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/exp/slices"
 )
 
 type GenerationStatus string
@@ -459,7 +460,7 @@ func (verifier *Verifier) CreateInitialTasksIfNeeded(ctx context.Context) error 
 	}
 	isPrimary, err := verifier.CreatePrimaryTaskIfNeeded(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating primary task")
 	}
 	if !isPrimary {
 		verifier.logger.Info().Msg("Primary task already existed; skipping setup")
@@ -468,9 +469,15 @@ func (verifier *Verifier) CreateInitialTasksIfNeeded(ctx context.Context) error 
 	if verifier.verifyAll {
 		err := verifier.setupAllNamespaceList(ctx)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "creating namespace list")
 		}
 	}
+
+	err = verifier.addTimeseriesBucketsToNamespaces(ctx)
+	if err != nil {
+		return errors.Wrap(err, "adding timeseries buckets to namespaces")
+	}
+
 	for _, src := range verifier.srcNamespaces {
 		_, err := verifier.InsertCollectionVerificationTask(ctx, src)
 		if err != nil {
@@ -480,15 +487,88 @@ func (verifier *Verifier) CreateInitialTasksIfNeeded(ctx context.Context) error 
 				src,
 			)
 		}
-	}
 
-	verifier.gen0PendingCollectionTasks.Store(int32(len(verifier.srcNamespaces)))
+		verifier.gen0PendingCollectionTasks.Add(1)
+	}
 
 	err = verifier.UpdatePrimaryTaskComplete(ctx)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) error {
+	srcTimeseriesNamespaces, err := whichNamespacesAreTimeseries(
+		ctx,
+		verifier.srcClient,
+		mapset.NewSet(verifier.srcNamespaces...),
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetching timeseries namespaces")
+	}
+
+	for _, srcNS := range slices.Clone(verifier.srcNamespaces) {
+		if !srcTimeseriesNamespaces.Contains(srcNS) {
+			continue
+		}
+
+		dstNS, ok := verifier.nsMap.GetDstNamespace(srcNS)
+		if !ok {
+			return fmt.Errorf("found no dst namespace for %#q", srcNS)
+		}
+
+		verifier.srcNamespaces = append(
+			verifier.srcNamespaces,
+			"system.buckets."+srcNS,
+		)
+
+		verifier.dstNamespaces = append(
+			verifier.dstNamespaces,
+			"system.buckets."+dstNS,
+		)
+	}
+
+	return nil
+}
+
+func whichNamespacesAreTimeseries(
+	ctx context.Context,
+	client *mongo.Client,
+	namespaces mapset.Set[string],
+) (mapset.Set[string], error) {
+	tsNamespaces := mapset.NewSet[string]()
+
+	dbNamespaces := map[string]mapset.Set[string]{}
+
+	for ns := range namespaces.Iter() {
+		db, coll := SplitNamespace(ns)
+		if set, exists := dbNamespaces[db]; exists {
+			set.Add(coll)
+		} else {
+			dbNamespaces[db] = mapset.NewSet(coll)
+		}
+	}
+
+	for db, colls := range dbNamespaces {
+		specs, err := client.Database(db).ListCollectionSpecifications(
+			ctx,
+			bson.D{
+				{"type", "timeseries"},
+				{"name", bson.D{{"$in", colls.ToSlice()}}},
+			},
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "listing %#q’s timeseries namespaces", db)
+		}
+
+		for _, spec := range specs {
+			tsNamespaces.Add(db + "." + spec.Name)
+		}
+	}
+
+	return tsNamespaces, nil
 }
 
 func FetchFailedAndIncompleteTasks(

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"golang.org/x/exp/slices"
 )
 
 type GenerationStatus string
@@ -487,88 +486,15 @@ func (verifier *Verifier) CreateInitialTasksIfNeeded(ctx context.Context) error 
 				src,
 			)
 		}
-
-		verifier.gen0PendingCollectionTasks.Add(1)
 	}
+
+	verifier.gen0PendingCollectionTasks.Store(int32(len(verifier.srcNamespaces)))
 
 	err = verifier.UpdatePrimaryTaskComplete(ctx)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) error {
-	srcTimeseriesNamespaces, err := whichNamespacesAreTimeseries(
-		ctx,
-		verifier.srcClient,
-		mapset.NewSet(verifier.srcNamespaces...),
-	)
-	if err != nil {
-		return errors.Wrap(err, "fetching timeseries namespaces")
-	}
-
-	for _, srcNS := range slices.Clone(verifier.srcNamespaces) {
-		if !srcTimeseriesNamespaces.Contains(srcNS) {
-			continue
-		}
-
-		dstNS, ok := verifier.nsMap.GetDstNamespace(srcNS)
-		if !ok {
-			return fmt.Errorf("found no dst namespace for %#q", srcNS)
-		}
-
-		verifier.srcNamespaces = append(
-			verifier.srcNamespaces,
-			"system.buckets."+srcNS,
-		)
-
-		verifier.dstNamespaces = append(
-			verifier.dstNamespaces,
-			"system.buckets."+dstNS,
-		)
-	}
-
-	return nil
-}
-
-func whichNamespacesAreTimeseries(
-	ctx context.Context,
-	client *mongo.Client,
-	namespaces mapset.Set[string],
-) (mapset.Set[string], error) {
-	tsNamespaces := mapset.NewSet[string]()
-
-	dbNamespaces := map[string]mapset.Set[string]{}
-
-	for ns := range namespaces.Iter() {
-		db, coll := SplitNamespace(ns)
-		if set, exists := dbNamespaces[db]; exists {
-			set.Add(coll)
-		} else {
-			dbNamespaces[db] = mapset.NewSet(coll)
-		}
-	}
-
-	for db, colls := range dbNamespaces {
-		specs, err := client.Database(db).ListCollectionSpecifications(
-			ctx,
-			bson.D{
-				{"type", "timeseries"},
-				{"name", bson.D{{"$in", colls.ToSlice()}}},
-			},
-		)
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "listing %#q’s timeseries namespaces", db)
-		}
-
-		for _, spec := range specs {
-			tsNamespaces.Add(db + "." + spec.Name)
-		}
-	}
-
-	return tsNamespaces, nil
 }
 
 func FetchFailedAndIncompleteTasks(

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -69,7 +69,9 @@ func ListAllUserNamespaces(
 					"name",
 					mslices.Of(ExcludedSystemCollPrefix),
 				),
-				mmongo.StartsWithAgg("$name", "system.buckets."),
+				bson.D{
+					{"$expr", mmongo.StartsWithAgg("$name", "system.buckets.")},
+				},
 			}},
 		}
 

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -69,7 +69,7 @@ func ListAllUserNamespaces(
 					"name",
 					mslices.Of(ExcludedSystemCollPrefix),
 				),
-				bson.D{
+				{
 					{"$expr", mmongo.StartsWithAgg("$name", "system.buckets.")},
 				},
 			}},

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1120,7 +1120,6 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		}
 		task.Status = verificationTaskMetadataMismatch
 	}
-
 	if !verifyData {
 		// If the metadata mismatched and we're not checking the actual data, that's a complete failure.
 		if task.Status == verificationTaskMetadataMismatch {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -827,11 +827,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 	switch srcSpec.Type {
 	case "collection":
 		canCompareData = true
-	case "view":
-	case "timeseries":
-		if !verifier.verifyAll {
-			return nil, false, fmt.Errorf("cannot verify time-series collection (%#q) under namespace filtering", srcNs)
-		}
+	case "view", "timeseries":
 	default:
 		return nil, false, fmt.Errorf("unrecognized collection type (spec: %+v)", srcSpec)
 	}

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1124,6 +1124,7 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		}
 		task.Status = verificationTaskMetadataMismatch
 	}
+
 	if !verifyData {
 		// If the metadata mismatched and we're not checking the actual data, that's a complete failure.
 		if task.Status == verificationTaskMetadataMismatch {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -822,8 +822,20 @@ func (verifier *Verifier) compareCollectionSpecifications(
 		}
 	}
 
-	// Don't compare view data; they have no data of their own.
-	canCompareData := srcSpec.Type != "view"
+	var canCompareData bool
+
+	switch srcSpec.Type {
+	case "collection":
+		canCompareData = true
+	case "view":
+	case "timeseries":
+		if !verifier.verifyAll {
+			return nil, false, fmt.Errorf("cannot verify time-series collection (%#q) under namespace filtering", srcNs)
+		}
+	default:
+		return nil, false, fmt.Errorf("unrecognized collection type (spec: %+v)", srcSpec)
+	}
+
 	// Do not compare data between capped and uncapped collections because the partitioning is different.
 	canCompareData = canCompareData && srcSpec.Options.Lookup("capped").Equal(dstSpec.Options.Lookup("capped"))
 

--- a/internal/verifier/nsmap.go
+++ b/internal/verifier/nsmap.go
@@ -1,5 +1,7 @@
 package verifier
 
+import "fmt"
+
 type NSMap struct {
 	srcDstNsMap map[string]string
 	dstSrcNsMap map[string]string
@@ -18,15 +20,9 @@ func (nsmap *NSMap) PopulateWithNamespaces(srcNamespaces []string, dstNamespaces
 	}
 
 	for i, srcNs := range srcNamespaces {
-		dstNs := dstNamespaces[i]
-		if _, exist := nsmap.srcDstNsMap[srcNs]; exist {
-			panic("another mapping already exists for source namespace " + srcNs)
+		if err := nsmap.Augment(srcNs, dstNamespaces[i]); err != nil {
+			panic(err.Error())
 		}
-		if _, exist := nsmap.dstSrcNsMap[dstNs]; exist {
-			panic("another mapping already exists for destination namespace " + dstNs)
-		}
-		nsmap.srcDstNsMap[srcNs] = dstNs
-		nsmap.dstSrcNsMap[dstNs] = srcNs
 	}
 }
 
@@ -36,6 +32,20 @@ func (nsmap *NSMap) Len() int {
 	}
 
 	return len(nsmap.srcDstNsMap)
+}
+
+func (nsmap *NSMap) Augment(srcNs, dstNs string) error {
+	if _, exist := nsmap.srcDstNsMap[srcNs]; exist {
+		return fmt.Errorf("another mapping already exists for source namespace %#q", srcNs)
+	}
+	if _, exist := nsmap.dstSrcNsMap[dstNs]; exist {
+		return fmt.Errorf("another mapping already exists for destination namespace %#q", dstNs)
+	}
+
+	nsmap.srcDstNsMap[srcNs] = dstNs
+	nsmap.dstSrcNsMap[dstNs] = srcNs
+
+	return nil
 }
 
 func (nsmap *NSMap) GetDstNamespace(srcNamespace string) (string, bool) {

--- a/internal/verifier/timeseries.go
+++ b/internal/verifier/timeseries.go
@@ -1,0 +1,97 @@
+package verifier
+
+import (
+	"context"
+	"fmt"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/exp/slices"
+)
+
+func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) error {
+	srcTimeseriesNamespaces, err := whichNamespacesAreTimeseries(
+		ctx,
+		verifier.srcClient,
+		mapset.NewSet(verifier.srcNamespaces...),
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetching timeseries namespaces")
+	}
+
+	for _, srcNS := range slices.Clone(verifier.srcNamespaces) {
+		if !srcTimeseriesNamespaces.Contains(srcNS) {
+			continue
+		}
+
+		dstNS, ok := verifier.nsMap.GetDstNamespace(srcNS)
+		if !ok {
+			return fmt.Errorf("found no dst namespace for %#q", srcNS)
+		}
+
+		srcBuckets := "system.buckets." + srcNS
+		dstBuckets := "system.buckets." + dstNS
+
+		verifier.srcNamespaces = append(
+			verifier.srcNamespaces,
+			srcBuckets,
+		)
+
+		verifier.dstNamespaces = append(
+			verifier.dstNamespaces,
+			dstBuckets,
+		)
+
+		if err := verifier.nsMap.Augment(srcBuckets, dstBuckets); err != nil {
+			return errors.Wrapf(
+				err,
+				"adding %#q -> %#q to internal namespace map",
+				srcBuckets,
+				dstBuckets,
+			)
+		}
+	}
+
+	return nil
+}
+
+func whichNamespacesAreTimeseries(
+	ctx context.Context,
+	client *mongo.Client,
+	namespaces mapset.Set[string],
+) (mapset.Set[string], error) {
+	tsNamespaces := mapset.NewSet[string]()
+
+	dbNamespaces := map[string]mapset.Set[string]{}
+
+	for ns := range namespaces.Iter() {
+		db, coll := SplitNamespace(ns)
+		if set, exists := dbNamespaces[db]; exists {
+			set.Add(coll)
+		} else {
+			dbNamespaces[db] = mapset.NewSet(coll)
+		}
+	}
+
+	for db, colls := range dbNamespaces {
+		specs, err := client.Database(db).ListCollectionSpecifications(
+			ctx,
+			bson.D{
+				{"type", "timeseries"},
+				{"name", bson.D{{"$in", colls.ToSlice()}}},
+			},
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "listing %#q’s timeseries namespaces", db)
+		}
+
+		for _, spec := range specs {
+			tsNamespaces.Add(db + "." + spec.Name)
+		}
+	}
+
+	return tsNamespaces, nil
+}

--- a/internal/verifier/timeseries.go
+++ b/internal/verifier/timeseries.go
@@ -28,9 +28,16 @@ func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) 
 			continue
 		}
 
-		dstNS, ok := verifier.nsMap.GetDstNamespace(srcNS)
-		if !ok {
-			return fmt.Errorf("found no dst namespace for %#q", srcNS)
+		var dstNS string
+
+		if verifier.nsMap.Len() == 0 {
+			dstNS = srcNS
+		} else {
+			var ok bool
+			dstNS, ok = verifier.nsMap.GetDstNamespace(srcNS)
+			if !ok {
+				return fmt.Errorf("found no dst namespace for %#q", srcNS)
+			}
 		}
 
 		srcBuckets := "system.buckets." + srcNS
@@ -46,13 +53,15 @@ func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) 
 			dstBuckets,
 		)
 
-		if err := verifier.nsMap.Augment(srcBuckets, dstBuckets); err != nil {
-			return errors.Wrapf(
-				err,
-				"adding %#q -> %#q to internal namespace map",
-				srcBuckets,
-				dstBuckets,
-			)
+		if verifier.nsMap.Len() > 0 {
+			if err := verifier.nsMap.Augment(srcBuckets, dstBuckets); err != nil {
+				return errors.Wrapf(
+					err,
+					"adding %#q -> %#q to internal namespace map",
+					srcBuckets,
+					dstBuckets,
+				)
+			}
 		}
 	}
 

--- a/internal/verifier/timeseries.go
+++ b/internal/verifier/timeseries.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// This method augments the verifier’s in-memory state to track the
+// `system.buckets.*` collection for each timeseries collection.
 func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) error {
 	srcTimeseriesNamespaces, err := whichNamespacesAreTimeseries(
 		ctx,

--- a/internal/verifier/timeseries.go
+++ b/internal/verifier/timeseries.go
@@ -40,8 +40,11 @@ func (verifier *Verifier) addTimeseriesBucketsToNamespaces(ctx context.Context) 
 			}
 		}
 
-		srcBuckets := "system.buckets." + srcNS
-		dstBuckets := "system.buckets." + dstNS
+		srcDB, srcColl := SplitNamespace(srcNS)
+		srcBuckets := srcDB + ".system.buckets." + srcColl
+
+		dstDB, dstColl := SplitNamespace(dstNS)
+		dstBuckets := dstDB + ".system.buckets." + dstColl
 
 		verifier.srcNamespaces = append(
 			verifier.srcNamespaces,

--- a/internal/verifier/timeseries_test.go
+++ b/internal/verifier/timeseries_test.go
@@ -19,6 +19,7 @@ func (suite *IntegrationTestSuite) TestTimeSeries_Simple() {
 	}
 
 	dbName := suite.DBNameForTest()
+	collName := "weather"
 	now := time.Now()
 
 	for _, client := range mslices.Of(suite.srcMongoClient, suite.dstMongoClient) {
@@ -36,7 +37,7 @@ func (suite *IntegrationTestSuite) TestTimeSeries_Simple() {
 	}
 
 	srcDB := suite.srcMongoClient.Database(dbName)
-	_, err := srcDB.Collection("weather").InsertOne(ctx, bson.D{
+	_, err := srcDB.Collection(collName).InsertOne(ctx, bson.D{
 		{"time", now},
 		{"metadata", 234.0},
 	})
@@ -44,8 +45,8 @@ func (suite *IntegrationTestSuite) TestTimeSeries_Simple() {
 
 	copyDocs(
 		suite.T(),
-		srcDB.Collection("system.buckets.weather"),
-		suite.dstMongoClient.Database(dbName).Collection("system.buckets.weather"),
+		srcDB.Collection("system.buckets."+collName),
+		suite.dstMongoClient.Database(dbName).Collection("system.buckets."+collName),
 	)
 
 	verifier := suite.BuildVerifier()

--- a/internal/verifier/timeseries_test.go
+++ b/internal/verifier/timeseries_test.go
@@ -1,0 +1,112 @@
+package verifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/10gen/migration-verifier/mslices"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (suite *IntegrationTestSuite) TestTimeSeries_Simple() {
+	ctx := suite.Context()
+
+	if suite.BuildVerifier().srcClusterInfo.VersionArray[0] < 6 {
+		suite.T().Skipf("Need a source version with time-series support.")
+	}
+
+	dbName := suite.DBNameForTest()
+	now := time.Now()
+
+	for _, client := range mslices.Of(suite.srcMongoClient, suite.dstMongoClient) {
+		suite.Require().NoError(
+			client.Database(dbName).CreateCollection(
+				ctx,
+				"weather",
+				options.CreateCollection().SetTimeSeriesOptions(
+					options.TimeSeries().
+						SetTimeField("time").
+						SetMetaField("metadata"),
+				),
+			),
+		)
+	}
+
+	srcDB := suite.srcMongoClient.Database(dbName)
+	_, err := srcDB.Collection("weather").InsertOne(ctx, bson.D{
+		{"time", now},
+		{"metadata", 234.0},
+	})
+	suite.Require().NoError(err, "should insert measurement")
+
+	copyDocs(
+		suite.T(),
+		srcDB.Collection("system.buckets.weather"),
+		suite.dstMongoClient.Database(dbName).Collection("system.buckets.weather"),
+	)
+
+	verifier := suite.BuildVerifier()
+	verifier.SetVerifyAll(true)
+
+	runner := RunVerifierCheck(ctx, suite.T(), verifier)
+	suite.Require().NoError(runner.AwaitGenerationEnd())
+
+	verificationStatus, err := verifier.GetVerificationStatus(ctx)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(
+		0,
+		verificationStatus.FailedTasks,
+		"should be no failed tasks",
+	)
+	suite.Assert().Equal(
+		3,
+		verificationStatus.CompletedTasks,
+		"should be completed: view meta, buckets meta, and buckets docs",
+	)
+
+	_, err = srcDB.Collection("weather").InsertOne(ctx, bson.D{
+		{"time", now},
+		{"metadata", 234.0},
+	})
+	suite.Require().NoError(err, "should insert measurement (dupe)")
+
+	suite.Assert().Eventually(
+		func() bool {
+			suite.Require().NoError(runner.StartNextGeneration())
+			suite.Require().NoError(runner.AwaitGenerationEnd())
+
+			verificationStatus, err := verifier.GetVerificationStatus(ctx)
+			suite.Require().NoError(err)
+
+			return verificationStatus.FailedTasks > 0
+		},
+		time.Minute,
+		50*time.Millisecond,
+		"uncopied update on source should trigger failure",
+	)
+}
+
+func copyDocs(
+	t *testing.T,
+	srcColl, dstColl *mongo.Collection,
+) {
+	ctx := t.Context()
+
+	cursor, err := srcColl.Find(ctx, bson.D{})
+	require.NoError(t, err, "should open src cursor")
+
+	inserted := 0
+	for cursor.Next(ctx) {
+		_, err := dstColl.InsertOne(ctx, cursor.Current)
+		require.NoError(t, err, "should insert on dst")
+
+		inserted++
+	}
+
+	require.NoError(t, cursor.Err(), "should iterate src cursor")
+
+	t.Logf("Copied %d docs %#q -> %#q", inserted, FullName(srcColl), FullName(dstColl))
+}


### PR DESCRIPTION
This changeset adds time-series support. It works with & without namespace filtering.

Because of the verifier’s `_id` dependency, this verifies buckets rather than logical measurements. This implies a requirement that the migration copy time-series collections via buckets as well since a logical replication would not preserve artifacts like bucket `_id` or even the grouping of measurements.

Because of the bucket-level verification, details in mismatch reports are not very useful for time-series because they reference bucket-level fields that the logical API doesn’t expose.