### PR TITLE
Ensure causal consistency when processing recheck queue

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -183,11 +183,14 @@ jobs:
 
       - name: Build migration-verifier & start clusters
         run: |-
+            metaArgs="$(perl -e'print rand > 0.5 ? q<--replicaset --nodes 1> : q<--single>')"
+            echo "Metadata mlaunch args: $metaArgs"
+
             {
                 echo ./build.sh
                 echo mlaunch init --binarypath $(cat .srcpath) --port 27020 --dir src --replicaset ${{ (matrix.topology == 'sharded') && '--sharded 2' || '' }}
                 echo mlaunch init --binarypath $(cat .dstpath) --port 27030 --dir dst --replicaset ${{ (matrix.topology == 'sharded' || matrix.topology == 'replset-to-sharded') && '--sharded 2' || '' }}
-                echo mlaunch init --binarypath $(cat .metapath) --port 27040 --dir meta --single
+                echo mlaunch init --binarypath $(cat .metapath) --port 27040 --dir meta $metaArgs
             } | parallel
 
       - name: Set Source FCV

--- a/internal/util/clusterinfo.go
+++ b/internal/util/clusterinfo.go
@@ -49,8 +49,9 @@ func ClusterHasCurrentOpIdleCursors(va [2]int) bool {
 var ClusterHasChangeStreamStartAfter = ClusterHasCurrentOpIdleCursors
 
 const (
-	TopologySharded ClusterTopology = "sharded"
-	TopologyReplset ClusterTopology = "replset"
+	TopologySharded    ClusterTopology = "sharded"
+	TopologyReplset    ClusterTopology = "replset"
+	TopologyStandalone ClusterTopology = "standalone"
 )
 
 func CmpMinorVersions(a, b [2]int) int {
@@ -86,7 +87,16 @@ func getTopology(ctx context.Context, client *mongo.Client) (ClusterTopology, er
 		return "", errors.Wrapf(err, "failed to check for %#q in hello response (%v)", "msg", raw)
 	}
 
-	return lo.Ternary(hasMsg, TopologySharded, TopologyReplset), nil
+	if hasMsg {
+		return TopologySharded, nil
+	}
+
+	hasMe, err := mbson.RawContains(raw, "me")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to check for %#q in hello response (%v)", "me", raw)
+	}
+
+	return lo.Ternary(hasMe, TopologyReplset, TopologyStandalone), nil
 }
 
 // GetHelloRaw returns the result of a `hello` (or, if needed,
@@ -118,8 +128,11 @@ func GetHelloRaw(
 	raw, err := resp.Raw()
 
 	// Proactively check for the problem that
-	// https://jira.mongodb.org/browse/SERVER-52654 fixed:
-	if err == nil {
+	// https://jira.mongodb.org/browse/SERVER-52654 fixed.
+	//
+	// We check for “me” to avoid failing if the cluster is a standalone,
+	// in which case the hello response legitimately lacks an operationTime.
+	if err == nil && !raw.Lookup("me").IsZero() {
 		const opTimeName = "operationTime"
 		_, err := raw.LookupErr(opTimeName)
 		if err != nil {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -266,8 +266,8 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 	// The anonymous function here makes it easier to ensure
 	// that we unlock the mutex.
 	err = func() error {
-		verifier.lock()
-		defer verifier.unlock()
+		verifier.mux.Lock()
+		defer verifier.mux.Unlock()
 
 		if verifier.writesOff {
 			return errors.New("writesOff already set")
@@ -326,9 +326,9 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 }
 
 func (verifier *Verifier) WritesOn(ctx context.Context) {
-	verifier.lock()
+	verifier.mux.Lock()
 	verifier.writesOff = false
-	verifier.unlock()
+	verifier.mux.Unlock()
 }
 
 func (verifier *Verifier) GetLogger() *logger.Logger {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -111,6 +111,7 @@ type Verifier struct {
 	dstClient          *mongo.Client
 	srcClusterInfo     *util.ClusterInfo
 	dstClusterInfo     *util.ClusterInfo
+	metaClusterInfo    *util.ClusterInfo
 	numWorkers         int
 	failureDisplaySize int64
 
@@ -265,8 +266,8 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 	// The anonymous function here makes it easier to ensure
 	// that we unlock the mutex.
 	err = func() error {
-		verifier.mux.Lock()
-		defer verifier.mux.Unlock()
+		verifier.lock()
+		defer verifier.unlock()
 
 		if verifier.writesOff {
 			return errors.New("writesOff already set")
@@ -325,9 +326,9 @@ func (verifier *Verifier) WritesOff(ctx context.Context) error {
 }
 
 func (verifier *Verifier) WritesOn(ctx context.Context) {
-	verifier.mux.Lock()
+	verifier.lock()
 	verifier.writesOff = false
-	verifier.mux.Unlock()
+	verifier.unlock()
 }
 
 func (verifier *Verifier) GetLogger() *logger.Logger {
@@ -342,9 +343,18 @@ func (verifier *Verifier) SetMetaURI(ctx context.Context, uri string) error {
 		return err
 	}
 
-	verifier.metaURI = uri
+	verifier.logger.Info().
+		Msg("Reading metadata’s cluster info.")
 
-	return err
+	clusterInfo, err := util.GetClusterInfo(ctx, verifier.logger, verifier.metaClient)
+	if err != nil {
+		return errors.Wrap(err, "read metadata cluster info")
+	}
+
+	verifier.metaURI = uri
+	verifier.metaClusterInfo = &clusterInfo
+
+	return nil
 }
 
 func (verifier *Verifier) AddMetaIndexes(ctx context.Context) error {

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -19,6 +19,7 @@ import (
 	"github.com/10gen/migration-verifier/mmongo"
 	"github.com/10gen/migration-verifier/option"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -104,10 +105,10 @@ func (verifier *Verifier) insertRecheckDocs(
 	verifier.mux.RLock()
 	defer verifier.mux.RUnlock()
 
-	generation, _ := verifier.getGenerationWhileLocked()
+	recheckInGeneration, _ := verifier.getGenerationWhileLocked()
 
 	// We enqueue for the generation after the current one.
-	generation++
+	recheckInGeneration++
 
 	eg, groupCtx := contextplus.ErrGroup(ctx)
 
@@ -115,7 +116,7 @@ func (verifier *Verifier) insertRecheckDocs(
 	// its connection pool’s size. To avoid that, we limit our concurrency.
 	eg.SetLimit(100)
 
-	genCollection := verifier.getRecheckQueueCollection(generation)
+	genCollection := verifier.getRecheckQueueCollection(recheckInGeneration)
 
 	start := time.Now()
 	insertThreads := 0
@@ -220,9 +221,9 @@ func (verifier *Verifier) insertRecheckDocs(
 	if err := eg.Wait(); err != nil {
 		return errors.Wrapf(
 			err,
-			"persisting %d recheck(s) for generation %d",
+			"persisting %d recheck(s) to be rechecked in generation %d",
 			len(documentIDs),
-			generation,
+			recheckInGeneration,
 		)
 	}
 
@@ -235,7 +236,7 @@ func (verifier *Verifier) insertRecheckDocs(
 	}
 
 	verifier.logger.Trace().
-		Int("generation", generation).
+		Int("recheckInGeneration", recheckInGeneration).
 		Int("count", len(documentIDs)).
 		Msg("Persisted rechecks.")
 
@@ -354,11 +355,51 @@ func (verifier *Verifier) GenerateRecheckTasks(
 	firstMismatchTime := map[int32]bson.DateTime{}
 	var latestSrcTimestamp, latestDstTimestamp bson.Timestamp
 
+	var findCtx context.Context
+
+	if verifier.metaClusterInfo.Topology == util.TopologyStandalone {
+		// Standalone mongod is always causally consistent as long
+		// as writes are acknowledged, so we don’t need a cluster time here.
+		findCtx = ctx
+	} else {
+		sess, err := recheckColl.Database().Client().StartSession(
+			options.Session().SetCausalConsistency(true),
+		)
+		if err != nil {
+			return errors.Wrap(err, "starting session for generating recheck tasks")
+		}
+		defer sess.EndSession(ctx)
+
+		findCtx = mongo.NewSessionContext(ctx, sess)
+
+		// Do this to bootstrap the causally-consistent session. This way we
+		// guarantee that all previously-written, majority-committed writes will
+		// be visible in the session, and thus that we see all rechecks enqueued
+		// up to this point.
+		_, err = GetNewClusterTime(
+			findCtx,
+			verifier.logger,
+			recheckColl.Database().Client(),
+		)
+		if err != nil {
+			return errors.Wrap(err, "bootstrapping causally-consistent session for generating recheck tasks")
+		}
+
+		lo.Assert(
+			sess.OperationTime() != nil,
+			"session operation time must be non-nil",
+		)
+		lo.Assert(
+			sess.ClusterTime() != nil,
+			"session cluster time must be non-nil",
+		)
+	}
+
 	// The sort here is important because the recheck _id is an embedded
 	// document that includes the namespace. Thus, all rechecks for a given
 	// namespace will be consecutive in this query’s result.
 	cursor, err := recheckColl.Find(
-		ctx,
+		findCtx,
 		bson.D{},
 		options.Find().
 			SetSort(bson.D{{"_id", 1}}).
@@ -369,7 +410,7 @@ func (verifier *Verifier) GenerateRecheckTasks(
 	if err != nil {
 		return err
 	}
-	defer cursor.Close(ctx)
+	defer cursor.Close(findCtx)
 
 	var (
 		curTasks      []bson.Raw
@@ -453,7 +494,7 @@ func (verifier *Verifier) GenerateRecheckTasks(
 
 	// We group these here using a sort rather than using aggregate because aggregate is
 	// subject to a 16MB limit on group size.
-	for cursor.Next(ctx) {
+	for cursor.Next(findCtx) {
 		var doc recheck.Doc
 		err = (&doc).UnmarshalFromBSON(cursor.Current)
 		if err != nil {


### PR DESCRIPTION
Processing the recheck queue is a “read-your-own-writes” scenario. It thus requires causal consistency.

Standalone metadata nodes already provide this, but with replsets don’t. This changeset fixes that by making recheck-queue reads from replsets happen in a causally-consistent session. Each session is “bootstrapped” with an `appendOplogNote` to ensure that we read all prior majority-committed writes, even in the event of a failover.

This means we need to test with replset metadata, so the GitHub Action now randomizes whether the metadata is a standalone or replset.