### PR TITLE
Parallelize persistence of mismatches

### DIFF
--- a/arenabuf/arenabuf.go
+++ b/arenabuf/arenabuf.go
@@ -1,0 +1,38 @@
+// Package arenabuf exposes a type that simplifies using a single backing array
+// for multiple byte slices.
+package arenabuf
+
+type bufferType interface {
+	~[]byte
+}
+
+// Buffer tracks multiple buffers in a single “arena” buffer.
+type Buffer[T bufferType] struct {
+	buf    []byte
+	slices []T
+}
+
+// Add copies a new slice to the Buffer’s internals and returns the copied
+// slice.
+func (b *Buffer[T]) Add(in T) T {
+	start := len(b.buf)
+	b.buf = append(b.buf, in...)
+
+	newSlice := b.buf[start:]
+	b.slices = append(b.slices, newSlice)
+
+	return newSlice
+}
+
+// Slices returns the Buffer’s internally-tracked slices.
+func (b *Buffer[T]) Slices() []T {
+	return b.slices
+}
+
+// Reset creates a new backing buffer & slices. To minimize allocations on
+// subsequent Add() calls, this makes the new buffer & slices the same size as
+// the existing ones.
+func (b *Buffer[T]) Reset() {
+	b.buf = make([]byte, 0, len(b.buf))
+	b.slices = make([]T, 0, len(b.slices))
+}

--- a/internal/verifier/mismatches.go
+++ b/internal/verifier/mismatches.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/10gen/migration-verifier/agg"
 	"github.com/10gen/migration-verifier/agg/accum"
+	"github.com/10gen/migration-verifier/arenabuf"
 	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/option"
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -19,6 +19,9 @@ import (
 
 const (
 	mismatchesCollectionName = "mismatches"
+
+	maxMismatchBatchBytes = 5 << 20
+	maxMismatchCount      = 10_000
 )
 
 type MismatchInfo struct {
@@ -313,22 +316,50 @@ func recordMismatches(
 		panic("empty task ID given")
 	}
 
-	models := lo.Map(
-		problems,
-		func(r VerificationResult, _ int) mongo.WriteModel {
-			return &mongo.InsertOneModel{
-				Document: MismatchInfo{
-					Task:   taskID,
-					Detail: r,
-				}.MarshalToBSON(),
-			}
-		},
-	)
+	totalBytes := 0
 
-	_, err := db.Collection(mismatchesCollectionName).BulkWrite(
-		ctx,
-		models,
-	)
+	buf := &arenabuf.Buffer[bson.Raw]{}
 
-	return errors.Wrapf(err, "recording %d mismatches", len(models))
+	eg, egCtx := contextplus.ErrGroup(ctx)
+
+	var flush = func() {
+		batch := buf.Slices()
+
+		buf.Reset()
+
+		eg.Go(func() error {
+			_, err := db.Collection(mismatchesCollectionName).InsertMany(
+				egCtx,
+				batch,
+				options.InsertMany().SetOrdered(false),
+			)
+
+			return errors.Wrapf(err, "persisting batch of %d mismatches for task %v", len(batch), taskID)
+		})
+	}
+
+	var nextMismatch bson.Raw
+
+	for _, prob := range problems {
+		nextMismatch = MismatchInfo{
+			Task:   taskID,
+			Detail: prob,
+		}.MarshalToBSON()
+
+		if totalBytes+len(nextMismatch) > maxMismatchBatchBytes {
+			flush()
+		}
+
+		buf.Add(nextMismatch)
+
+		if len(buf.Slices()) == maxMismatchCount {
+			flush()
+		}
+	}
+
+	if len(buf.Slices()) > 0 {
+		flush()
+	}
+
+	return eg.Wait()
 }

--- a/internal/verifier/mismatches.go
+++ b/internal/verifier/mismatches.go
@@ -20,8 +20,10 @@ import (
 const (
 	mismatchesCollectionName = "mismatches"
 
-	maxMismatchBatchBytes = 5 << 20
-	maxMismatchCount      = 10_000
+	// These are chosen somewhat arbitrarily:
+	defaultMaxMismatchCount = 50_000
+	maxMismatchRequests     = 10
+	maxMismatchBatchBytes   = 5 << 20
 )
 
 type MismatchInfo struct {
@@ -312,6 +314,15 @@ func recordMismatches(
 	taskID bson.ObjectID,
 	problems []VerificationResult,
 ) error {
+
+	// If the # of problems is so great that honoring the default max mismatches
+	// per request would create “too many” requests, then pack more mismatches
+	// per request.
+	maxMismatchCount := max(
+		defaultMaxMismatchCount,
+		len(problems)/maxMismatchRequests,
+	)
+
 	if option.IfNotZero(taskID).IsNone() {
 		panic("empty task ID given")
 	}


### PR DESCRIPTION
This changeset rewrites recordMismatches() to parallelize requests. This prevents a single, over-large request from blocking if there are many thousands of documents to recheck.