### PR TITLE
REP-7413 Make the retryer retry authn failures during tests

### DIFF
--- a/internal/retry/constants.go
+++ b/internal/retry/constants.go
@@ -3,6 +3,8 @@ package retry
 import "time"
 
 const (
+	authenticationFailedCode = 18
+
 	// DefaultDurationLimit is the default time limit for all retries.
 	DefaultDurationLimit = 10 * time.Minute
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/mmongo"
+	"github.com/10gen/migration-verifier/mslices"
 	"github.com/10gen/migration-verifier/msync"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -20,6 +21,9 @@ import (
 )
 
 type RetryCallback = func(context.Context, *FuncInfo) error
+
+// Overridden in tests
+var isTesting = testing.Testing()
 
 // Run() runs each given callback in parallel. If none of them fail,
 // then no error is returned.
@@ -309,12 +313,12 @@ func (r *Retryer) shouldRetryWithSleep(
 		return true
 	}
 
-	if testing.Testing() {
+	if isTesting {
 		// Unfortunately Go provides no compile-time mechanism to include this logic
 		// exclusively in tests, so we just put it in the production code.
-		retryableErrorCodesInTests := []int{
-			18, // AuthenticationFailed
-		}
+		retryableErrorCodesInTests := mslices.Of(
+			authenticationFailedCode,
+		)
 
 		if errHasAnyCode(err, retryableErrorCodesInTests) {
 			logger.Debug().

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,9 +1,11 @@
 package retry
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
+	"testing"
 	"time"
 
 	"github.com/10gen/migration-verifier/contextplus"
@@ -273,11 +275,9 @@ func (r *Retryer) shouldRetryWithSleep(
 		panic("nil error should not get here")
 	}
 
-	isTransient := util.IsTransientError(err) || lo.SomeBy(
-		r.additionalErrorCodes,
-		func(code int) bool {
-			return mmongo.ErrorHasCode(err, code)
-		},
+	isTransient := cmp.Or(
+		util.IsTransientError(err),
+		errHasAnyCode(err, r.additionalErrorCodes),
 	)
 
 	event := logger.WithLevel(
@@ -309,7 +309,34 @@ func (r *Retryer) shouldRetryWithSleep(
 		return true
 	}
 
+	if testing.Testing() {
+		// Unfortunately Go provides no compile-time mechanism to include this logic
+		// exclusively in tests, so we just put it in the production code.
+		retryableErrorCodesInTests := []int{
+			18, // AuthenticationFailed
+		}
+
+		if errHasAnyCode(err, retryableErrorCodesInTests) {
+			logger.Debug().
+				Strs("description", descriptions).
+				Err(err).
+				Msg("Treating error as retryable in test.")
+
+			return true
+		}
+	}
+
 	event.Msg("Non-retryable error occurred.")
+
+	return false
+}
+
+func errHasAnyCode(err error, codes []int) bool {
+	for _, code := range codes {
+		if mmongo.ErrorHasCode(err, code) {
+			return true
+		}
+	}
 
 	return false
 }

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -173,6 +173,64 @@ func (suite *UnitTestSuite) TestCancelViaContext() {
 	wg.Wait()
 }
 
+// TestAuthnError verifies that authentication errors are retried in tests.
+//
+// Ideally we’d also check that they’re *NOT* retried in production, but we
+// have no good way to flex that since the production code checks
+// testing.Testing().
+func (suite *UnitTestSuite) TestAuthnError() {
+	ctx := suite.Context()
+	logger := suite.Logger()
+
+	customError := mongo.CommandError{
+		Name: "MySpecialAuthnError",
+		Code: authenticationFailedCode,
+	}
+
+	var attemptNumber int
+	f := func(_ context.Context, ri *FuncInfo) error {
+		attemptNumber = ri.GetAttemptNumber()
+		if attemptNumber == 0 {
+			return customError
+		}
+		return nil
+	}
+
+	suite.Run(
+		"test",
+		func() {
+			attemptNumber = 0
+
+			retryer := New()
+			err := retryer.WithCallback(f, "f").Run(ctx, logger)
+			suite.Assert().NoError(err)
+			suite.Assert().Equal(1, attemptNumber)
+		},
+	)
+
+	suite.Run(
+		"production",
+		func() {
+			attemptNumber = 0
+
+			isTesting = false
+			defer func() {
+				isTesting = true
+			}()
+
+			retryer := New()
+			err := retryer.WithCallback(f, "f").Run(ctx, logger)
+			suite.Assert().Error(err)
+			suite.Assert().Contains(
+				mongo.ErrorCodes(err),
+				authenticationFailedCode,
+				"error must indicate authn failure",
+			)
+			suite.Assert().Equal(0, attemptNumber)
+		},
+	)
+}
+
 func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	logger := suite.Logger()
 


### PR DESCRIPTION
This resolves some flaky downstream tests.