### PR TITLE
Make GetShardKey retry on transient errors.

### DIFF
--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -1,8 +1,11 @@
-package util
+package sharding
 
 import (
 	"context"
 
+	"github.com/10gen/migration-verifier/internal/logger"
+	"github.com/10gen/migration-verifier/internal/retry"
+	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/mongodb-labs/migration-tools/option"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -20,6 +23,7 @@ const (
 // if the collection is unsharded.
 func GetShardKey(
 	ctx context.Context,
+	logger *logger.Logger,
 	coll *mongo.Collection,
 ) (option.Option[bson.Raw], error) {
 	namespace := coll.Database().Name() + "." + coll.Name()
@@ -32,18 +36,28 @@ func GetShardKey(
 		Key option.Option[bson.Raw]
 	}{}
 
-	err := configCollectionsColl.
-		FindOne(ctx, bson.D{{"_id", namespace}}).
-		Decode(&decoded)
+	err := retry.New().WithCallback(
+		func(ctx context.Context, ri *retry.FuncInfo) error {
+			err := configCollectionsColl.
+				FindOne(ctx, bson.D{{"_id", namespace}}).
+				Decode(&decoded)
 
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return option.None[bson.Raw](), nil
-	} else if err != nil {
-		return option.None[bson.Raw](), errors.Wrapf(
-			err,
-			"failed to find sharding info for %#q",
-			namespace,
-		)
+			if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+				return errors.Wrapf(
+					err,
+					"failed to find sharding info for %#q",
+					namespace,
+				)
+			}
+
+			return nil
+		},
+		"fetch %#q’s shard key",
+		namespace,
+	).Run(ctx, logger)
+
+	if err != nil {
+		return option.None[bson.Raw](), err
 	}
 
 	key, hasKey := decoded.Key.Get()
@@ -60,7 +74,7 @@ func DisableBalancing(ctx context.Context, coll *mongo.Collection) error {
 	client := coll.Database().Client()
 	configDB := client.Database("config")
 
-	ns := FullName(coll)
+	ns := util.FullName(coll)
 
 	_, err := configDB.
 		Collection(

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -21,6 +21,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/internal/reportutils"
 	"github.com/10gen/migration-verifier/internal/retry"
+	"github.com/10gen/migration-verifier/internal/sharding"
 	"github.com/10gen/migration-verifier/internal/types"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/uuidutil"
@@ -884,7 +885,7 @@ func (verifier *Verifier) getShardKeyFields(
 	coll := verifier.srcClient.Database(namespaceAndUUID.DBName).
 		Collection(namespaceAndUUID.CollName)
 
-	shardKeyOpt, err := util.GetShardKey(ctx, coll)
+	shardKeyOpt, err := sharding.GetShardKey(ctx, verifier.logger, coll)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/internal/retry"
+	"github.com/10gen/migration-verifier/internal/sharding"
 	"github.com/10gen/migration-verifier/internal/testutil"
 	"github.com/10gen/migration-verifier/internal/types"
 	"github.com/10gen/migration-verifier/internal/util"
@@ -275,7 +276,7 @@ func (suite *IntegrationTestSuite) TestVerifier_Dotted_Shard_Key() {
 		)
 
 		require.NoError(
-			util.DisableBalancing(ctx, coll),
+			sharding.DisableBalancing(ctx, coll),
 			"should disable %#q’s balancing on %s",
 			FullName(coll),
 			clientLabel,

--- a/internal/verifier/sharding.go
+++ b/internal/verifier/sharding.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/10gen/migration-verifier/internal/sharding"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/verifier/compare"
 	"github.com/10gen/migration-verifier/internal/verifier/constants"
@@ -29,7 +30,7 @@ func (verifier *Verifier) verifyShardingIfNeeded(
 		return nil, nil
 	}
 
-	srcShardOpt, err := util.GetShardKey(ctx, srcColl)
+	srcShardOpt, err := sharding.GetShardKey(ctx, verifier.logger, srcColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -38,7 +39,7 @@ func (verifier *Verifier) verifyShardingIfNeeded(
 		)
 	}
 
-	dstShardOpt, err := util.GetShardKey(ctx, dstColl)
+	dstShardOpt, err := sharding.GetShardKey(ctx, verifier.logger, dstColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,


### PR DESCRIPTION
This resolves downstream test flapping.