### PR TITLE
Remove assertion that assumes 0-documents collection has 0 bytes.

### DIFF
--- a/internal/partitions/partitions.go
+++ b/internal/partitions/partitions.go
@@ -378,15 +378,6 @@ func GetSizeAndDocumentCount(ctx context.Context, logger *logger.Logger, srcColl
 		return 0, 0, false, fmt.Errorf("queried $collStats on %#q but got %#q", util.FullName(srcColl), value.Namespace)
 	}
 
-	// If this panics, then the aggregation logic above is wrong.
-	lo.Assertf(
-		(value.Size == 0) == (value.Count == 0),
-		"%#q: size=%d but count=%d; must be both zero or both nonzero",
-		util.FullName(srcColl),
-		value.Size,
-		value.Count,
-	)
-
 	logger.Debug().
 		Str("namespace", util.FullName(srcColl)).
 		Str("size", reportutils.FmtBytes(value.Size)).


### PR DESCRIPTION
Apparently $collStats reads the collection size & document count separately rather than atomically. Thus it’s possible for there to be 0 documents but >0 bytes in this aggregation’s response.

This changeset removes an assertion that assumed these would always be 0 together.