### PR TITLE
Fix grouping bug when multiple rechecks occur for the same document.

### DIFF
--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -102,6 +102,10 @@ func (verifier *Verifier) insertRecheckDocs(
 		panic("Expect either mismatch times or optimes, not both/neither.")
 	}
 
+	if len(changeOpTimes) > 0 && changeOrigin.IsNone() {
+		panic("change origin must be specified if optimes are specified")
+	}
+
 	verifier.mux.RLock()
 	defer verifier.mux.RUnlock()
 
@@ -503,17 +507,24 @@ func (verifier *Verifier) GenerateRecheckTasks(
 
 		idRaw := doc.PrimaryKey.DocumentID
 
+		isSameNamespace := doc.PrimaryKey.SrcDatabaseName == prevDBName &&
+			doc.PrimaryKey.SrcCollectionName == prevCollName
+
+		// If we’ve already seen this ID, then we don’t re-add it. We may,
+		// though, still want to incorporate the duplicate into the task’s
+		// document metadata.
+		isSameDoc := isSameNamespace && idRaw.Equal(lastIDRaw)
+
 		// We persist rechecks if any of these happen:
 		// - the namespace has changed
 		// - we’ve reached the per-task recheck maximum
 		// - the buffered document IDs’ size exceeds the per-task maximum
 		// - the buffered documents exceed the partition size
 		//
-		if doc.PrimaryKey.SrcDatabaseName != prevDBName ||
-			doc.PrimaryKey.SrcCollectionName != prevCollName ||
+		if !isSameDoc && (!isSameNamespace ||
 			len(idAccum) > maxRecheckIDs ||
 			types.ByteCount(idsSizer.Len()) >= maxRecheckIDsBytes ||
-			dataSizeAccum >= verifier.partitionSizeInBytes {
+			dataSizeAccum >= verifier.partitionSizeInBytes) {
 
 			err := persistBufferedRechecks()
 			if err != nil {
@@ -534,10 +545,6 @@ func (verifier *Verifier) GenerateRecheckTasks(
 		// This is the index for storing info about the doc in metadata.
 		metadataIndex := int32(len(idAccum))
 
-		// If we’ve already seen this ID, then we don’t re-add it. We may,
-		// though, still want to incorporate the duplicate into the task’s
-		// document metadata.
-		isSameDoc := idRaw.Equal(lastIDRaw)
 		if isSameDoc {
 			// We’re not going to add this ID to the idAccum slice because it’s
 			// already in that slice. But we still may need to record metadata

--- a/internal/verifier/recheck.go
+++ b/internal/verifier/recheck.go
@@ -522,7 +522,7 @@ func (verifier *Verifier) GenerateRecheckTasks(
 		// - the buffered documents exceed the partition size
 		//
 		if !isSameDoc && (!isSameNamespace ||
-			len(idAccum) > maxRecheckIDs ||
+			len(idAccum) >= maxRecheckIDs ||
 			types.ByteCount(idsSizer.Len()) >= maxRecheckIDsBytes ||
 			dataSizeAccum >= verifier.partitionSizeInBytes) {
 

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -436,7 +436,7 @@ func (suite *IntegrationTestSuite) TestDupeRechecksStraddleBatch() {
 	err = cursor.All(ctx, &foundTasks)
 	suite.Require().NoError(err)
 
-	suite.Assert().Len(foundTasks, 1, "only 1 task should exist")
+	suite.Assert().EqualValues(1, len(foundTasks), "1 task should exist")
 }
 
 func (suite *IntegrationTestSuite) TestManyManyRechecks() {

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -381,7 +381,7 @@ func (suite *IntegrationTestSuite) TestDupeRechecksStraddleBatch() {
 	verifier := suite.BuildVerifier()
 	suite.Require().NoError(verifier.SetNumWorkers(10))
 
-	docsCount := maxRecheckIDs - 1
+	docsCount := maxRecheckIDs
 
 	suite.T().Logf("Inserting %d rechecks …", docsCount)
 

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -375,6 +375,56 @@ func (suite *IntegrationTestSuite) TestMismatchAndChangeRechecks() {
 	)
 }
 
+func (suite *IntegrationTestSuite) TestDupeRechecksStraddleBatch() {
+	ctx := suite.Context()
+
+	verifier := suite.BuildVerifier()
+	suite.Require().NoError(verifier.SetNumWorkers(10))
+
+	docsCount := maxRecheckIDs - 1
+
+	suite.T().Logf("Inserting %d rechecks …", docsCount)
+
+	dbName := suite.DBNameForTest()
+
+	ids := lo.Range(docsCount)
+	err := insertRecheckDocs(
+		ctx,
+		verifier,
+		dbName,
+		"testColl",
+		lo.ToAnySlice(ids),
+		lo.RepeatBy(docsCount, func(_ int) int32 { return 1 }),
+	)
+	suite.Require().NoError(err)
+
+	// Add a recheck for the source:
+	err = verifier.insertRecheckDocs(
+		ctx,
+		mslices.Of(dbName),
+		mslices.Of("testColl"),
+		mslices.Of(mbson.ToRawValue("foo")),
+		mslices.Of(int32(1)),
+		nil,
+		option.Some(src),
+		mslices.Of(bson.Timestamp{123, 456}),
+	)
+	suite.Require().NoError(err)
+
+	// Another for the destination:
+	err = verifier.insertRecheckDocs(
+		ctx,
+		mslices.Of(dbName),
+		mslices.Of("testColl"),
+		mslices.Of(mbson.ToRawValue("foo")),
+		mslices.Of(int32(1)),
+		nil,
+		option.Some(dst),
+		mslices.Of(bson.Timestamp{234, 345}),
+	)
+	suite.Require().NoError(err)
+}
+
 func (suite *IntegrationTestSuite) TestManyManyRechecks() {
 	if len(os.Getenv("CI")) > 0 {
 		suite.T().Skip("Skipping this test in CI. (It causes GitHub Action to self-terminate.)")

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -381,7 +381,7 @@ func (suite *IntegrationTestSuite) TestDupeRechecksStraddleBatch() {
 	verifier := suite.BuildVerifier()
 	suite.Require().NoError(verifier.SetNumWorkers(10))
 
-	docsCount := maxRecheckIDs
+	docsCount := maxRecheckIDs - 1
 
 	suite.T().Logf("Inserting %d rechecks …", docsCount)
 

--- a/internal/verifier/recheck_test.go
+++ b/internal/verifier/recheck_test.go
@@ -423,6 +423,20 @@ func (suite *IntegrationTestSuite) TestDupeRechecksStraddleBatch() {
 		mslices.Of(bson.Timestamp{234, 345}),
 	)
 	suite.Require().NoError(err)
+
+	verifier.generation++
+
+	err = verifier.GenerateRecheckTasks(ctx, &testutil.MockSuccessNotifier{})
+	suite.Require().NoError(err)
+
+	taskColl := suite.metaMongoClient.Database(verifier.metaDBName).Collection(verificationTasksCollection)
+	cursor, err := taskColl.Find(ctx, bson.D{})
+	suite.Require().NoError(err)
+	var foundTasks []tasks.Task
+	err = cursor.All(ctx, &foundTasks)
+	suite.Require().NoError(err)
+
+	suite.Assert().Len(foundTasks, 1, "only 1 task should exist")
 }
 
 func (suite *IntegrationTestSuite) TestManyManyRechecks() {
@@ -753,7 +767,7 @@ func insertRecheckDocs(
 		rawIDs,
 		dataSizes,
 		nil,
-		option.None[whichCluster](),
+		option.Some(src),
 		lo.RepeatBy(
 			len(dbNames),
 			func(index int) bson.Timestamp {


### PR DESCRIPTION
Previously if enqueued rechecks for the same document straddled a recheck-group boundary, GenerateRecheckTasks would split the dupe rechecks across tasks. Now those rechecks are in the same task.

Example: Assume 9,999 rechecks are ready to be converted to a task. Assume the next 2 rechecks are for the same document. Verifier _should_ deduplicate those rechecks into the same recheck task. Instead it was splitting them across tasks.

This changeset also fixes an off-by-one error in that part of the code that made the effective per-recheck-task document limit 10,001 rather than 10,000.

An additional assertion is added, with an errantly omitted change reader name added.

This should not affect significant user-visible behavior. It’s still good to clear up, though, given the high complexity of this part of the code.