### PR TITLE
REP-7428 Fix missing retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 )
 
 require (
-	github.com/ccoveille/go-safecast/v2 v2.0.0
-	github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0
+	github.com/ccoveille/go-safecast/v2 v2.0.1
+	github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877
 	github.com/samber/slog-zerolog/v2 v2.9.2
 	github.com/wI2L/jsondiff v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCN
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/ccoveille/go-safecast/v2 v2.0.0 h1:+5eyITXAUj3wMjad6cRVJKGnC7vDS55zk0INzJagub0=
 github.com/ccoveille/go-safecast/v2 v2.0.0/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
+github.com/ccoveille/go-safecast/v2 v2.0.1 h1:2+mIu3gXtwmWelBia2kkxfB8eP4orTHDH7ClSlWkd6I=
+github.com/ccoveille/go-safecast/v2 v2.0.1/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
 github.com/cespare/permute/v2 v2.0.0-beta2 h1:iiJWgDsInCbnwfDZiLJX7cVlJevgIM1pUiArcUylUMc=
 github.com/cespare/permute/v2 v2.0.0-beta2/go.mod h1:7e2Tqe0fjn1T4rTjDLJjQ+kNtt+UW4B9lg10asqWw0A=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
@@ -94,6 +96,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0 h1:rcwt6yxagYjYtM83Ayxl5GbcErFvBS51k57+saTJDj8=
 github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0/go.mod h1:sBx9rr+6+EPgS9hEot8oLGXiBKoiwX6tQ46xKO2g5u4=
+github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877 h1:EZ0cmoqYznA2k/Ro+5cbC8EupnAMIpLbUsiblfsyKM4=
+github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877/go.mod h1:kr/kTzB30NlOUXeib9a/wmT5eysIog/fEpc1T0Ze++U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/internal/retry/constants.go
+++ b/internal/retry/constants.go
@@ -5,8 +5,8 @@ import "time"
 const (
 	authenticationFailedCode = 18
 
-	// DefaultDurationLimit is the default time limit for all retries.
-	DefaultDurationLimit = 10 * time.Minute
+	// DefaultTimeLimit is the default time limit for all retries.
+	DefaultTimeLimit = 10 * time.Minute
 
 	// Constants for spacing out the retry attempts.
 	// See: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/internal/retry/error.go
+++ b/internal/retry/error.go
@@ -7,13 +7,13 @@ import (
 	"github.com/10gen/migration-verifier/internal/reportutils"
 )
 
-type RetryDurationLimitExceededErr struct {
+type RetryLimitExceededErr struct {
 	lastErr  error
 	attempts int
 	duration time.Duration
 }
 
-func (rde RetryDurationLimitExceededErr) Error() string {
+func (rde RetryLimitExceededErr) Error() string {
 	return fmt.Sprintf(
 		"retryable function did not succeed after %d attempt(s) over %s; last error was: %v",
 		rde.attempts,
@@ -22,7 +22,7 @@ func (rde RetryDurationLimitExceededErr) Error() string {
 	)
 }
 
-func (rde RetryDurationLimitExceededErr) Unwrap() error {
+func (rde RetryLimitExceededErr) Unwrap() error {
 	return rde.lastErr
 }
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -74,7 +74,8 @@ func (r *Retryer) runRetryLoop(
 	startTime := time.Now()
 
 	li := &LoopInfo{
-		timeLimit: r.timeLimit,
+		timeLimit:   r.timeLimit,
+		maxAttempts: r.maxAttempts,
 	}
 	funcinfos := lo.Map(
 		r.callbacks,

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -35,8 +35,9 @@ var isTesting = testing.Testing()
 // The retryer tracks the last time each callback either a) succeeded or b)
 // was canceled. Whenever a callback fails, the retryer checks how long it
 // has gone since a success/cancellation. If that time period exceeds the
-// retryer's duration limit, then the retry loop ends, and a
-// RetryDurationLimitExceededErr is returned.
+// retryer's duration limit, or if the number of attempts exceeds the retryer’s
+// attempt limit, then the retryer returns an error instead of retrying again.
+// (By default only duration is limited, but either or both limits can be set.)
 //
 // Note that, if a given callback runs multiple potentially-retryable requests,
 // each successful request should be noted in the callback's FuncInfo.

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -74,7 +74,7 @@ func (r *Retryer) runRetryLoop(
 	startTime := time.Now()
 
 	li := &LoopInfo{
-		durationLimit: r.retryLimit,
+		timeLimit: r.timeLimit,
 	}
 	funcinfos := lo.Map(
 		r.callbacks,
@@ -194,17 +194,29 @@ func (r *Retryer) runRetryLoop(
 			return wrapErrWithDescriptions(cbErr, descriptions)
 		}
 
-		// Our error is transient. If we've exhausted the allowed time
-		// then fail.
+		// Our error is transient. If we've exhausted the allowed time or
+		// attempts then fail.
+		limitExceeded := false
 
-		if failedFuncInfo.GetDurationSoFar() > li.durationLimit {
-			var err error = RetryDurationLimitExceededErr{
-				attempts: li.attemptsSoFar,
-				duration: failedFuncInfo.GetDurationSoFar(),
-				lastErr:  groupErr.errFromCallback,
+		if maxDuration, has := li.timeLimit.Get(); has {
+			limitExceeded = failedFuncInfo.GetDurationSoFar() > maxDuration
+		}
+
+		if !limitExceeded {
+			if maxAttempts, has := li.maxAttempts.Get(); has {
+				limitExceeded = li.attemptsSoFar >= maxAttempts
 			}
+		}
 
-			return wrapErrWithDescriptions(err, descriptions)
+		if limitExceeded {
+			return wrapErrWithDescriptions(
+				RetryLimitExceededErr{
+					attempts: li.attemptsSoFar,
+					duration: failedFuncInfo.GetDurationSoFar(),
+					lastErr:  groupErr.errFromCallback,
+				},
+				descriptions,
+			)
 		}
 
 		// Sleep and increase the sleep time for the next retry,

--- a/internal/retry/retry_info.go
+++ b/internal/retry/retry_info.go
@@ -19,7 +19,8 @@ import (
 // The duration tracks the duration of retrying for transient errors only.
 type LoopInfo struct {
 	attemptsSoFar int
-	durationLimit time.Duration
+	timeLimit     option.Option[time.Duration]
+	maxAttempts   option.Option[int]
 }
 
 type lastResetInfo struct {
@@ -68,9 +69,19 @@ func (fi *FuncInfo) Log(logger *zerolog.Logger, cmdName string, clientType strin
 	}
 	event.Str("context", msg).
 		Int("attemptNumber", fi.GetAttemptNumber()).
-		Str("durationSoFar", reportutils.DurationToHMS(fi.GetDurationSoFar())).
-		Str("durationLimit", reportutils.DurationToHMS(fi.loopInfo.durationLimit)).
-		Msg("Running retryable function")
+		Str("durationSoFar", reportutils.DurationToHMS(fi.GetDurationSoFar()))
+
+	if timeLimit, has := fi.loopInfo.timeLimit.Get(); has {
+		event.
+			Str("timeLimit", reportutils.DurationToHMS(timeLimit))
+	}
+
+	if maxAttempts, has := fi.loopInfo.maxAttempts.Get(); has {
+		event.
+			Int("maxAttempts", maxAttempts)
+	}
+
+	event.Msg("Running retryable function")
 }
 
 // GetAttemptNumber returns the Info's current attempt number (0-indexed).

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -23,7 +23,7 @@ type Retryer struct {
 	maxAttempts          option.Option[int]
 }
 
-// New returns a new Retryer with DefaultDurationLimit as its time limit.
+// New returns a new Retryer with DefaultTimeLimit as its time limit.
 func New() *Retryer {
 	return &Retryer{
 		timeLimit: option.Some(DefaultTimeLimit),

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -44,7 +44,7 @@ func (r *Retryer) WithErrorCodes(codes ...int) *Retryer {
 
 // WithTimeLimit returns a new retryer with the specified time limit.
 func (r *Retryer) WithTimeLimit(limit time.Duration) *Retryer {
-	lo.Assert(limit > 0, "time limit must be positive")
+	lo.Assert(limit >= 0, "time limit must be nonnegative")
 
 	r2 := r.clone()
 	r2.timeLimit = option.Some(limit)

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -15,17 +15,18 @@ type retryCallbackInfo struct {
 
 // Retryer handles retrying operations that fail because of network failures.
 type Retryer struct {
-	retryLimit           time.Duration
+	timeLimit            option.Option[time.Duration]
 	before               option.Option[func() error]
 	callbacks            []retryCallbackInfo
 	description          option.Option[string]
 	additionalErrorCodes []int
+	maxAttempts          option.Option[int]
 }
 
 // New returns a new Retryer with DefaultDurationLimit as its time limit.
 func New() *Retryer {
 	return &Retryer{
-		retryLimit: DefaultDurationLimit,
+		timeLimit: option.Some(DefaultTimeLimit),
 	}
 }
 
@@ -40,10 +41,24 @@ func (r *Retryer) WithErrorCodes(codes ...int) *Retryer {
 	return r2
 }
 
-// WithRetryLimit returns a new retryer with the specified time limit.
-func (r *Retryer) WithRetryLimit(limit time.Duration) *Retryer {
+// WithTimeLimit returns a new retryer with the specified time limit.
+func (r *Retryer) WithTimeLimit(limit time.Duration) *Retryer {
 	r2 := r.clone()
-	r2.retryLimit = limit
+	r2.timeLimit = option.Some(limit)
+
+	return r2
+}
+
+func (r *Retryer) WithoutTimeLimit() *Retryer {
+	r2 := r.clone()
+	r2.timeLimit = r2.timeLimit.ToNone()
+
+	return r2
+}
+
+func (r *Retryer) WithMaxAttempts(max int) *Retryer {
+	r2 := r.clone()
+	r2.maxAttempts = option.Some(max)
 
 	return r2
 }

--- a/internal/retry/retryer.go
+++ b/internal/retry/retryer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mongodb-labs/migration-tools/option"
+	"github.com/samber/lo"
 )
 
 type retryCallbackInfo struct {
@@ -43,6 +44,8 @@ func (r *Retryer) WithErrorCodes(codes ...int) *Retryer {
 
 // WithTimeLimit returns a new retryer with the specified time limit.
 func (r *Retryer) WithTimeLimit(limit time.Duration) *Retryer {
+	lo.Assert(limit > 0, "time limit must be positive")
+
 	r2 := r.clone()
 	r2.timeLimit = option.Some(limit)
 
@@ -57,6 +60,8 @@ func (r *Retryer) WithoutTimeLimit() *Retryer {
 }
 
 func (r *Retryer) WithMaxAttempts(max int) *Retryer {
+	lo.Assert(max > 0, "max attempts must be positive")
+
 	r2 := r.clone()
 	r2.maxAttempts = option.Some(max)
 

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/10gen/migration-verifier/contextplus"
@@ -47,30 +49,92 @@ func (suite *UnitTestSuite) TestRetryer() {
 
 	suite.Run("with a function that succeeds after two attempts", func() {
 		attemptNumber := -1
-		f := func(_ context.Context, ri *FuncInfo) error {
-			attemptNumber = ri.GetAttemptNumber()
-			if attemptNumber < 2 {
-				return someNetworkError
-			}
-			return nil
-		}
+		var err error
 
-		err := retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		synctest.Test(suite.T(), func(*testing.T) {
+			f := func(_ context.Context, ri *FuncInfo) error {
+				attemptNumber = ri.GetAttemptNumber()
+				if attemptNumber < 2 {
+					return someNetworkError
+				}
+				return nil
+			}
+			err = retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		})
 		suite.NoError(err)
 		suite.Equal(2, attemptNumber)
 
-		attemptNumber = -1
-		f2 := func(_ context.Context, ri *FuncInfo) error {
-			attemptNumber = ri.GetAttemptNumber()
-			if attemptNumber < 2 {
-				return someNetworkError
+		synctest.Test(suite.T(), func(*testing.T) {
+			attemptNumber = -1
+			f2 := func(_ context.Context, ri *FuncInfo) error {
+				attemptNumber = ri.GetAttemptNumber()
+				if attemptNumber < 2 {
+					return someNetworkError
+				}
+				return nil
 			}
-			return nil
-		}
-
-		err = retryer.WithCallback(f2, "f2").Run(suite.Context(), logger)
+			err = retryer.WithCallback(f2, "f2").Run(suite.Context(), logger)
+		})
 		suite.NoError(err)
 		suite.Equal(2, attemptNumber)
+	})
+}
+
+func (suite *UnitTestSuite) TestRetryerMaxAttempts() {
+	ctx := suite.Context()
+	logger := suite.Logger()
+
+	errTransient := someNetworkError
+
+	makeCounter := func(failTimes int) (func(context.Context, *FuncInfo) error, *int) {
+		attempts := 0
+		return func(_ context.Context, _ *FuncInfo) error {
+			attempts++
+			if attempts <= failTimes {
+				return errTransient
+			}
+			return nil
+		}, &attempts
+	}
+
+	retryer := New().WithMaxAttempts(3).WithoutTimeLimit()
+
+	suite.Run("succeeds on first attempt", func() {
+		f, attempts := makeCounter(0)
+		err := retryer.WithCallback(f, "f").Run(ctx, logger)
+		suite.NoError(err)
+		suite.Equal(1, *attempts)
+	})
+
+	suite.Run("fails once then succeeds", func() {
+		f, attempts := makeCounter(1)
+		var err error
+		synctest.Test(suite.T(), func(*testing.T) {
+			err = retryer.WithCallback(f, "f").Run(ctx, logger)
+		})
+		suite.NoError(err)
+		suite.Equal(2, *attempts)
+	})
+
+	suite.Run("fails twice then succeeds", func() {
+		f, attempts := makeCounter(2)
+		var err error
+		synctest.Test(suite.T(), func(*testing.T) {
+			err = retryer.WithCallback(f, "f").Run(ctx, logger)
+		})
+		suite.NoError(err)
+		suite.Equal(3, *attempts)
+	})
+
+	suite.Run("fails all 3 times", func() {
+		f, attempts := makeCounter(3)
+		var err error
+		synctest.Test(suite.T(), func(*testing.T) {
+			err = retryer.WithCallback(f, "f").Run(ctx, logger)
+		})
+		suite.ErrorAs(err, &RetryLimitExceededErr{})
+		suite.ErrorIs(err, errTransient)
+		suite.Equal(3, *attempts)
 	})
 }
 
@@ -127,18 +191,20 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 	// 2) Calling IterationSuccess() means f will run more than once because the
 	// duration should be reset.
 	successIterations := 0
-	f2 := func(_ context.Context, ri *FuncInfo) error {
-		ri.NoteSuccess("immediate success")
+	synctest.Test(suite.T(), func(*testing.T) {
+		f2 := func(_ context.Context, ri *FuncInfo) error {
+			ri.NoteSuccess("immediate success")
 
-		successIterations++
-		if successIterations == 1 {
-			return someNetworkError
+			successIterations++
+			if successIterations == 1 {
+				return someNetworkError
+			}
+
+			return nil
 		}
 
-		return nil
-	}
-
-	err = retryer.WithCallback(f2, "f2").Run(suite.Context(), logger)
+		err = retryer.WithCallback(f2, "f2").Run(suite.Context(), logger)
+	})
 	suite.Assert().NoError(err)
 	suite.Assert().Equal(2, successIterations)
 }
@@ -175,7 +241,7 @@ func (suite *UnitTestSuite) TestCancelViaContext() {
 
 // TestAuthnError verifies that authentication errors are retried in tests.
 //
-// Ideally we’d also check that they’re *NOT* retried in production, but we
+// Ideally we'd also check that they're *NOT* retried in production, but we
 // have no good way to flex that since the production code checks
 // testing.Testing().
 func (suite *UnitTestSuite) TestAuthnError() {
@@ -199,10 +265,12 @@ func (suite *UnitTestSuite) TestAuthnError() {
 	suite.Run(
 		"test",
 		func() {
-			attemptNumber = 0
-
-			retryer := New()
-			err := retryer.WithCallback(f, "f").Run(ctx, logger)
+			var err error
+			synctest.Test(suite.T(), func(*testing.T) {
+				attemptNumber = 0
+				retryer := New()
+				err = retryer.WithCallback(f, "f").Run(ctx, logger)
+			})
 			suite.Assert().NoError(err)
 			suite.Assert().Equal(1, attemptNumber)
 		},
@@ -256,17 +324,21 @@ func (suite *UnitTestSuite) TestRetryerAdditionalErrorCodes() {
 	})
 
 	suite.Run("with one additional error code", func() {
-		retryer := New()
-		retryer = retryer.WithErrorCodes(42)
-		err := retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		var err error
+		synctest.Test(suite.T(), func(*testing.T) {
+			retryer := New().WithErrorCodes(42)
+			err = retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		})
 		suite.NoError(err)
 		suite.Equal(1, attemptNumber)
 	})
 
 	suite.Run("with multiple additional error codes", func() {
-		retryer := New()
-		retryer = retryer.WithErrorCodes(42, 43, 44)
-		err := retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		var err error
+		synctest.Test(suite.T(), func(*testing.T) {
+			retryer := New().WithErrorCodes(42, 43, 44)
+			err = retryer.WithCallback(f, "f").Run(suite.Context(), logger)
+		})
 		suite.NoError(err)
 		suite.Equal(1, attemptNumber)
 	})
@@ -315,27 +387,30 @@ func (suite *UnitTestSuite) TestMulti_Transient() {
 			func() {
 				cb1Attempts := 0
 				cb2Attempts := 0
+				var err error
 
-				err := New().WithCallback(
-					func(ctx context.Context, _ *FuncInfo) error {
-						cb1Attempts++
+				synctest.Test(suite.T(), func(*testing.T) {
+					err = New().WithCallback(
+						func(ctx context.Context, _ *FuncInfo) error {
+							cb1Attempts++
 
-						return nil
-					},
-					"succeeds every time",
-				).WithCallback(
-					func(_ context.Context, _ *FuncInfo) error {
-						cb2Attempts++
+							return nil
+						},
+						"succeeds every time",
+					).WithCallback(
+						func(_ context.Context, _ *FuncInfo) error {
+							cb2Attempts++
 
-						switch cb2Attempts {
-						case 1, 2:
-							return someNetworkError
-						default:
-							return finalErr
-						}
-					},
-					"fails variously",
-				).Run(ctx, logger)
+							switch cb2Attempts {
+							case 1, 2:
+								return someNetworkError
+							default:
+								return finalErr
+							}
+						},
+						"fails variously",
+					).Run(ctx, logger)
+				})
 
 				if finalErr == nil {
 					suite.Assert().NoError(err)
@@ -351,41 +426,44 @@ func (suite *UnitTestSuite) TestMulti_Transient() {
 }
 
 // TestMulti_LongRunningSuccess verifies that a long-running
-// success won’t spuriously fail because another thread keeps
+// success won't spuriously fail because another thread keeps
 // restarting.
 func (suite *UnitTestSuite) TestMulti_LongRunningSuccess() {
 	ctx := suite.Context()
 	logger := suite.Logger()
 
-	startTime := time.Now()
-	retryerLimit := 2 * time.Second
-	retryer := New().WithTimeLimit(retryerLimit)
+	var err error
+	synctest.Test(suite.T(), func(*testing.T) {
+		startTime := time.Now()
+		retryerLimit := 2 * time.Second
+		retryer := New().WithTimeLimit(retryerLimit)
 
-	succeedPastTime := startTime.Add(retryerLimit + 1*time.Second)
+		succeedPastTime := startTime.Add(retryerLimit + 1*time.Second)
 
-	err := retryer.WithCallback(
-		func(ctx context.Context, fi *FuncInfo) error {
-			fi.NoteSuccess("success right away")
+		err = retryer.WithCallback(
+			func(ctx context.Context, fi *FuncInfo) error {
+				fi.NoteSuccess("success right away")
 
-			if time.Now().Before(succeedPastTime) {
-				time.Sleep(1 * time.Second)
-				return someNetworkError
-			}
+				if time.Now().Before(succeedPastTime) {
+					time.Sleep(1 * time.Second)
+					return someNetworkError
+				}
 
-			return nil
-		},
-		"quick success, then fail; all success after a bit",
-	).WithCallback(
-		func(ctx context.Context, fi *FuncInfo) error {
-			if time.Now().Before(succeedPastTime) {
-				<-ctx.Done()
-				return ctx.Err()
-			}
+				return nil
+			},
+			"quick success, then fail; all success after a bit",
+		).WithCallback(
+			func(ctx context.Context, fi *FuncInfo) error {
+				if time.Now().Before(succeedPastTime) {
+					<-ctx.Done()
+					return ctx.Err()
+				}
 
-			return nil
-		},
-		"long-running: hangs then succeeds",
-	).Run(ctx, logger)
+				return nil
+			},
+			"long-running: hangs then succeeds",
+		).Run(ctx, logger)
+	})
 
 	suite.Assert().NoError(err)
 }

--- a/internal/retry/retryer_test.go
+++ b/internal/retry/retryer_test.go
@@ -75,7 +75,7 @@ func (suite *UnitTestSuite) TestRetryer() {
 }
 
 func (suite *UnitTestSuite) TestRetryerDurationLimitIsZero() {
-	retryer := New().WithRetryLimit(0)
+	retryer := New().WithTimeLimit(0)
 
 	attemptNumber := -1
 	f := func(_ context.Context, ri *FuncInfo) error {
@@ -103,7 +103,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 		// Artificially advance how much time was taken.
 		ri.lastReset.Store(
 			lastResetInfo{
-				time:        ri.lastReset.Load().time.Add(-2 * ri.loopInfo.durationLimit),
+				time:        ri.lastReset.Load().time.Add(-2 * ri.loopInfo.timeLimit.MustGet()),
 				description: option.Some("artificially rewinding time"),
 			},
 		)
@@ -120,7 +120,7 @@ func (suite *UnitTestSuite) TestRetryerDurationReset() {
 
 	// The error should be the limit-exceeded error, with the
 	// last-noted error being the transient error.
-	suite.Assert().ErrorAs(err, &RetryDurationLimitExceededErr{})
+	suite.Assert().ErrorAs(err, &RetryLimitExceededErr{})
 	suite.Assert().ErrorIs(err, someNetworkError)
 	suite.Equal(1, noSuccessIterations)
 
@@ -359,7 +359,7 @@ func (suite *UnitTestSuite) TestMulti_LongRunningSuccess() {
 
 	startTime := time.Now()
 	retryerLimit := 2 * time.Second
-	retryer := New().WithRetryLimit(retryerLimit)
+	retryer := New().WithTimeLimit(retryerLimit)
 
 	succeedPastTime := startTime.Add(retryerLimit + 1*time.Second)
 

--- a/internal/verifier/change_reader.go
+++ b/internal/verifier/change_reader.go
@@ -405,21 +405,12 @@ func (rc *ChangeReaderCommon) persistResumeToken(ctx context.Context, token bson
 	}
 
 	coll := rc.metaDB.Collection(changeReaderCollectionName)
-
-	err = retry.New().WithCallback(
-		func(ctx context.Context, ri *retry.FuncInfo) error {
-			_, err := coll.ReplaceOne(
-				ctx,
-				bson.D{{"_id", docID}},
-				doc,
-				options.Replace().SetUpsert(true),
-			)
-			return err
-		},
-		"persisting %s resume token",
-		rc.readerType,
-	).Run(ctx, rc.logger)
-
+	_, err = coll.ReplaceOne(
+		ctx,
+		bson.D{{"_id", docID}},
+		doc,
+		options.Replace().SetUpsert(true),
+	)
 	if err != nil {
 		return errors.Wrapf(err, "persisting %s resume token (%v)", rc.readerType, token)
 	}

--- a/internal/verifier/change_reader.go
+++ b/internal/verifier/change_reader.go
@@ -405,12 +405,21 @@ func (rc *ChangeReaderCommon) persistResumeToken(ctx context.Context, token bson
 	}
 
 	coll := rc.metaDB.Collection(changeReaderCollectionName)
-	_, err = coll.ReplaceOne(
-		ctx,
-		bson.D{{"_id", docID}},
-		doc,
-		options.Replace().SetUpsert(true),
-	)
+
+	err = retry.New().WithCallback(
+		func(ctx context.Context, ri *retry.FuncInfo) error {
+			_, err := coll.ReplaceOne(
+				ctx,
+				bson.D{{"_id", docID}},
+				doc,
+				options.Replace().SetUpsert(true),
+			)
+			return err
+		},
+		"persisting %s resume token",
+		rc.readerType,
+	).Run(ctx, rc.logger)
+
 	if err != nil {
 		return errors.Wrapf(err, "persisting %s resume token (%v)", rc.readerType, token)
 	}

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -634,40 +634,46 @@ func (verifier *Verifier) work(
 			}
 		}
 
-		verifier.workerTracker.Set(workerNum, task)
+		err = verifier.processAnyTask(ctx, workerNum, task)
+		if err != nil {
+			return err
+		}
 
-		switch task.Type {
-		case tasks.VerifyCollection:
-			err := verifier.ProcessCollectionVerificationTask(ctx, workerNum, &task)
-			verifier.workerTracker.Unset(workerNum)
+		if task.Type == tasks.VerifyCollection && task.Generation == 0 {
 
-			if err != nil {
-				return errors.Wrapf(err, "process %#q task %#q", task.Type, task.PrimaryKey)
+			newVal := verifier.gen0PendingCollectionTasks.Add(-1)
+			if newVal == 0 {
+				verifier.PrintVerificationSummary(ctx, Gen0MetadataAnalysisComplete)
 			}
-			if task.Generation == 0 {
-				newVal := verifier.gen0PendingCollectionTasks.Add(-1)
-				if newVal == 0 {
-					verifier.PrintVerificationSummary(ctx, Gen0MetadataAnalysisComplete)
-				}
-			}
-		case tasks.VerifyDocuments:
-			err := verifier.ProcessVerifyTask(ctx, workerNum, &task)
-			verifier.workerTracker.Unset(workerNum)
-
-			if err != nil {
-				return errors.Wrapf(err, "process %#q task %#q", task.Type, task.PrimaryKey)
-			}
-		case tasks.ProcessRecheckQueue:
-			err := verifier.processCreateRechecksTask(ctx, task)
-			verifier.workerTracker.Unset(workerNum)
-
-			if err != nil {
-				return errors.Wrapf(err, "process %#q task %#q", task.Type, task.PrimaryKey)
-			}
-		default:
-			panic("Unknown verification task type: " + task.Type)
 		}
 	}
+}
+
+func (verifier *Verifier) processAnyTask(
+	ctx context.Context,
+	workerNum int,
+	task tasks.Task,
+) error {
+	verifier.workerTracker.Set(workerNum, task)
+	defer verifier.workerTracker.Unset(workerNum)
+
+	return retry.New().WithCallback(
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			switch task.Type {
+			case tasks.VerifyCollection:
+				return verifier.ProcessCollectionVerificationTask(ctx, -1, &task)
+			case tasks.VerifyDocuments:
+				return verifier.ProcessVerifyTask(ctx, -1, &task)
+			case tasks.ProcessRecheckQueue:
+				return verifier.processCreateRechecksTask(ctx, task)
+			default:
+				panic("Unknown verification task type: " + task.Type)
+			}
+		},
+		"process %#q task %#q",
+		task.Type,
+		task.PrimaryKey,
+	).Run(ctx, verifier.logger)
 }
 
 func (verifier *Verifier) processCreateRechecksTask(

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -661,9 +661,9 @@ func (verifier *Verifier) processAnyTask(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
 			switch task.Type {
 			case tasks.VerifyCollection:
-				return verifier.ProcessCollectionVerificationTask(ctx, -1, &task)
+				return verifier.ProcessCollectionVerificationTask(ctx, workerNum, &task)
 			case tasks.VerifyDocuments:
-				return verifier.ProcessVerifyTask(ctx, -1, &task)
+				return verifier.ProcessVerifyTask(ctx, workerNum, &task)
 			case tasks.ProcessRecheckQueue:
 				return verifier.processCreateRechecksTask(ctx, task)
 			default:

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -663,9 +663,29 @@ func (verifier *Verifier) processAnyTask(
 		WithoutTimeLimit().
 		WithMaxAttempts(5).
 		WithCallback(
-			func(ctx context.Context, _ *retry.FuncInfo) error {
+			func(ctx context.Context, fi *retry.FuncInfo) error {
 				switch task.Type {
 				case tasks.VerifyCollection:
+					if fi.GetAttemptNumber() > 0 {
+						verifier.logger.Info().
+							Int("workerNum", workerNum).
+							Any("task", task.PrimaryKey).
+							Int("attemptNumber", fi.GetAttemptNumber()).
+							Msg("Clearing mismatches before retrying task.")
+
+						err := clearMismatchesForTask(
+							ctx,
+							verifier.verificationDatabase(),
+							task.PrimaryKey,
+						)
+						if err != nil {
+							verifier.logger.Warn().
+								Err(err).
+								Any("task", task.PrimaryKey).
+								Msg("Failed to clear mismatches before retrying task. You may see duplicate mismatches.")
+						}
+					}
+
 					return verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
 				case tasks.VerifyDocuments:
 					_, err := verifier.ProcessVerifyTask(ctx, workerNum, task)

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -640,7 +640,6 @@ func (verifier *Verifier) work(
 		}
 
 		if task.Type == tasks.VerifyCollection && task.Generation == 0 {
-
 			newVal := verifier.gen0PendingCollectionTasks.Add(-1)
 			if newVal == 0 {
 				verifier.PrintVerificationSummary(ctx, Gen0MetadataAnalysisComplete)
@@ -661,9 +660,10 @@ func (verifier *Verifier) processAnyTask(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
 			switch task.Type {
 			case tasks.VerifyCollection:
-				return verifier.ProcessCollectionVerificationTask(ctx, -1, &task)
+				return verifier.ProcessCollectionVerificationTask(ctx, -1, task)
 			case tasks.VerifyDocuments:
-				return verifier.ProcessVerifyTask(ctx, -1, &task)
+				_, err := verifier.ProcessVerifyTask(ctx, -1, task)
+				return err
 			case tasks.ProcessRecheckQueue:
 				return verifier.processCreateRechecksTask(ctx, task)
 			default:

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -664,28 +664,16 @@ func (verifier *Verifier) processAnyTask(
 		WithMaxAttempts(5).
 		WithCallback(
 			func(ctx context.Context, fi *retry.FuncInfo) error {
+				// This is useless, but also harmless, for recheck-queue tasks:
+				verifier.clearMismatchesIfRetryingTask(
+					ctx,
+					workerNum,
+					task.PrimaryKey,
+					fi.GetAttemptNumber(),
+				)
+
 				switch task.Type {
 				case tasks.VerifyCollection:
-					if fi.GetAttemptNumber() > 0 {
-						verifier.logger.Info().
-							Int("workerNum", workerNum).
-							Any("task", task.PrimaryKey).
-							Int("attemptNumber", fi.GetAttemptNumber()).
-							Msg("Clearing mismatches before retrying task.")
-
-						err := clearMismatchesForTask(
-							ctx,
-							verifier.verificationDatabase(),
-							task.PrimaryKey,
-						)
-						if err != nil {
-							verifier.logger.Warn().
-								Err(err).
-								Any("task", task.PrimaryKey).
-								Msg("Failed to clear mismatches before retrying task. You may see duplicate mismatches.")
-						}
-					}
-
 					return verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
 				case tasks.VerifyDocuments:
 					_, err := verifier.ProcessVerifyTask(ctx, workerNum, task)
@@ -700,6 +688,35 @@ func (verifier *Verifier) processAnyTask(
 			task.Type,
 			task.PrimaryKey,
 		).Run(ctx, verifier.logger)
+}
+
+func (verifier *Verifier) clearMismatchesIfRetryingTask(
+	ctx context.Context,
+	workerNum int,
+	taskID bson.ObjectID,
+	attemptNumber int,
+) {
+	if attemptNumber == 0 {
+		return
+	}
+
+	verifier.logger.Info().
+		Int("workerNum", workerNum).
+		Any("task", taskID).
+		Int("attemptNumber", attemptNumber).
+		Msg("Clearing mismatches before retrying task.")
+
+	err := clearMismatchesForTask(
+		ctx,
+		verifier.verificationDatabase(),
+		taskID,
+	)
+	if err != nil {
+		verifier.logger.Warn().
+			Err(err).
+			Any("task", taskID).
+			Msg("Failed to clear mismatches before retrying task. You may see duplicate mismatches.")
+	}
 }
 
 func (verifier *Verifier) processCreateRechecksTask(

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -656,24 +656,30 @@ func (verifier *Verifier) processAnyTask(
 	verifier.workerTracker.Set(workerNum, task)
 	defer verifier.workerTracker.Unset(workerNum)
 
-	return retry.New().WithCallback(
-		func(ctx context.Context, _ *retry.FuncInfo) error {
-			switch task.Type {
-			case tasks.VerifyCollection:
-				return verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
-			case tasks.VerifyDocuments:
-				_, err := verifier.ProcessVerifyTask(ctx, workerNum, task)
-				return err
-			case tasks.ProcessRecheckQueue:
-				return verifier.processCreateRechecksTask(ctx, task)
-			default:
-				panic("Unknown verification task type: " + task.Type)
-			}
-		},
-		"process %#q task %#q",
-		task.Type,
-		task.PrimaryKey,
-	).Run(ctx, verifier.logger)
+	// This retryer is special because it retries an entire task. That can
+	// take a long time, so we configure this retryer with no time limit and
+	// a max attempt limit of 5 (arbitrary) to prevent infinite retries.
+	return retry.New().
+		WithoutTimeLimit().
+		WithMaxAttempts(5).
+		WithCallback(
+			func(ctx context.Context, _ *retry.FuncInfo) error {
+				switch task.Type {
+				case tasks.VerifyCollection:
+					return verifier.ProcessCollectionVerificationTask(ctx, workerNum, task)
+				case tasks.VerifyDocuments:
+					_, err := verifier.ProcessVerifyTask(ctx, workerNum, task)
+					return err
+				case tasks.ProcessRecheckQueue:
+					return verifier.processCreateRechecksTask(ctx, task)
+				default:
+					panic("Unknown verification task type: " + task.Type)
+				}
+			},
+			"process %#q task %#q",
+			task.Type,
+			task.PrimaryKey,
+		).Run(ctx, verifier.logger)
 }
 
 func (verifier *Verifier) processCreateRechecksTask(

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -668,7 +668,7 @@ func (verifier *Verifier) processAnyTask(
 				verifier.clearMismatchesIfRetryingTask(
 					ctx,
 					workerNum,
-					task.PrimaryKey,
+					task,
 					fi.GetAttemptNumber(),
 				)
 
@@ -693,7 +693,7 @@ func (verifier *Verifier) processAnyTask(
 func (verifier *Verifier) clearMismatchesIfRetryingTask(
 	ctx context.Context,
 	workerNum int,
-	taskID bson.ObjectID,
+	task tasks.Task,
 	attemptNumber int,
 ) {
 	if attemptNumber == 0 {
@@ -702,19 +702,19 @@ func (verifier *Verifier) clearMismatchesIfRetryingTask(
 
 	verifier.logger.Info().
 		Int("workerNum", workerNum).
-		Any("task", taskID).
+		Any("task", task.PrimaryKey).
 		Int("attemptNumber", attemptNumber).
 		Msg("Clearing mismatches before retrying task.")
 
 	err := clearMismatchesForTask(
 		ctx,
 		verifier.verificationDatabase(),
-		taskID,
+		task,
 	)
 	if err != nil {
 		verifier.logger.Warn().
 			Err(err).
-			Any("task", taskID).
+			Any("task", task.PrimaryKey).
 			Msg("Failed to clear mismatches before retrying task. You may see duplicate mismatches.")
 	}
 }

--- a/internal/verifier/generation.go
+++ b/internal/verifier/generation.go
@@ -79,8 +79,7 @@ func (v *Verifier) readGeneration(ctx context.Context) (option.Option[int], erro
 	parsed := generationDoc{}
 
 	err := retry.New().WithCallback(
-		func(ctx context.Context, ri *retry.FuncInfo) error {
-			err := db.Collection(generationCollName).FindOne(
+		func(ctx context.Context, _ *retry.FuncInfo) error {
 				ctx,
 				bson.D{},
 			).Decode(&parsed)

--- a/internal/verifier/generation.go
+++ b/internal/verifier/generation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/mongodb-labs/migration-tools/option"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -74,23 +75,32 @@ func (v *Verifier) persistGenerationWhileLocked(ctx context.Context) error {
 func (v *Verifier) readGeneration(ctx context.Context) (option.Option[int], error) {
 	db := v.verificationDatabase()
 
-	result := db.Collection(generationCollName).FindOne(
-		ctx,
-		bson.D{},
-	)
-
+	var foundNothing bool
 	parsed := generationDoc{}
 
-	err := result.Decode(&parsed)
+	err := retry.New().WithCallback(
+		func(ctx context.Context, ri *retry.FuncInfo) error {
+			err := db.Collection(generationCollName).FindOne(
+				ctx,
+				bson.D{},
+			).Decode(&parsed)
+
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				foundNothing = true
+				return nil
+			}
+
+			return err
+		},
+		"read persisted generation",
+	).Run(ctx, v.logger)
 
 	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			err = nil
-		} else {
-			err = errors.Wrap(err, "failed to read persisted generation")
-		}
-
 		return option.None[int](), err
+	}
+
+	if foundNothing {
+		return option.None[int](), nil
 	}
 
 	if parsed.MetadataVersion != verifierMetadataVersion {

--- a/internal/verifier/generation.go
+++ b/internal/verifier/generation.go
@@ -80,6 +80,7 @@ func (v *Verifier) readGeneration(ctx context.Context) (option.Option[int], erro
 
 	err := retry.New().WithCallback(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
+			err := db.Collection(generationCollName).FindOne(
 				ctx,
 				bson.D{},
 			).Decode(&parsed)

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/10gen/migration-verifier/internal/logger"
+	"github.com/10gen/migration-verifier/internal/retry"
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/verifier/namespaces"
 	"github.com/10gen/migration-verifier/mmongo"
@@ -11,7 +12,6 @@ import (
 	"github.com/10gen/migration-verifier/timeseries"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // ListAllUserNamespaces lists all the user collections on a cluster,
@@ -35,21 +35,37 @@ func ListAllUserNamespaces(
 		excluded = append(excluded, e)
 	}
 
-	dbNames, err := client.ListDatabaseNames(ctx, bson.D{
-		{"$and", []bson.D{
-			{{"name", bson.D{{"$nin", excluded}}}},
-			util.ExcludePrefixesQuery("name", namespaces.ExcludedDBPrefixes),
-		}},
-	})
+	var dbNames []string
+	collectionNamespaces := []string{}
+
+	err := retry.New().WithCallback(
+		func(ctx context.Context, ri *retry.FuncInfo) error {
+
+			var err error
+			dbNames, err = client.ListDatabaseNames(ctx, bson.D{
+				{"$and", []bson.D{
+					{{"name", bson.D{{"$nin", excluded}}}},
+					util.ExcludePrefixesQuery("name", namespaces.ExcludedDBPrefixes),
+				}},
+			})
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		"list DB names",
+	).Run(ctx, logger)
 
 	if err != nil {
 		return nil, err
 	}
+
 	logger.Debug().
 		Strs("databases", dbNames).
 		Msg("All user databases.")
 
-	collectionNamespaces := []string{}
 	for _, dbName := range dbNames {
 		db := client.Database(dbName)
 
@@ -65,17 +81,32 @@ func ListAllUserNamespaces(
 			}},
 		}
 
-		specifications, err := db.ListCollectionSpecifications(ctx, filter, options.ListCollections().SetNameOnly(true))
+		var collNames []string
+
+		err := retry.New().WithCallback(
+			func(ctx context.Context, ri *retry.FuncInfo) error {
+				var err error
+				collNames, err = db.ListCollectionNames(ctx, filter)
+				return err
+			},
+			"list DB %#q’s collection names",
+			dbName,
+		).Run(ctx, logger)
+
 		if err != nil {
 			return nil, err
 		}
+
 		logger.Debug().
 			Str("database", dbName).
-			Any("specifications", specifications).
-			Msg("Found database members.")
+			Strs("collections", collNames).
+			Msg("All collection names.")
 
-		for _, spec := range specifications {
-			collectionNamespaces = append(collectionNamespaces, dbName+"."+spec.Name)
+		for _, collName := range collNames {
+			collectionNamespaces = append(
+				collectionNamespaces,
+				dbName+"."+collName,
+			)
 		}
 	}
 	return collectionNamespaces, nil

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -84,7 +84,7 @@ func ListAllUserNamespaces(
 		var collNames []string
 
 		err := retry.New().WithCallback(
-			func(ctx context.Context, ri *retry.FuncInfo) error {
+			func(ctx context.Context, _ *retry.FuncInfo) error {
 				var err error
 				collNames, err = db.ListCollectionNames(ctx, filter)
 				return err

--- a/internal/verifier/list_namespaces.go
+++ b/internal/verifier/list_namespaces.go
@@ -39,7 +39,7 @@ func ListAllUserNamespaces(
 	collectionNamespaces := []string{}
 
 	err := retry.New().WithCallback(
-		func(ctx context.Context, ri *retry.FuncInfo) error {
+		func(ctx context.Context, _ *retry.FuncInfo) error {
 
 			var err error
 			dbNames, err = client.ListDatabaseNames(ctx, bson.D{

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -658,7 +658,11 @@ func mismatchResultsToVerificationResults(mismatch *MismatchDetails, srcClientDo
 	return
 }
 
-func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, task *tasks.Task) error {
+func (verifier *Verifier) ProcessVerifyTask(
+	ctx context.Context,
+	workerNum int,
+	task tasks.Task,
+) (tasks.Task, error) {
 	start := time.Now()
 
 	debugLog := verifier.logger.Debug().
@@ -676,7 +680,7 @@ func (verifier *Verifier) ProcessVerifyTask(ctx context.Context, workerNum int, 
 	reportsResultChan := verifier.FetchAndCompareDocuments(
 		compareCtx,
 		workerNum,
-		task,
+		&task,
 	)
 
 	problemsCount := 0
@@ -688,7 +692,7 @@ REPORTS:
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return tasks.Task{}, ctx.Err()
 		case repResult, open := <-reportsResultChan:
 			if !open {
 				lo.Assertf(
@@ -701,7 +705,7 @@ REPORTS:
 
 			report, err := repResult.Get()
 			if err != nil {
-				return errors.Wrapf(
+				return tasks.Task{}, errors.Wrapf(
 					err,
 					"worker %d failed to process document comparison task %s (namespace: %#q)",
 					workerNum,
@@ -754,7 +758,7 @@ REPORTS:
 					func() error {
 						err := verifier.InsertFailedCompareRecheckDocs(
 							egCtx,
-							task,
+							&task,
 							idsToRecheck,
 							dataSizes,
 							firstMismatchTimes,
@@ -774,7 +778,7 @@ REPORTS:
 					err := recordMismatches(
 						egCtx,
 						verifier.metaClient.Database(verifier.metaDBName),
-						task,
+						&task,
 						problems,
 					)
 
@@ -788,7 +792,7 @@ REPORTS:
 			)
 
 			if err := eg.Wait(); err != nil {
-				return errors.Wrapf(err, "persisting mismatches/rechecks")
+				return tasks.Task{}, errors.Wrapf(err, "persisting mismatches/rechecks")
 			}
 		}
 	}
@@ -818,9 +822,9 @@ REPORTS:
 	task.FoundSourceDocumentsCount = docsCount
 	task.SourceBytesCount = bytesCount
 
-	err := verifier.UpdateVerificationTask(ctx, task)
+	err := verifier.UpdateVerificationTask(ctx, &task)
 	if err != nil {
-		return errors.Wrapf(
+		return tasks.Task{}, errors.Wrapf(
 			err,
 			"failed to persist task %s's new status (%#q)",
 			task.PrimaryKey,
@@ -845,7 +849,7 @@ REPORTS:
 		Stringer("timeElapsed", time.Since(start)).
 		Msg("Finished document comparison task.")
 
-	return nil
+	return task, nil
 }
 
 func (verifier *Verifier) logChunkInfo(ctx context.Context, namespaceAndUUID *uuidutil.NamespaceAndUUID) {
@@ -1062,7 +1066,7 @@ func (verifier *Verifier) compareCollectionSpecifications(
 func (verifier *Verifier) ProcessCollectionVerificationTask(
 	ctx context.Context,
 	workerNum int,
-	task *tasks.Task,
+	task tasks.Task,
 ) error {
 	verifier.logger.Debug().
 		Int("workerNum", workerNum).
@@ -1070,7 +1074,7 @@ func (verifier *Verifier) ProcessCollectionVerificationTask(
 		Str("namespace", task.QueryFilter.Namespace).
 		Msg("Processing collection.")
 
-	err := verifier.verifyMetadataAndPartitionCollection(ctx, workerNum, task)
+	err := verifier.verifyMetadataAndPartitionCollection(ctx, workerNum, &task)
 	if err != nil {
 		return errors.Wrapf(
 			err,
@@ -1081,7 +1085,7 @@ func (verifier *Verifier) ProcessCollectionVerificationTask(
 	}
 
 	return errors.Wrapf(
-		verifier.UpdateVerificationTask(ctx, task),
+		verifier.UpdateVerificationTask(ctx, &task),
 		"failed to update verification task %s's status",
 		task.PrimaryKey,
 	)

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1089,27 +1089,40 @@ func (verifier *Verifier) ProcessCollectionVerificationTask(
 
 func getIndexesMap(
 	ctx context.Context,
+	logger *logger.Logger,
 	coll *mongo.Collection,
 ) (map[string]bson.Raw, error) {
 	var specs []bson.Raw
-	specsMap := map[string]bson.Raw{}
 
-	cursor, err := coll.Indexes().List(ctx)
+	err := retry.New().WithCallback(
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+
+			cursor, err := coll.Indexes().List(ctx)
+			if err != nil {
+				return errors.Wrap(
+					err,
+					"request indexes",
+				)
+			}
+			err = cursor.All(ctx, &specs)
+			if err != nil {
+				return errors.Wrap(
+					err,
+					"parse indexes",
+				)
+			}
+
+			return nil
+		},
+		"fetching %#q’s indexes",
+		FullName(coll),
+	).Run(ctx, logger)
+
 	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to read %#q’s indexes",
-			FullName(coll),
-		)
+		return nil, err
 	}
-	err = cursor.All(ctx, &specs)
-	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to parse %#q’s indexes",
-			FullName(coll),
-		)
-	}
+
+	specsMap := map[string]bson.Raw{}
 
 	for _, spec := range specs {
 		var name string
@@ -1143,7 +1156,7 @@ func (verifier *Verifier) verifyIndexes(
 	srcColl, dstColl *mongo.Collection,
 	srcIdIndexSpec, dstIdIndexSpec bson.Raw,
 ) ([]compare.Result, error) {
-	srcMap, err := getIndexesMap(ctx, srcColl)
+	srcMap, err := getIndexesMap(ctx, verifier.logger, srcColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -1156,7 +1169,7 @@ func (verifier *Verifier) verifyIndexes(
 		srcMap["_id"] = srcIdIndexSpec
 	}
 
-	dstMap, err := getIndexesMap(ctx, dstColl)
+	dstMap, err := getIndexesMap(ctx, verifier.logger, dstColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -1089,40 +1089,27 @@ func (verifier *Verifier) ProcessCollectionVerificationTask(
 
 func getIndexesMap(
 	ctx context.Context,
-	logger *logger.Logger,
 	coll *mongo.Collection,
 ) (map[string]bson.Raw, error) {
 	var specs []bson.Raw
-
-	err := retry.New().WithCallback(
-		func(ctx context.Context, _ *retry.FuncInfo) error {
-
-			cursor, err := coll.Indexes().List(ctx)
-			if err != nil {
-				return errors.Wrap(
-					err,
-					"request indexes",
-				)
-			}
-			err = cursor.All(ctx, &specs)
-			if err != nil {
-				return errors.Wrap(
-					err,
-					"parse indexes",
-				)
-			}
-
-			return nil
-		},
-		"fetching %#q’s indexes",
-		FullName(coll),
-	).Run(ctx, logger)
-
-	if err != nil {
-		return nil, err
-	}
-
 	specsMap := map[string]bson.Raw{}
+
+	cursor, err := coll.Indexes().List(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to read %#q’s indexes",
+			FullName(coll),
+		)
+	}
+	err = cursor.All(ctx, &specs)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to parse %#q’s indexes",
+			FullName(coll),
+		)
+	}
 
 	for _, spec := range specs {
 		var name string
@@ -1156,7 +1143,7 @@ func (verifier *Verifier) verifyIndexes(
 	srcColl, dstColl *mongo.Collection,
 	srcIdIndexSpec, dstIdIndexSpec bson.Raw,
 ) ([]compare.Result, error) {
-	srcMap, err := getIndexesMap(ctx, verifier.logger, srcColl)
+	srcMap, err := getIndexesMap(ctx, srcColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -1169,7 +1156,7 @@ func (verifier *Verifier) verifyIndexes(
 		srcMap["_id"] = srcIdIndexSpec
 	}
 
-	dstMap, err := getIndexesMap(ctx, verifier.logger, dstColl)
+	dstMap, err := getIndexesMap(ctx, dstColl)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -200,7 +200,7 @@ func (suite *IntegrationTestSuite) TestProcessVerifyTask_Failure() {
 		},
 	}
 
-	err := verifier.ProcessVerifyTask(ctx, 12, task)
+	_, err := verifier.ProcessVerifyTask(ctx, 12, *task)
 
 	expectedIDHex := task.PrimaryKey.Hex()
 
@@ -837,7 +837,7 @@ func (suite *IntegrationTestSuite) TestVerifierFetchDocuments_ChangeOpTime() {
 	)
 	suite.Require().NoError(err, "must insert recheck task")
 
-	err = verifier.ProcessVerifyTask(ctx, 0, task)
+	*task, err = verifier.ProcessVerifyTask(ctx, 0, *task)
 	suite.Require().NoError(err)
 
 	verifier.srcLastRecheckedTS.Load(func(ts bson.Timestamp) {

--- a/internal/verifier/mismatches.go
+++ b/internal/verifier/mismatches.go
@@ -587,3 +587,15 @@ func findAndSendMismatches[MT api.AnyMismatchInfo](
 
 	return nil
 }
+
+func clearMismatchesForTask(
+	ctx context.Context,
+	db *mongo.Database,
+	taskID bson.ObjectID,
+) error {
+	_, err := db.Collection(mismatchesCollectionName).DeleteMany(
+		ctx,
+		bson.D{{"taskID", taskID}},
+	)
+	return err
+}

--- a/internal/verifier/mismatches.go
+++ b/internal/verifier/mismatches.go
@@ -598,7 +598,7 @@ func clearMismatchesForTask(
 		bson.D{
 			{"generation", task.Generation},
 			{"taskType", task.Type},
-			{"detail.id", task.PrimaryKey},
+			{"taskID", task.PrimaryKey},
 		},
 	)
 	return err

--- a/internal/verifier/mismatches.go
+++ b/internal/verifier/mismatches.go
@@ -591,11 +591,15 @@ func findAndSendMismatches[MT api.AnyMismatchInfo](
 func clearMismatchesForTask(
 	ctx context.Context,
 	db *mongo.Database,
-	taskID bson.ObjectID,
+	task tasks.Task,
 ) error {
 	_, err := db.Collection(mismatchesCollectionName).DeleteMany(
 		ctx,
-		bson.D{{"taskID", taskID}},
+		bson.D{
+			{"generation", task.Generation},
+			{"taskType", task.Type},
+			{"detail.id", task.PrimaryKey},
+		},
 	)
 	return err
 }

--- a/internal/verifier/mismatches_test.go
+++ b/internal/verifier/mismatches_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/10gen/migration-verifier/internal/verifier/api"
 	"github.com/10gen/migration-verifier/internal/verifier/compare"
+	"github.com/10gen/migration-verifier/internal/verifier/tasks"
 	"github.com/10gen/migration-verifier/mbson"
 	"github.com/10gen/migration-verifier/mslices"
 	"github.com/10gen/migration-verifier/mstrings"
@@ -563,4 +564,50 @@ func (suite *IntegrationTestSuite) TestIndexSpecIgnoreInLogOutput() {
 	// The tally should show.
 	suite.Assert().Regexp(` 13(?:[^0-9]|$)`, output,
 		"log should contain the tolerated-mismatch count")
+}
+
+func (suite *IntegrationTestSuite) TestRecordAndClearMismatches() {
+	verifier := suite.BuildVerifier()
+
+	task := tasks.Task{
+		PrimaryKey: bson.NewObjectID(),
+		Type:       tasks.VerifyDocuments,
+		Generation: verifier.generation,
+	}
+
+	err := recordMismatches(
+		suite.Context(),
+		verifier.verificationDatabase(),
+		&task,
+		[]compare.Result{
+			{
+				ID:      mbson.ToRawValue("doc1"),
+				Field:   "fieldA",
+				Details: "mismatch details A",
+			},
+		},
+	)
+	suite.Require().NoError(err)
+
+	mismatchesChan := make(chan api.DocMismatchInfo, 100)
+
+	err = verifier.SendDocumentMismatches(
+		suite.Context(),
+		0,
+		mismatchesChan,
+	)
+	suite.Require().NoError(err)
+
+	mismatches := lo.ChannelToSlice(mismatchesChan)
+	suite.Assert().Len(mismatches, 1)
+
+	err = clearMismatchesForTask(
+		suite.Context(),
+		verifier.verificationDatabase(),
+		task,
+	)
+	suite.Require().NoError(err)
+
+	mismatches = lo.ChannelToSlice(mismatchesChan)
+	suite.Assert().Empty(mismatches, "mismatches should be cleared")
 }

--- a/internal/verifier/mismatches_test.go
+++ b/internal/verifier/mismatches_test.go
@@ -608,6 +608,15 @@ func (suite *IntegrationTestSuite) TestRecordAndClearMismatches() {
 	)
 	suite.Require().NoError(err)
 
+	mismatchesChan = make(chan api.DocMismatchInfo, 100)
+
+	err = verifier.SendDocumentMismatches(
+		suite.Context(),
+		0,
+		mismatchesChan,
+	)
+	suite.Require().NoError(err)
+
 	mismatches = lo.ChannelToSlice(mismatchesChan)
 	suite.Assert().Empty(mismatches, "mismatches should be cleared")
 }

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -89,24 +89,24 @@ func (verifier *Verifier) ensureCreateRecheckTaskIfNeeded(
 
 	recheckColl := verifier.getRecheckQueueCollection(newGeneration)
 
-	err := recheckColl.FindOne(ctx, bson.D{}).Err()
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		verifier.logger.Info().
-			Int("generation", newGeneration).
-			Msg("Recheck queue is empty. Will thus not create recheck-creation task.")
-
-		return nil
-	} else if err != nil {
-		return errors.Wrapf(err, "fetching %#q’s first document", recheckColl.Name())
-	}
-
-	verifier.logger.Info().
-		Int("generation", newGeneration).
-		Msg("Creating/resetting recheck-creation task.")
-
 	return retry.New().WithCallback(
 		func(ctx context.Context, _ *retry.FuncInfo) error {
-			_, err := verifier.verificationTaskCollection().UpdateOne(
+			err := recheckColl.FindOne(ctx, bson.D{}).Err()
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				verifier.logger.Info().
+					Int("generation", newGeneration).
+					Msg("Recheck queue is empty. Will thus not create recheck-creation task.")
+
+				return nil
+			} else if err != nil {
+				return errors.Wrapf(err, "fetching %#q’s first document", recheckColl.Name())
+			}
+
+			verifier.logger.Info().
+				Int("generation", newGeneration).
+				Msg("Creating/resetting recheck-creation task.")
+
+			_, err = verifier.verificationTaskCollection().UpdateOne(
 				ctx,
 				bson.D{
 					{"generation", newGeneration},

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -285,36 +285,35 @@ func (verifier *Verifier) FindNextVerifyTaskAndUpdate(
 }
 
 func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *tasks.Task) error {
-	return retry.New().WithCallback(
-		func(ctx context.Context, _ *retry.FuncInfo) error {
-			result, err := verifier.verificationTaskCollection().UpdateOne(
-				ctx,
-				bson.M{"_id": task.PrimaryKey},
-				bson.M{
-					"$set": bson.M{
-						"status":                       task.Status,
-						"documents_count":              task.DocumentsCount,
-						"found_source_documents_count": task.FoundSourceDocumentsCount,
-						"source_bytes_count":           task.SourceBytesCount,
-					},
-				},
-			)
-			if err != nil {
-				return err
-			}
-			if result.MatchedCount == 0 {
-				return TaskError{
-					Code:    ErrorUpdateTask,
-					Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey),
-				}
-			}
 
-			return err
+	result, err := verifier.verificationTaskCollection().UpdateOne(
+		ctx,
+		bson.M{"_id": task.PrimaryKey},
+		bson.M{
+			"$set": bson.M{
+				"status":                       task.Status,
+				"documents_count":              task.DocumentsCount,
+				"found_source_documents_count": task.FoundSourceDocumentsCount,
+				"source_bytes_count":           task.SourceBytesCount,
+			},
 		},
-		"updating task %v (namespace %#q)",
-		task.PrimaryKey,
-		task.QueryFilter.Namespace,
-	).Run(ctx, verifier.logger)
+	)
+	if err != nil {
+		return errors.Wrapf(err,
+			"updating task %v (namespace %#q)",
+			task.PrimaryKey,
+			task.QueryFilter.Namespace,
+		)
+	}
+
+	if result.MatchedCount == 0 {
+		return TaskError{
+			Code:    ErrorUpdateTask,
+			Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey),
+		}
+	}
+
+	return nil
 }
 
 func (verifier *Verifier) CreatePrimaryTaskIfNeeded(ctx context.Context) (bool, error) {

--- a/internal/verifier/verification_task.go
+++ b/internal/verifier/verification_task.go
@@ -285,35 +285,36 @@ func (verifier *Verifier) FindNextVerifyTaskAndUpdate(
 }
 
 func (verifier *Verifier) UpdateVerificationTask(ctx context.Context, task *tasks.Task) error {
+	return retry.New().WithCallback(
+		func(ctx context.Context, _ *retry.FuncInfo) error {
+			result, err := verifier.verificationTaskCollection().UpdateOne(
+				ctx,
+				bson.M{"_id": task.PrimaryKey},
+				bson.M{
+					"$set": bson.M{
+						"status":                       task.Status,
+						"documents_count":              task.DocumentsCount,
+						"found_source_documents_count": task.FoundSourceDocumentsCount,
+						"source_bytes_count":           task.SourceBytesCount,
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if result.MatchedCount == 0 {
+				return TaskError{
+					Code:    ErrorUpdateTask,
+					Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey),
+				}
+			}
 
-	result, err := verifier.verificationTaskCollection().UpdateOne(
-		ctx,
-		bson.M{"_id": task.PrimaryKey},
-		bson.M{
-			"$set": bson.M{
-				"status":                       task.Status,
-				"documents_count":              task.DocumentsCount,
-				"found_source_documents_count": task.FoundSourceDocumentsCount,
-				"source_bytes_count":           task.SourceBytesCount,
-			},
+			return err
 		},
-	)
-	if err != nil {
-		return errors.Wrapf(err,
-			"updating task %v (namespace %#q)",
-			task.PrimaryKey,
-			task.QueryFilter.Namespace,
-		)
-	}
-
-	if result.MatchedCount == 0 {
-		return TaskError{
-			Code:    ErrorUpdateTask,
-			Message: fmt.Sprintf(`no matched task updated: "%v"`, task.PrimaryKey),
-		}
-	}
-
-	return nil
+		"updating task %v (namespace %#q)",
+		task.PrimaryKey,
+		task.QueryFilter.Namespace,
+	).Run(ctx, verifier.logger)
 }
 
 func (verifier *Verifier) CreatePrimaryTaskIfNeeded(ctx context.Context) (bool, error) {

--- a/vendor/github.com/ccoveille/go-safecast/v2/conversion.go
+++ b/vendor/github.com/ccoveille/go-safecast/v2/conversion.go
@@ -49,7 +49,7 @@ func RequireConvert[NumOut Number, NumIn Number](t TestingT, orig NumIn) (conver
 //
 // # Errors when conversion is not possible, the following errors are wrapped in the returned error:
 //
-//   - [ErrorUnsupportedConversion] when the conversion is not possible for the desired type (example: NaN to int).
+//   - [ErrUnsupportedConversion] when the conversion is not possible for the desired type (example: NaN to int).
 //   - [ErrStringConversion] when the conversion from string fails (example: "abc" to int).
 //
 // # General errors wrapped on conversion failure:
@@ -89,14 +89,18 @@ func Convert[NumOut Number, NumIn Number](orig NumIn, opts ...ConvertOption) (Nu
 		return converted, getRangeError[NumOut](orig)
 	}
 
-	if !sameSign(orig, converted) {
-		return converted, getRangeError[NumOut](orig)
-	}
-
-	// and compare
 	base := orig
 	if isFloat[NumIn]() {
 		base = NumIn(math.Trunc(float64(orig)))
+	}
+
+	if !sameSign(orig, converted) {
+		if isFloat[NumIn]() && base == 0 {
+			// small fractional values like -0.1 that truncate to 0
+			// are considered to be within range, even if the original value is negative
+			return converted, nil
+		}
+		return converted, getRangeError[NumOut](orig)
 	}
 
 	// convert back to the original type

--- a/vendor/github.com/mongodb-labs/migration-tools/option/option.go
+++ b/vendor/github.com/mongodb-labs/migration-tools/option/option.go
@@ -57,6 +57,14 @@ func None[T any]() Option[T] {
 	return Option[T]{}
 }
 
+// NoneOf is a convenience that calls None for the static (compile-time) type
+// of the provided expression. For example, if you have a value `obj`, you can
+// call `NoneOf(obj)` to get an empty Option for `obj`’s static type without
+// writing the type out explicitly.
+func NoneOf[T any](_ T) Option[T] {
+	return None[T]()
+}
+
 // FromPointer will convert a nilable pointer into its
 // equivalent Option.
 func FromPointer[T any](valPtr *T) Option[T] {
@@ -139,6 +147,14 @@ func (o Option[T]) OrElse(fallback T) T {
 	}
 
 	return fallback
+}
+
+// ToNone returns an empty Option of the receiver’s type.
+// This simplifies “evacuation” of Options. For example:
+//
+//	opt = opt.ToNone()
+func (Option[T]) ToNone() Option[T] {
+	return None[T]()
 }
 
 // ToPointer converts the Option to a nilable pointer.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -42,7 +42,7 @@ github.com/bytedance/sonic/loader/internal/abi
 github.com/bytedance/sonic/loader/internal/iasm/expr
 github.com/bytedance/sonic/loader/internal/iasm/x86_64
 github.com/bytedance/sonic/loader/internal/rt
-# github.com/ccoveille/go-safecast/v2 v2.0.0
+# github.com/ccoveille/go-safecast/v2 v2.0.1
 ## explicit; go 1.21
 github.com/ccoveille/go-safecast/v2
 # github.com/cespare/permute/v2 v2.0.0-beta2
@@ -203,7 +203,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.2
 ## explicit; go 1.12
 github.com/modern-go/reflect2
-# github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0
+# github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877
 ## explicit; go 1.25.7
 github.com/mongodb-labs/migration-tools/bsontools
 github.com/mongodb-labs/migration-tools/future


### PR DESCRIPTION
This fills missing retry gaps:
- Refactors the task-dispatch logic to happen within a retryer. This way, any transient error that causes a task to fail will triggerr a retry of that task.
- `readGeneration` and `ListAllUserNamespaces` now have internal retryers.
- `ensureCreateRecheckTaskIfNeeded` had a retryer that only protected part of its activity. Now all of the function’s server calls happen under that retryer.

Putting all tasks into the retryer necessitated allowing the retryer to limit based solely on the number of iterations. This changeset adds that flexibility.