### PR TITLE
REP-7314 Crash during initial check if any collection is missing on either cluster

### DIFF
--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -723,6 +723,11 @@ func (suite *IntegrationTestSuite) TestChangeStreamDDLError() {
 		db.CreateCollection(ctx, "mycoll"),
 	)
 
+	suite.Require().NoError(
+		suite.dstMongoClient.
+			Database(suite.DBNameForTest()).CreateCollection(ctx, "mycoll"),
+	)
+
 	verifier.SetSrcNamespaces([]string{db.Name() + ".mycoll"})
 	verifier.SetDstNamespaces([]string{db.Name() + ".mycoll"})
 	verifier.SetNamespaceMap()
@@ -751,6 +756,11 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 
 	suite.Require().NoError(
 		db.CreateCollection(ctx, "mycoll"),
+	)
+
+	suite.Require().NoError(
+		suite.dstMongoClient.
+			Database(suite.DBNameForTest()).CreateCollection(ctx, "mycoll"),
 	)
 
 	verifier := suite.BuildVerifier()
@@ -799,12 +809,19 @@ func (suite *IntegrationTestSuite) TestChangeStreamLag() {
 // batch regardless of whether watched events were seen.
 func (suite *IntegrationTestSuite) TestLastSeenClusterTimeSetWithoutWatchedEvents() {
 	ctx := suite.Context()
-	db := suite.srcMongoClient.Database(suite.DBNameForTest())
-	suite.Require().NoError(db.CreateCollection(ctx, "watched"))
+
+	dbName := suite.DBNameForTest()
+
+	for _, client := range mslices.Of(suite.srcMongoClient, suite.dstMongoClient) {
+		suite.Require().NoError(
+			client.Database(dbName).
+				CreateCollection(ctx, "watched"),
+		)
+	}
 
 	verifier := suite.BuildVerifier()
-	verifier.SetSrcNamespaces([]string{db.Name() + ".watched"})
-	verifier.SetDstNamespaces([]string{db.Name() + ".watched"})
+	verifier.SetSrcNamespaces([]string{dbName + ".watched"})
+	verifier.SetDstNamespaces([]string{dbName + ".watched"})
 	verifier.SetNamespaceMap()
 
 	verifierRunner := RunVerifierCheck(ctx, suite.T(), verifier)
@@ -835,11 +852,18 @@ func (suite *IntegrationTestSuite) TestLastSeenClusterTimeSetWithoutWatchedEvent
 func (suite *IntegrationTestSuite) TestLastSeenClusterTimeAdvancesBeyondLastEvent() {
 	ctx := suite.Context()
 	db := suite.srcMongoClient.Database(suite.DBNameForTest())
-	suite.Require().NoError(db.CreateCollection(ctx, "watched"))
 
-	// We’ll need this below. Pre-create it so that oplog-tailing doesn’t
-	// complain about its creation during the verification.
-	suite.Require().NoError(db.CreateCollection(ctx, "unwatched"))
+	for _, client := range mslices.Of(suite.srcMongoClient, suite.dstMongoClient) {
+		suite.Require().NoError(
+			client.Database(db.Name()).CreateCollection(ctx, "watched"),
+		)
+
+		// We’ll need this below. Pre-create it so that oplog-tailing doesn’t
+		// complain about its creation during the verification.
+		suite.Require().NoError(
+			client.Database(db.Name()).CreateCollection(ctx, "unwatched"),
+		)
+	}
 
 	verifier := suite.BuildVerifier()
 	verifier.SetSrcNamespaces([]string{db.Name() + ".watched"})

--- a/internal/verifier/check_test.go
+++ b/internal/verifier/check_test.go
@@ -60,7 +60,7 @@ func (suite *IntegrationTestSuite) TestCheckMissingNamespace() {
 			client.Database(dbName).CreateCollection(ctx, collName),
 		)
 
-		runner := RunVerifierCheck(ctx, suite.T(), verifier)
+		runner := RunVerifierCheck(ctx, t, verifier)
 		err := runner.AwaitGenerationEnd()
 
 		assert.ErrorContains(t, err, collName)

--- a/internal/verifier/check_test.go
+++ b/internal/verifier/check_test.go
@@ -1,5 +1,14 @@
 package verifier
 
+import (
+	"testing"
+
+	"github.com/10gen/migration-verifier/mslices"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
 func (suite *IntegrationTestSuite) TestPersistedMetadataVersionMismatch() {
 	ctx := suite.Context()
 
@@ -23,4 +32,45 @@ func (suite *IntegrationTestSuite) TestPersistedMetadataVersionMismatch() {
 
 	mme := metadataMismatchErr{}
 	suite.Require().ErrorAs(err, &mme)
+}
+
+func (suite *IntegrationTestSuite) TestCheckMissingNamespace() {
+	ctx := suite.Context()
+
+	dbName := suite.DBNameForTest()
+
+	runTest := func(
+		t *testing.T,
+		client *mongo.Client,
+		collName string,
+	) {
+		defer func() {
+			err := client.Database(dbName).Collection(collName).Drop(ctx)
+			assert.NoError(t, err, "should clean up collection after test")
+		}()
+
+		verifier := suite.BuildVerifier()
+		verifier.SetMetaDBName(suite.DBNameForTest("verifier-" + collName))
+		verifier.SetSrcNamespaces(mslices.Of(dbName + "." + collName))
+		verifier.SetDstNamespaces(mslices.Of(dbName + "." + collName))
+		verifier.SetNamespaceMap()
+
+		require.NoError(
+			t,
+			client.Database(dbName).CreateCollection(ctx, collName),
+		)
+
+		runner := RunVerifierCheck(ctx, suite.T(), verifier)
+		err := runner.AwaitGenerationEnd()
+
+		assert.ErrorContains(t, err, collName)
+	}
+
+	suite.T().Run("src-only", func(t *testing.T) {
+		runTest(t, suite.srcMongoClient, "srcOnlyColl")
+	})
+
+	suite.T().Run("dst-only", func(t *testing.T) {
+		runTest(t, suite.dstMongoClient, "dstOnlyColl")
+	})
 }

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -36,7 +36,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/mongodb-labs/migration-tools/bsontools"
 	"github.com/mongodb-labs/migration-tools/mongotools/index"
-	"github.com/mongodb-labs/migration-tools/option"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -948,25 +947,9 @@ func (verifier *Verifier) partitionAndInspectNamespace(
 // not the collection data can be safely verified.
 func (verifier *Verifier) compareCollectionSpecifications(
 	srcNs, dstNs string,
-	srcSpecOpt, dstSpecOpt option.Option[util.CollectionSpec],
+	srcSpec, dstSpec util.CollectionSpec,
 ) ([]compare.Result, bool, error) {
-	srcSpec, hasSrcSpec := srcSpecOpt.Get()
-	dstSpec, hasDstSpec := dstSpecOpt.Get()
 
-	if !hasSrcSpec {
-		return []compare.Result{{
-			NameSpace: srcNs,
-			Cluster:   constants.ClusterSource,
-			Details:   compare.Missing,
-		}}, false, nil
-	}
-	if !hasDstSpec {
-		return []compare.Result{{
-			NameSpace: dstNs,
-			Cluster:   constants.ClusterTarget,
-			Details:   compare.Missing,
-		}}, false, nil
-	}
 	if srcSpec.Type != dstSpec.Type {
 		return []compare.Result{{
 			NameSpace: srcNs,
@@ -1252,24 +1235,26 @@ func (verifier *Verifier) verifyMetadataAndPartitionCollection(
 		}
 	}
 
-	if !hasDstSpec {
-		if !hasSrcSpec {
-			verifier.logger.Info().
-				Int("workerNum", workerNum).
-				Str("srcNamespace", srcNs).
-				Str("dstNamespace", dstNs).
-				Msg("Collection not present on either cluster.")
+	if !hasSrcSpec {
+		if hasDstSpec {
 
-			// This counts as success.
-			task.Status = tasks.Completed
-			return nil
+			return fmt.Errorf("collection %#q exists only on destination", dstNs)
 		}
 
-		task.Status = tasks.Failed
-		// Fall through here; comparing the collection specifications will produce the correct
-		// failure output.
+		verifier.logger.Info().
+			Int("workerNum", workerNum).
+			Str("srcNamespace", srcNs).
+			Str("dstNamespace", dstNs).
+			Msg("Collection not present on either cluster.")
+
+		// This counts as success.
+		task.Status = tasks.Completed
+		return nil
+	} else if !hasDstSpec {
+		return fmt.Errorf("collection %#q exists only on source", srcNs)
 	}
-	specificationProblems, verifyData, err := verifier.compareCollectionSpecifications(srcNs, dstNs, srcSpecOpt, dstSpecOpt)
+
+	specificationProblems, verifyData, err := verifier.compareCollectionSpecifications(srcNs, dstNs, srcSpec, dstSpec)
 	if err != nil {
 		return errors.Wrapf(
 			err,

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -994,11 +994,13 @@ func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Metadata(
 
 	dbName := suite.DBNameForTest()
 
-	err := verifier.srcClient.Database(dbName).CreateCollection(
-		ctx,
-		"foo",
-	)
-	suite.Require().NoError(err)
+	for _, client := range mslices.Of(verifier.srcClient, verifier.dstClient) {
+		err := client.Database(dbName).CreateCollection(
+			ctx,
+			"foo",
+		)
+		suite.Require().NoError(err)
+	}
 
 	runner := RunVerifierCheck(ctx, suite.T(), verifier)
 	suite.Require().NoError(runner.AwaitGenerationEnd())

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1908,7 +1908,6 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	verifier := suite.BuildVerifier()
 	ctx := suite.Context()
 
-	// Collection exists only on source.
 	err := suite.srcMongoClient.Database("testDb").CreateCollection(ctx, "testColl")
 	suite.Require().NoError(err)
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "testColl")

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -987,50 +987,6 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments() {
 	)
 }
 
-func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_Metadata() {
-	ctx := suite.Context()
-	verifier := suite.BuildVerifier()
-	verifier.SetVerifyAll(true)
-
-	dbName := suite.DBNameForTest()
-
-	for _, client := range mslices.Of(verifier.srcClient, verifier.dstClient) {
-		err := client.Database(dbName).CreateCollection(
-			ctx,
-			"foo",
-		)
-		suite.Require().NoError(err)
-	}
-
-	runner := RunVerifierCheck(ctx, suite.T(), verifier)
-	suite.Require().NoError(runner.AwaitGenerationEnd())
-
-	stats, err := verifier.GetPersistedNamespaceStatistics(ctx, verifier.generation)
-	suite.Require().NoError(err)
-
-	suite.Assert().Equal(
-		mslices.Of(NamespaceStats{
-			Namespace: dbName + ".foo",
-		}),
-		stats,
-		"stats should be as expected",
-	)
-
-	suite.Require().NoError(runner.StartNextGeneration())
-	suite.Require().NoError(runner.AwaitGenerationEnd())
-
-	stats, err = verifier.GetPersistedNamespaceStatistics(ctx, verifier.generation)
-	suite.Require().NoError(err)
-
-	suite.Assert().Equal(
-		mslices.Of(NamespaceStats{
-			Namespace: dbName + ".foo",
-		}),
-		stats,
-		"stats should be as expected",
-	)
-}
-
 func (suite *IntegrationTestSuite) TestGetPersistedNamespaceStatistics_OneDoc() {
 	ctx := suite.Context()
 	verifier := suite.BuildVerifier()
@@ -1955,30 +1911,14 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	// Collection exists only on source.
 	err := suite.srcMongoClient.Database("testDb").CreateCollection(ctx, "testColl")
 	suite.Require().NoError(err)
-	task := &tasks.Task{
-		PrimaryKey: bson.NewObjectID(),
-		Type:       tasks.VerifyCollection,
-		Status:     tasks.Processing,
-		QueryFilter: tasks.QueryFilter{
-			Namespace: "testDb.testColl",
-			To:        "testDb.testColl",
-		},
-	}
-	suite.Require().NoError(
-		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
-	)
-	suite.Equal(tasks.Failed, task.Status)
-
-	failures := suite.getFailuresForTask(verifier, task.PrimaryKey)
-	suite.Equal(1, len(failures))
-	suite.Equal(failures[0].Details, compare.Missing)
-	suite.Equal(failures[0].Cluster, constants.ClusterTarget)
-	suite.Equal(failures[0].NameSpace, "testDb.testColl")
-
-	// Make sure "To" is respected.
 	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "testColl")
 	suite.Require().NoError(err)
-	task = &tasks.Task{
+
+	// Make sure "To" is respected.
+	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "testCollTo")
+	suite.Require().NoError(err)
+
+	task := &tasks.Task{
 		PrimaryKey: bson.NewObjectID(),
 		Type:       tasks.VerifyCollection,
 		Status:     tasks.Processing,
@@ -1990,36 +1930,10 @@ func (suite *IntegrationTestSuite) TestVerifierCompareMetadata() {
 	suite.Require().NoError(
 		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
 	)
-	suite.Equal(tasks.Failed, task.Status)
+	suite.Equal(tasks.Completed, task.Status)
 
-	failures = suite.getFailuresForTask(verifier, task.PrimaryKey)
-	suite.Equal(1, len(failures))
-	suite.Equal(failures[0].Details, compare.Missing)
-	suite.Equal(failures[0].Cluster, constants.ClusterTarget)
-	suite.Equal(failures[0].NameSpace, "testDb.testCollTo")
-
-	// Collection exists only on dest.
-	err = suite.dstMongoClient.Database("testDb").CreateCollection(ctx, "destOnlyColl")
-	suite.Require().NoError(err)
-	task = &tasks.Task{
-		PrimaryKey: bson.NewObjectID(),
-		Type:       tasks.VerifyCollection,
-		Status:     tasks.Processing,
-		QueryFilter: tasks.QueryFilter{
-			Namespace: "testDb.destOnlyColl",
-			To:        "testDb.destOnlyColl",
-		},
-	}
-	suite.Require().NoError(
-		verifier.verifyMetadataAndPartitionCollection(ctx, 1, task),
-	)
-	suite.Equal(tasks.Failed, task.Status)
-
-	failures = suite.getFailuresForTask(verifier, task.PrimaryKey)
-	suite.Equal(1, len(failures))
-	suite.Equal(failures[0].Details, compare.Missing)
-	suite.Equal(failures[0].Cluster, constants.ClusterSource)
-	suite.Equal(failures[0].NameSpace, "testDb.destOnlyColl")
+	failures := suite.getFailuresForTask(verifier, task.PrimaryKey)
+	suite.Require().Empty(failures)
 
 	// A view and a collection are different.
 	err = suite.srcMongoClient.Database("testDb").CreateView(ctx, "viewOnSrc", "testColl", bson.A{bson.D{{"$project", bson.D{{"_id", 1}}}}})

--- a/internal/verifier/mismatches_test.go
+++ b/internal/verifier/mismatches_test.go
@@ -191,13 +191,6 @@ func (suite *IntegrationTestSuite) TestSendNamespaceMismatches() {
 	dstDB := suite.dstMongoClient.Database(suite.DBNameForTest())
 
 	suite.Require().NoError(
-		dstDB.CreateCollection(ctx, "extraOnDst"),
-	)
-	suite.Require().NoError(
-		srcDB.CreateCollection(ctx, "missingOnDst"),
-	)
-
-	suite.Require().NoError(
 		dstDB.CreateCollection(ctx, "mismatchedType"),
 	)
 	suite.Require().NoError(
@@ -322,17 +315,6 @@ func (suite *IntegrationTestSuite) TestSendNamespaceMismatches() {
 	mismatches := lo.ChannelToSlice(mmChan)
 
 	expected := []api.NSMismatchInfo{
-		// missing/extra collections:
-		{
-			Type:      api.MismatchMissing,
-			Namespace: srcDB.Name() + ".missingOnDst",
-			Aspect:    api.NSMismatchAspectExist,
-		},
-		{
-			Type:      api.MismatchExtra,
-			Namespace: srcDB.Name() + ".extraOnDst",
-			Aspect:    api.NSMismatchAspectExist,
-		},
 
 		// mismatched namespace type:
 		{

--- a/internal/verifier/timeseries_test.go
+++ b/internal/verifier/timeseries_test.go
@@ -219,18 +219,20 @@ func (suite *IntegrationTestSuite) TestTimeSeries_BucketsOnly() {
 		func() {
 			// The server forbids creation of a buckets collection without the
 			// relevant time-series options.
-			suite.Require().NoError(
-				db.CreateCollection(
-					ctx,
-					bucketsCollName,
-					options.CreateCollection().SetTimeSeriesOptions(
-						options.TimeSeries().
-							SetTimeField("time").
-							SetMetaField("sensor"),
+			for _, curDB := range mslices.Of(db, dstDB) {
+				suite.Require().NoError(
+					curDB.CreateCollection(
+						ctx,
+						bucketsCollName,
+						options.CreateCollection().SetTimeSeriesOptions(
+							options.TimeSeries().
+								SetTimeField("time").
+								SetMetaField("sensor"),
+						),
 					),
-				),
-				"should create source buckets collection",
-			)
+					"should create source buckets collection",
+				)
+			}
 
 			_, err := db.Collection(bucketsCollName).InsertMany(
 				ctx,

--- a/internal/verifier/timeseries_test.go
+++ b/internal/verifier/timeseries_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/internal/testutil"
+	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/verifier/api"
 	"github.com/10gen/migration-verifier/internal/verifier/compare"
 	"github.com/10gen/migration-verifier/internal/verifier/constants"
@@ -251,18 +252,25 @@ func (suite *IntegrationTestSuite) TestTimeSeries_BucketsOnly() {
 				verificationStatus,
 			)
 
-			suite.Require().NoError(
-				dstDB.CreateCollection(
-					ctx,
-					bucketsCollName,
-					options.CreateCollection().SetTimeSeriesOptions(
-						options.TimeSeries().
-							SetTimeField("time").
-							SetMetaField("sensor"),
-					),
+			// 8.0 doesn’t throw a NamespaceExists error here, but earlier
+			// server versions do.
+			err = dstDB.CreateCollection(
+				ctx,
+				bucketsCollName,
+				options.CreateCollection().SetTimeSeriesOptions(
+					options.TimeSeries().
+						SetTimeField("time").
+						SetMetaField("sensor"),
 				),
-				"should create destination buckets collection",
 			)
+
+			if err != nil {
+				suite.Require().True(
+					util.IsNamespaceExistsError(err),
+					"err (%v) must be namespace-exists",
+					err,
+				)
+			}
 
 			_, err = dstDB.
 				Collection(bucketsCollName).

--- a/internal/verifier/timeseries_test.go
+++ b/internal/verifier/timeseries_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/internal/testutil"
-	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/verifier/api"
 	"github.com/10gen/migration-verifier/internal/verifier/compare"
 	"github.com/10gen/migration-verifier/internal/verifier/constants"
@@ -231,7 +230,7 @@ func (suite *IntegrationTestSuite) TestTimeSeries_BucketsOnly() {
 								SetMetaField("sensor"),
 						),
 					),
-					"should create source buckets collection",
+					"must create buckets collection",
 				)
 			}
 
@@ -251,26 +250,6 @@ func (suite *IntegrationTestSuite) TestTimeSeries_BucketsOnly() {
 				"missing buckets collection should show mismatch (status: %+v)",
 				verificationStatus,
 			)
-
-			// 8.0 doesn’t throw a NamespaceExists error here, but earlier
-			// server versions do.
-			err = dstDB.CreateCollection(
-				ctx,
-				bucketsCollName,
-				options.CreateCollection().SetTimeSeriesOptions(
-					options.TimeSeries().
-						SetTimeField("time").
-						SetMetaField("sensor"),
-				),
-			)
-
-			if err != nil {
-				suite.Require().True(
-					util.IsNamespaceExistsError(err),
-					"err (%v) must be namespace-exists",
-					err,
-				)
-			}
 
 			_, err = dstDB.
 				Collection(bucketsCollName).


### PR DESCRIPTION
Assume a nonempty collection exists only on the source when verification starts. Verifier will show that as a collection-level mismatch.

Now assume that the collection gets created, empty, on the destination. Verifier will resolve the collection-level mismatch _but pay no mind of the actual documents_. This is because it never actually did a partition & scan of existing documents during generation 0.

Thus, even if the replicator leaves the destination’s collection totally empty, Verifier will report no mismatches.

This changeset makes Verifier crash instead of reporting the missing collection.