### PR TITLE
Default metadata to the destination.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ curl -sSL https://raw.githubusercontent.com/mongodb-labs/migration-verifier/refs
 ```
 (Alternatively, you can check out this repository then `./build.sh` to build from source.)
 
-Then start a local mongod to store verification metadata:
-```
-podman run -it --rm -p27017:27017 -v ./verifier_db:/data/db --entrypoint bash docker.io/mongodb/mongodb-community-server
-```
-(This will create a local `verifier_db` directory so that you can resume verification if needed. Omit `-v` with its argument to avoid that.)
-
 Finally, run verification:
 ```
 ./migration_verifier \
@@ -27,14 +21,8 @@ Finally, run verification:
     --start
 ```
 The above will stream verification logs to standard output. Once writes stop,
-watch for change stream lag to hit 0. The log will report either the found
+wait for change stream lag to hit 0. The log will report either the found
 mismatches or a confirmation of exact match between the clusters.
-
-# Verifier Metadata Considerations
-
-migration-verifier needs a `mongod` to store its state. By default, this is assumed to run on localhost:27017. For best performance this should be a standalone `mongod`.
-
-See [above](#Quick-Start) for a one-line command to start up such a `mongod`.
 
 # More Details
 
@@ -91,7 +79,14 @@ srcURI: mongodb://localhost:28010
 dstURI: mongodb://localhost:28011
 metaURI: mongodb://localhost:28012
 ```
+## Metadata considerations
 
+By default, the verifier stores its metadata on the destination cluster. This works well in most migrations. It does require a destination that can handle
+both the migration *and* the verification workloads concurrently.
+
+If this combined workload overpowers the destination, put the
+verification’s metadata on a different cluster. To do this, give that cluster’s
+connection string in the `--metaURI` parameter.
 
 ## Send the Verifier Process Commands:
 
@@ -347,7 +342,7 @@ unaffected. When set, a corresponding entry is added to `notes`.
 | `--configFile <value>`                  | path to an optional YAML config file                                                                                                                                                        |
 | `--srcURI <URI>`                        | source Host URI for migration verification (required)                                                                                                           |
 | `--dstURI <URI>`                        | destination Host URI for migration verification (required)                                                                                                      |
-| `--metaURI <URI>`                       | host URI for storing migration verification metadata (default: "mongodb://localhost")                                                                                                 |
+| `--metaURI <URI>`                       | host URI for storing migration verification metadata (default: same as `--dstURI`)                                                                                                 |
 | `--serverPort <port>`                   | port for the control web server (default: 27020)                                                                                                                                            |
 | `--logPath <path>`                      | logging file path (default: "stdout")                                                                                                                                                       |
 | `--numWorkers <number>`                 | number of worker threads to use for verification (default: 10)                                                                                                                              |

--- a/internal/verifier/change_stream_test.go
+++ b/internal/verifier/change_stream_test.go
@@ -319,6 +319,8 @@ func (suite *IntegrationTestSuite) startSrcChangeStreamReaderAndHandler(
 }
 
 func (suite *IntegrationTestSuite) TestLastRecheckedOpTime_Resume() {
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+
 	ctx := suite.T().Context()
 
 	verifier1 := suite.BuildVerifier()
@@ -358,10 +360,6 @@ func (suite *IntegrationTestSuite) TestLastRecheckedOpTime_Resume() {
 
 	suite.Require().Eventually(
 		func() bool {
-			if !srcTS.IsZero() && !dstTS.IsZero() {
-				return true
-			}
-
 			suite.Require().NoError(
 				verifierRunner.StartNextGeneration(),
 			)
@@ -376,11 +374,11 @@ func (suite *IntegrationTestSuite) TestLastRecheckedOpTime_Resume() {
 				dstTS = t
 			})
 
-			return false
+			return !srcTS.IsZero() && !dstTS.IsZero()
 		},
 		time.Minute,
 		time.Second,
-		"last-rechecked timestamps must update",
+		"last-rechecked timestamps must exist",
 	)
 
 	v1Cancel(fmt.Errorf("ending verifier 1"))
@@ -422,21 +420,28 @@ func (suite *IntegrationTestSuite) TestLastRecheckedOpTime_Resume() {
 	suite.T().Logf("Waiting for last-recheck optimes to update …")
 
 	srcTS3, dstTS3 := srcTS, dstTS
-	for srcTS3.Equal(srcTS) || dstTS3.Equal(dstTS) {
-		suite.Require().NoError(
-			verifierRunner.StartNextGeneration(),
-		)
-		suite.Require().NoError(
-			verifierRunner.AwaitGenerationEnd(),
-		)
+	suite.Require().Eventually(
+		func() bool {
+			suite.Require().NoError(
+				verifierRunner.StartNextGeneration(),
+			)
+			suite.Require().NoError(
+				verifierRunner.AwaitGenerationEnd(),
+			)
 
-		verifier2.srcLastRecheckedTS.Load(func(t bson.Timestamp) {
-			srcTS3 = t
-		})
-		verifier2.dstLastRecheckedTS.Load(func(t bson.Timestamp) {
-			dstTS3 = t
-		})
-	}
+			verifier2.srcLastRecheckedTS.Load(func(t bson.Timestamp) {
+				srcTS3 = t
+			})
+			verifier2.dstLastRecheckedTS.Load(func(t bson.Timestamp) {
+				dstTS3 = t
+			})
+
+			return !srcTS3.Equal(srcTS) && !dstTS3.Equal(dstTS)
+		},
+		time.Minute,
+		time.Second,
+		"last-rechecked timestamps must update",
+	)
 
 	v2Cancel(fmt.Errorf("stopping verifier 2"))
 

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -96,8 +96,7 @@ func main() {
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:  metaURI,
-			Value: "mongodb://localhost",
-			Usage: "connection string to replset that stores verifier metadata",
+			Usage: "connection string to replset that stores verifier metadata (defaults to destination)",
 		}),
 		altsrc.NewIntFlag(cli.IntFlag{
 			Name:  serverPort,
@@ -391,18 +390,22 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	}
 
 	metaConnStr := cCtx.String(metaURI)
-	_, metaConnStr, err = mongotools.MaybeAddDirectConnection(metaConnStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing metadata connection string")
+
+	if metaConnStr == "" {
+		metaConnStr = dstConnStr
+
+		v.GetLogger().Info().
+			Msgf("Storing metadata on the destination cluster by default. Use a dedicated %#q instead if this underperforms.", metaURI)
+	} else {
+		_, metaConnStr, err = mongotools.MaybeAddDirectConnection(metaConnStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing metadata connection string")
+		}
 	}
+
 	err = v.SetMetaURI(ctx, metaConnStr)
 	if err != nil {
 		return nil, err
-	}
-
-	if dstConnStr == metaConnStr {
-		v.GetLogger().Warn().
-			Msg("Storing migration-verifier’s metadata on the destination can significantly impede performance. Use a dedicated cluster for the metadata if you can.")
 	}
 
 	v.SetServerPort(cCtx.Int(serverPort))


### PR DESCRIPTION
This changes the `--metaURI` to default to the destination and updates documentation accordingly.

Two reasons:
- Few migrations—even large ones—actually use a dedicated cluster for the metadata.
- Recent query optimizations have largely obviated the need for a dedicated metadata cluster.