### PR TITLE
Prevent progress logs from running nonstop

### DIFF
--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -120,8 +120,6 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 			case <-timer.C:
 				verifier.PrintVerificationSummary(egCtx, GenerationInProgress)
 			}
-
-			timer.Stop()
 		}
 	})
 

--- a/internal/verifier/check.go
+++ b/internal/verifier/check.go
@@ -109,18 +109,19 @@ func (verifier *Verifier) CheckWorker(ctxIn context.Context) error {
 	}
 
 	eg.Go(func() error {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-
 		for {
+			timer := time.NewTimer(30 * time.Second)
+
 			select {
 			case <-egCtx.Done():
 				return egCtx.Err()
 			case <-generationDone:
 				return nil
-			case <-ticker.C:
+			case <-timer.C:
 				verifier.PrintVerificationSummary(egCtx, GenerationInProgress)
 			}
+
+			timer.Stop()
 		}
 	})
 


### PR DESCRIPTION
PR #303 made the progress logs start running every 30s, regardless of how much time it takes to create those logs. Thus, if the progress logs take >=30s to create—as can happen when load is very high—Verifier will continually run those logs.

This fixes that bug by waiting 30s from the end of one progress log until the next one starts.