### PR TITLE
Indicate partition task status in worker status table

### DIFF
--- a/internal/verifier/comparator.go
+++ b/internal/verifier/comparator.go
@@ -231,7 +231,7 @@ func (c *comparator) recordSrcMetrics(docs []compare.DocWithTS) {
 		}
 	}
 
-	c.verifier.workerTracker.SetSrcCounts(c.workerNum, c.srcDocCount, c.srcByteCount)
+	c.verifier.workerTracker.SetDocTaskSrcCounts(c.workerNum, c.srcDocCount, c.srcByteCount)
 }
 
 func (c *comparator) publishHistoryCounts() {

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1535,7 +1535,7 @@ func (verifier *Verifier) partitionCollection(
 	case partitions.SchemeID:
 		if verifier.srcHasSampleRate() {
 			var err error
-			partitionsCount, err = verifier.createPartitionTasksWithSampleRate(ctx, task, shardKeyFields)
+			partitionsCount, err = verifier.createPartitionTasksWithSampleRate(ctx, workerNum, task, shardKeyFields)
 			if err != nil {
 				return errors.Wrapf(err, "partitioning %#q via $sampleRate", srcNs)
 			}
@@ -1645,8 +1645,6 @@ func (verifier *Verifier) partitionCollection(
 				return fmt.Errorf("reading natural partition: %w", err)
 			}
 
-			partitionsCount++
-
 			_, err = verifier.InsertPartitionVerificationTask(ctx, &partition, shardKeyFields, dstNs)
 			if err != nil {
 				return errors.Wrapf(
@@ -1656,6 +1654,13 @@ func (verifier *Verifier) partitionCollection(
 					srcNs,
 				)
 			}
+
+			partitionsCount++
+
+			verifier.workerTracker.SetNamespaceTaskPartitionsCount(
+				workerNum,
+				partitionsCount,
+			)
 		}
 	default:
 		panic(fmt.Sprintf("bad partition method (%#q); how did that happen?!?", verifier.partitioningScheme))

--- a/internal/verifier/partition.go
+++ b/internal/verifier/partition.go
@@ -53,6 +53,7 @@ func (verifier *Verifier) findLatestPartitionUpperBound(
 
 func (verifier *Verifier) createPartitionTasksWithSampleRate(
 	ctx context.Context,
+	workerNum int,
 	task *tasks.Task,
 	shardFields []string,
 ) (int, error) {
@@ -72,6 +73,7 @@ func (verifier *Verifier) createPartitionTasksWithSampleRate(
 
 			partitionsCount, err = verifier.createPartitionTasksWithSampleRateRetryable(
 				ctx,
+				workerNum,
 				fi,
 				task,
 				shardFields,
@@ -88,6 +90,7 @@ func (verifier *Verifier) createPartitionTasksWithSampleRate(
 
 func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 	ctx context.Context,
+	workerNum int,
 	fi *retry.FuncInfo,
 	task *tasks.Task,
 	shardFields []string,
@@ -186,6 +189,11 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 		partitionsCount++
 
 		fi.NoteSuccess("inserted partition #%d", partitionsCount)
+
+		verifier.workerTracker.SetNamespaceTaskPartitionsCount(
+			workerNum,
+			partitionsCount,
+		)
 
 		return nil
 	}

--- a/internal/verifier/partition.go
+++ b/internal/verifier/partition.go
@@ -110,6 +110,8 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 		return 0, err
 	}
 
+	fi.NoteSuccess("found latest partition’s upper bound (if applicable)")
+
 	if lowerBound, has := lowerBoundOpt.Get(); has {
 		verifier.logger.Info().
 			Any("resumeFrom", lowerBound).
@@ -152,6 +154,8 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 	if err != nil {
 		return 0, errors.Wrapf(err, "getting %#q’s size", srcNs)
 	}
+
+	fi.NoteSuccess("read collection size & document count")
 
 	dstNs := FullName(verifier.dstClientCollection(task))
 
@@ -200,9 +204,7 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 
 	idealNumPartitions := util.DivideToF64(collBytes, idealPartitionBytes)
 
-	docsPerPartition := util.DivideToF64(docsCount, idealNumPartitions)
-
-	sampleRate := util.DivideToF64(1, docsPerPartition)
+	sampleRate := util.DivideToF64(idealNumPartitions, docsCount)
 
 	if sampleRate > 0 && sampleRate < 1 {
 		pipeline = append(
@@ -226,10 +228,14 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 		return 0, errors.Wrapf(err, "opening %#q’s sampling cursor", srcNs)
 	}
 
+	fi.NoteSuccess("opened partitioning cursor")
+
 	defer cursor.Close(ctx)
 	cursor.SetBatchSize(1)
 
 	for cursor.Next(ctx) {
+		fi.NoteSuccess("received partition boundary")
+
 		upperBound, err := cursor.Current.LookupErr("_id")
 		if err != nil {
 			return 0, errors.Wrapf(err, "fetching %#q from %#q’s sampling cursor", "_id", srcNs)
@@ -237,7 +243,7 @@ func (verifier *Verifier) createPartitionTasksWithSampleRateRetryable(
 
 		err = createAndInsertPartition(lowerBound, upperBound)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("create and insert partition: %w", err)
 		}
 
 		lowerBound = upperBound

--- a/internal/verifier/progress_test.go
+++ b/internal/verifier/progress_test.go
@@ -218,7 +218,7 @@ func (suite *IntegrationTestSuite) TestGetProgress_Gen0StatsExcludesActiveWorker
 		QueryFilter: tasks.QueryFilter{Namespace: dbName + ".coll"},
 	}
 	verifier.workerTracker.Set(fakeSlot, fakeTask)
-	verifier.workerTracker.SetSrcCounts(fakeSlot, fakeWorkerDocs, fakeWorkerBytes)
+	verifier.workerTracker.SetDocTaskSrcCounts(fakeSlot, fakeWorkerDocs, fakeWorkerBytes)
 	defer verifier.workerTracker.Unset(fakeSlot)
 
 	progress, err := verifier.GetProgress(ctx)

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -390,8 +390,11 @@ func (verifier *Verifier) getComparisonStatistics(
 		for _, nsWorkerStats := range perNamespaceWorkerStats {
 			for _, workerStats := range nsWorkerStats {
 				activeWorkers++
-				comparedDocs += workerStats.SrcDocCount
-				comparedBytes += workerStats.SrcByteCount
+
+				if ws, ok := workerStats.TaskStatus.(DocumentTaskStatus); ok {
+					comparedDocs += ws.SrcDocCount
+					comparedBytes += ws.SrcByteCount
+				}
 			}
 		}
 	}
@@ -530,8 +533,15 @@ func (verifier *Verifier) printNamespaceStatistics(
 			threads = len(nsWorkerStats)
 
 			for _, workerStats := range nsWorkerStats {
-				docsCompared += workerStats.SrcDocCount
-				bytesCompared += workerStats.SrcByteCount
+				switch ws := workerStats.TaskStatus.(type) {
+				case DocumentTaskStatus:
+					docsCompared += ws.SrcDocCount
+					bytesCompared += ws.SrcByteCount
+				case NamespaceTaskStatus:
+					// No-op for namespace tasks
+				default:
+					// Unknown task type
+				}
 			}
 		}
 
@@ -922,12 +932,17 @@ func (verifier *Verifier) printWorkerStatus(builder *strings.Builder, now time.T
 		}
 
 		var detail string
-		if wsmap[w].TaskType == tasks.VerifyDocuments {
+		switch wsmap[w].TaskType {
+		case tasks.VerifyCollection:
+			detail = fmt.Sprintf("%d partitions", wsmap[w].TaskStatus.(NamespaceTaskStatus).PartitionsCount)
+		case tasks.VerifyDocuments:
 			detail = fmt.Sprintf(
 				"%s documents (%s)",
-				reportutils.FmtReal(wsmap[w].SrcDocCount),
-				reportutils.FmtBytes(wsmap[w].SrcByteCount),
+				reportutils.FmtReal(wsmap[w].TaskStatus.(DocumentTaskStatus).SrcDocCount),
+				reportutils.FmtBytes(wsmap[w].TaskStatus.(DocumentTaskStatus).SrcByteCount),
 			)
+		default:
+			detail = fmt.Sprintf("unknown task type %#q", wsmap[w].TaskType)
 		}
 
 		tableRows = append(

--- a/internal/verifier/worker_tracker.go
+++ b/internal/verifier/worker_tracker.go
@@ -104,7 +104,12 @@ func (wt *WorkerTracker) SetDocTaskSrcCounts(workerNum int, docs types.DocumentC
 func (wt *WorkerTracker) SetNamespaceTaskPartitionsCount(workerNum int, partitions int) {
 	wt.guard.Store(func(m WorkerStatusMap) WorkerStatusMap {
 		status := m[workerNum]
-		new(status.TaskStatus.(NamespaceTaskStatus)).PartitionsCount = partitions
+		nsTaskStatus, ok := status.TaskStatus.(NamespaceTaskStatus)
+		if !ok {
+			panic(fmt.Sprintf("attempting to set namespace partitions count on %T", status.TaskStatus))
+		}
+		nsTaskStatus.PartitionsCount = partitions
+		status.TaskStatus = nsTaskStatus
 		m[workerNum] = status
 
 		return m

--- a/internal/verifier/worker_tracker.go
+++ b/internal/verifier/worker_tracker.go
@@ -1,6 +1,7 @@
 package verifier
 
 import (
+	"fmt"
 	"maps"
 	"time"
 
@@ -22,18 +23,34 @@ type WorkerStatusMap = map[int]WorkerStatus
 // WorkerStatus details the work that an individual worker thread
 // is doing.
 type WorkerStatus struct {
-	TaskID       any
-	StartTime    time.Time
-	TaskType     tasks.Type
-	Namespace    string
+	TaskID     any
+	StartTime  time.Time
+	TaskType   tasks.Type
+	Namespace  string
+	TaskStatus taskStatus
+}
+
+type taskStatus interface {
+	isTaskStatus()
+}
+
+type DocumentTaskStatus struct {
 	SrcDocCount  types.DocumentCount
 	SrcByteCount types.ByteCount
 }
 
+func (DocumentTaskStatus) isTaskStatus() {}
+
+type NamespaceTaskStatus struct {
+	PartitionsCount int
+}
+
+func (NamespaceTaskStatus) isTaskStatus() {}
+
 // NewWorkerTracker creates and returns a WorkerTracker.
 func NewWorkerTracker(workersCount int) *WorkerTracker {
 	wsmap := WorkerStatusMap{}
-	for i := 0; i < workersCount; i++ {
+	for i := range workersCount {
 		wsmap[i] = WorkerStatus{}
 	}
 	return &WorkerTracker{
@@ -44,22 +61,50 @@ func NewWorkerTracker(workersCount int) *WorkerTracker {
 // Set updates the worker’s state in the WorkerTracker.
 func (wt *WorkerTracker) Set(workerNum int, task tasks.Task) {
 	wt.guard.Store(func(m WorkerStatusMap) WorkerStatusMap {
-		m[workerNum] = WorkerStatus{
+		newStatus := WorkerStatus{
 			TaskID:    task.PrimaryKey,
 			TaskType:  task.Type,
 			Namespace: task.QueryFilter.Namespace,
 			StartTime: time.Now(),
 		}
 
+		switch task.Type {
+		case tasks.VerifyDocuments:
+			newStatus.TaskStatus = DocumentTaskStatus{}
+		case tasks.VerifyCollection:
+			newStatus.TaskStatus = NamespaceTaskStatus{}
+		default:
+			panic("unknown task type")
+		}
+
+		m[workerNum] = newStatus
+
 		return m
 	})
 }
 
-func (wt *WorkerTracker) SetSrcCounts(workerNum int, docs types.DocumentCount, bytes types.ByteCount) {
+func (wt *WorkerTracker) SetDocTaskSrcCounts(workerNum int, docs types.DocumentCount, bytes types.ByteCount) {
 	wt.guard.Store(func(m WorkerStatusMap) WorkerStatusMap {
 		status := m[workerNum]
-		status.SrcDocCount = docs
-		status.SrcByteCount = bytes
+
+		dTaskStatus, ok := status.TaskStatus.(DocumentTaskStatus)
+		if !ok {
+			panic(fmt.Sprintf("attempting to set document counts on %T", status.TaskStatus))
+		}
+		dTaskStatus.SrcDocCount = docs
+		dTaskStatus.SrcByteCount = bytes
+		status.TaskStatus = dTaskStatus
+
+		m[workerNum] = status
+
+		return m
+	})
+}
+
+func (wt *WorkerTracker) SetNamespaceTaskPartitionsCount(workerNum int, partitions int) {
+	wt.guard.Store(func(m WorkerStatusMap) WorkerStatusMap {
+		status := m[workerNum]
+		new(status.TaskStatus.(NamespaceTaskStatus)).PartitionsCount = partitions
 		m[workerNum] = status
 
 		return m


### PR DESCRIPTION
When a partition task is in the worker status table, this makes the table show the # of partitions that that task has created.