### PR TITLE
Fix hashed-comparison guardrail

### DIFF
--- a/internal/comparehashed/tohashedindexkey.go
+++ b/internal/comparehashed/tohashedindexkey.go
@@ -1,22 +1,44 @@
 package comparehashed
 
-func CanCompareDocsViaToHashedIndexKey(
-	version []int,
-) bool {
+import (
+	"github.com/mongodb-labs/migration-tools/option"
+)
+
+// MinNextVersion returns the nearest server version that supports
+// hashed-index-key document comparison. Returns None if the given version
+// already supports it.
+func MinNextVersion(version []int) option.Option[[]int] {
+	none := option.None[[]int]()
+
 	if version[0] >= 8 {
-		return true
+		return none
 	}
+
+	// NB: The following assumes minor==0. It’s not worth
+	// panicking on if that’s not true, though.
 
 	switch version[0] {
 	case 7:
-		return version[2] >= 6
+		if version[2] >= 6 {
+			return none
+		}
+		return option.Some([]int{7, 0, 6})
 	case 6:
-		return version[2] >= 14
+		if version[2] >= 14 {
+			return none
+		}
+		return option.Some([]int{6, 0, 14})
 	case 5:
-		return version[2] >= 25
+		if version[2] >= 25 {
+			return none
+		}
+		return option.Some([]int{5, 0, 25})
 	case 4:
-		return version[1] == 4 && version[2] >= 29
+		if version[1] == 4 && version[2] >= 29 {
+			return none
+		}
+		return option.Some([]int{4, 4, 29})
 	default:
-		return false
+		return option.Some([]int{4, 4, 29})
 	}
 }

--- a/internal/verifier/compare_test.go
+++ b/internal/verifier/compare_test.go
@@ -530,7 +530,7 @@ func (s *IntegrationTestSuite) TestFetchAndCompareDocuments_BigProblems() {
 
 	// For this test to work we need binary comparison … or else memory usage
 	// will be too modest to trip the failure.
-	verifier.SetDocCompareMethod(compare.Binary)
+	s.Require().NoError(verifier.SetDocCompareMethod(compare.Binary))
 
 	s.Require().NoError(verifier.startChangeHandling(ctx))
 

--- a/internal/verifier/comparehashed_test.go
+++ b/internal/verifier/comparehashed_test.go
@@ -24,8 +24,8 @@ func (suite *IntegrationTestSuite) TestCompare_Hashed() {
 	suite.Require().NoError(err)
 
 	// We only check the source since the destination should be more recent.
-	if !comparehashed.CanCompareDocsViaToHashedIndexKey(buildInfo.VersionArray) {
-		suite.T().Skipf("source (%v) can’t do hashed comparison", buildInfo.VersionArray)
+	if minVer, needed := comparehashed.MinNextVersion(buildInfo.VersionArray).Get(); needed {
+		suite.T().Skipf("source (%v) can’t do hashed comparison; needs at least %v", buildInfo.VersionArray, minVer)
 	}
 
 	decimal128_42, err := bson.ParseDecimal128("42")

--- a/internal/verifier/comparehashed_test.go
+++ b/internal/verifier/comparehashed_test.go
@@ -90,7 +90,7 @@ func (suite *IntegrationTestSuite) TestCompare_Hashed() {
 				verifier.SetSrcNamespaces([]string{ns})
 				verifier.SetDstNamespaces([]string{ns})
 				verifier.SetNamespaceMap()
-				verifier.SetDocCompareMethod(compare.ToHashedIndexKey)
+				suite.Require().NoError(verifier.SetDocCompareMethod(compare.ToHashedIndexKey))
 
 				runner := RunVerifierCheck(ctx, suite.T(), verifier)
 				suite.Require().NoError(runner.AwaitGenerationEnd())

--- a/internal/verifier/integration_test_suite.go
+++ b/internal/verifier/integration_test_suite.go
@@ -203,14 +203,6 @@ func (suite *IntegrationTestSuite) buildVerifierInternal(
 	verifier.verificationStatusCheckInterval = 10 * time.Millisecond
 	verifier.resumeTokenPersistInterval = 10 * time.Millisecond
 
-	docCompareMethod := compare.Default
-	envDocCompareMethod := os.Getenv("MVTEST_DOC_COMPARE_METHOD")
-	if envDocCompareMethod != "" {
-		docCompareMethod = compare.Method(envDocCompareMethod)
-
-		// Forgo validation because the tested code should do that.
-	}
-	verifier.SetDocCompareMethod(docCompareMethod)
 	verifier.SetPartitioningScheme(partitions.SchemeID)
 
 	ctx := suite.Context()
@@ -227,6 +219,18 @@ func (suite *IntegrationTestSuite) buildVerifierInternal(
 		verifier.SetMetaURI(ctx, suite.metaConnStr),
 		"should set metadata connection string",
 	)
+
+	docCompareMethod := compare.Default
+	envDocCompareMethod := os.Getenv("MVTEST_DOC_COMPARE_METHOD")
+	if envDocCompareMethod != "" {
+		docCompareMethod = compare.Method(envDocCompareMethod)
+
+		// Forgo validation because the tested code should do that.
+	}
+	suite.Require().NoError(
+		verifier.SetDocCompareMethod(docCompareMethod),
+	)
+
 	verifier.SetMetaDBName(metaDBName)
 
 	envSrcChangeReader := cmp.Or(

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	_ "net/http/pprof"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,6 +19,7 @@ import (
 	"github.com/10gen/migration-verifier/contextplus"
 	"github.com/10gen/migration-verifier/history"
 	"github.com/10gen/migration-verifier/internal/collspec"
+	"github.com/10gen/migration-verifier/internal/comparehashed"
 	"github.com/10gen/migration-verifier/internal/logger"
 	"github.com/10gen/migration-verifier/internal/partitions"
 	"github.com/10gen/migration-verifier/internal/reportutils"
@@ -381,13 +383,17 @@ func (verifier *Verifier) SetMetaURI(ctx context.Context, uri string) error {
 		return err
 	}
 
-	verifier.logger.Info().
+	verifier.logger.Debug().
 		Msg("Reading metadata’s cluster info.")
 
 	clusterInfo, err := util.GetClusterInfo(ctx, verifier.logger, verifier.metaClient)
 	if err != nil {
 		return errors.Wrap(err, "read metadata cluster info")
 	}
+
+	verifier.logger.Info().
+		Any("clusterInfo", clusterInfo).
+		Msg("Found metadata’s cluster info.")
 
 	verifier.metaURI = uri
 	verifier.metaClusterInfo = &clusterInfo
@@ -479,8 +485,32 @@ func (verifier *Verifier) SetMetaDBName(arg string) {
 	verifier.metaDBName = arg
 }
 
-func (verifier *Verifier) SetDocCompareMethod(method compare.Method) {
+func (verifier *Verifier) SetDocCompareMethod(method compare.Method) error {
+	lo.Assert(
+		verifier.srcClusterInfo != nil,
+		"source cluster info must be set",
+	)
+	lo.Assert(
+		verifier.dstClusterInfo != nil,
+		"destination cluster info must be set",
+	)
+
+	if !slices.Contains(compare.Methods, method) {
+		return errors.Errorf("invalid doc compare method (%s); valid values are: %#q", method, compare.Methods)
+	}
+
+	if method == compare.ToHashedIndexKey {
+		if minVer, needed := comparehashed.MinNextVersion(verifier.srcClusterInfo.VersionArray).Get(); needed {
+			return errors.Errorf("source version %v is too old for document comparison mode %#q; try version %v", verifier.srcClusterInfo.VersionArray, compare.ToHashedIndexKey, minVer)
+		}
+
+		if minVer, needed := comparehashed.MinNextVersion(verifier.dstClusterInfo.VersionArray).Get(); needed {
+			return errors.Errorf("destination version %v is too old for document comparison mode %#q; try version %v", verifier.dstClusterInfo.VersionArray, compare.ToHashedIndexKey, minVer)
+		}
+	}
+
 	verifier.docCompareMethod = method
+	return nil
 }
 
 func (verifier *Verifier) SetPartitioningScheme(method partitions.Scheme) {

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1602,15 +1602,10 @@ func TestVerifierCompareDocs(t *testing.T) {
 	}
 
 	for _, curTest := range compareTests {
-		require.NoError(
-			t,
-			verifier.SetDocCompareMethod(
-				lo.Ternary(
-					!curTest.checkOrder,
-					compare.IgnoreOrder,
-					compare.Binary,
-				),
-			),
+		verifier.docCompareMethod = lo.Ternary(
+			!curTest.checkOrder,
+			compare.IgnoreOrder,
+			compare.Binary,
 		)
 
 		indexFields := curTest.indexFields

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1455,7 +1455,7 @@ func TestVerifierCompareDocs(t *testing.T) {
 
 	id := rand.Intn(1000)
 	verifier := NewVerifier(VerifierSettings{}, "stderr")
-	verifier.SetDocCompareMethod(compare.IgnoreOrder)
+	require.NoError(t, verifier.SetDocCompareMethod(compare.IgnoreOrder))
 
 	type compareTest struct {
 		label       string
@@ -1600,11 +1600,14 @@ func TestVerifierCompareDocs(t *testing.T) {
 	}
 
 	for _, curTest := range compareTests {
-		verifier.SetDocCompareMethod(
-			lo.Ternary(
-				!curTest.checkOrder,
-				compare.IgnoreOrder,
-				compare.Binary,
+		require.NoError(
+			t,
+			verifier.SetDocCompareMethod(
+				lo.Ternary(
+					!curTest.checkOrder,
+					compare.IgnoreOrder,
+					compare.Binary,
+				),
 			),
 		)
 
@@ -2791,7 +2794,7 @@ func (suite *IntegrationTestSuite) TestVerifierWithFilter() {
 	verifier.SetSrcNamespaces([]string{dbname1 + ".testColl1"})
 	verifier.SetDstNamespaces([]string{dbname2 + ".testColl3"})
 	verifier.SetNamespaceMap()
-	verifier.SetDocCompareMethod(compare.IgnoreOrder)
+	suite.Require().NoError(verifier.SetDocCompareMethod(compare.IgnoreOrder))
 	// Set this value low to test the verifier with multiple partitions.
 	verifier.partitionSizeInBytes = 50
 

--- a/internal/verifier/migration_verifier_test.go
+++ b/internal/verifier/migration_verifier_test.go
@@ -1455,7 +1455,9 @@ func TestVerifierCompareDocs(t *testing.T) {
 
 	id := rand.Intn(1000)
 	verifier := NewVerifier(VerifierSettings{}, "stderr")
-	require.NoError(t, verifier.SetDocCompareMethod(compare.IgnoreOrder))
+
+	// set directly to avoid checking server version
+	verifier.docCompareMethod = compare.IgnoreOrder
 
 	type compareTest struct {
 		label       string

--- a/internal/verifier/progress_test.go
+++ b/internal/verifier/progress_test.go
@@ -126,7 +126,9 @@ func (suite *IntegrationTestSuite) TestGetProgress_Gen0StatsHashedReportsActualD
 
 	verifier := suite.BuildVerifier()
 	verifier.SetVerifyAll(true)
-	verifier.SetDocCompareMethod(compare.ToHashedIndexKey)
+	suite.Require().NoError(
+		verifier.SetDocCompareMethod(compare.ToHashedIndexKey),
+	)
 
 	runner := RunVerifierCheck(ctx, suite.T(), verifier)
 	suite.Require().NoError(runner.AwaitGenerationEnd())

--- a/internal/verifier/progress_test.go
+++ b/internal/verifier/progress_test.go
@@ -107,8 +107,8 @@ func (suite *IntegrationTestSuite) TestGetProgress_Gen0StatsHashedReportsActualD
 	)
 	suite.Require().NoError(err)
 
-	if !comparehashed.CanCompareDocsViaToHashedIndexKey(buildInfo.VersionArray) {
-		suite.T().Skipf("source (%v) can't do hashed comparison", buildInfo.VersionArray)
+	if minVer, needed := comparehashed.MinNextVersion(buildInfo.VersionArray).Get(); needed {
+		suite.T().Skipf("source (%v) can't do hashed comparison; needs at least %v", buildInfo.VersionArray, minVer)
 	}
 
 	dbName := suite.DBNameForTest()

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -3,9 +3,7 @@ package verifier
 import (
 	"context"
 
-	"github.com/10gen/migration-verifier/internal/comparehashed"
 	"github.com/10gen/migration-verifier/internal/util"
-	"github.com/10gen/migration-verifier/internal/verifier/compare"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
@@ -23,13 +21,17 @@ func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
 
 	verifier.srcURI = uri
 
-	verifier.logger.Info().
+	verifier.logger.Debug().
 		Msg("Reading source’s cluster info.")
 
 	clusterInfo, err := util.GetClusterInfo(ctx, verifier.logger, verifier.srcClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to read source cluster info")
 	}
+
+	verifier.logger.Info().
+		Any("clusterInfo", clusterInfo).
+		Msg("Found source’s cluster info.")
 
 	verifier.srcClusterInfo = &clusterInfo
 
@@ -52,38 +54,7 @@ func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
 		return errors.Errorf("unsupported source version: %v", clusterInfo.VersionArray)
 	}
 
-	if verifier.docCompareMethod == compare.ToHashedIndexKey {
-		if !comparehashed.CanCompareDocsViaToHashedIndexKey(clusterInfo.VersionArray) {
-			return errors.Errorf("document comparison mode %#q doesn’t work on source version %v", compare.ToHashedIndexKey, clusterInfo.VersionArray)
-		}
-	}
-
-	verifier.maybeSuggestHashedComparisonOptimization()
-
 	return checkURIAgainstServerVersion(uri, clusterInfo)
-}
-
-func (verifier *Verifier) maybeSuggestHashedComparisonOptimization() {
-	if verifier.srcClusterInfo == nil || verifier.dstClusterInfo == nil {
-		// We’re not ready yet.
-		return
-	}
-
-	if verifier.docCompareMethod != compare.Default {
-		// User already gave a non-default comparison method.
-		return
-	}
-
-	if !comparehashed.CanCompareDocsViaToHashedIndexKey(verifier.srcClusterInfo.VersionArray) {
-		return
-	}
-
-	if !comparehashed.CanCompareDocsViaToHashedIndexKey(verifier.dstClusterInfo.VersionArray) {
-		return
-	}
-
-	verifier.logger.Info().
-		Msg("Source & destination cluster seem recent enough to use hashed document comparison, which dramatically accelerates verification. See README for details.")
 }
 
 func isVersionSupported(version []int) bool {
@@ -98,22 +69,20 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 		return errors.Wrapf(err, "failed to connect to destination %#q", uri)
 	}
 
-	verifier.logger.Info().
+	verifier.logger.Debug().
 		Msg("Reading destination’s cluster info.")
 
 	clusterInfo, err := util.GetClusterInfo(ctx, verifier.logger, verifier.dstClient)
 	if err != nil {
-		return errors.Wrap(err, "failed to read destination build info")
+		return errors.Wrap(err, "failed to read destination cluster info")
 	}
+
+	verifier.logger.Info().
+		Any("clusterInfo", clusterInfo).
+		Msg("Found destination’s cluster info.")
 
 	if !isVersionSupported(clusterInfo.VersionArray) {
 		return errors.Errorf("unsupported destination version: %v", clusterInfo.VersionArray)
-	}
-
-	if verifier.docCompareMethod == compare.ToHashedIndexKey {
-		if !comparehashed.CanCompareDocsViaToHashedIndexKey(clusterInfo.VersionArray) {
-			return errors.Errorf("document comparison mode %#q doesn’t work on destination version %v", compare.ToHashedIndexKey, clusterInfo.VersionArray)
-		}
 	}
 
 	verifier.dstClusterInfo = &clusterInfo

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -330,6 +330,10 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 		verifierSettings.ReadConcernSetting = verifier.ReadConcernIgnore
 	}
 
+	logPath := cCtx.String(logPath)
+
+	v := verifier.NewVerifier(verifierSettings, logPath)
+
 	missingStringArgs := lo.Filter(
 		mslices.Of(srcURI, dstURI),
 		func(setting string, _ int) bool {
@@ -338,12 +342,8 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	)
 
 	if len(missingStringArgs) > 0 {
-		return nil, fmt.Errorf("missing required parameters: %#q", missingStringArgs)
+		return v, fmt.Errorf("missing required parameters: %#q", missingStringArgs)
 	}
-
-	logPath := cCtx.String(logPath)
-
-	v := verifier.NewVerifier(verifierSettings, logPath)
 
 	logger := v.GetLogger()
 
@@ -471,10 +471,10 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	v.SetDDLHandling(ddlHandling)
 
 	docCompareMethod := compare.Method(cCtx.String(docCompareMethod))
-	if !slices.Contains(compare.Methods, docCompareMethod) {
-		return nil, errors.Errorf("invalid doc compare method (%s); valid values are: %#q", docCompareMethod, compare.Methods)
+	err = v.SetDocCompareMethod(docCompareMethod)
+	if err != nil {
+		return nil, errors.Wrapf(err, "set doc compare method (%s)", docCompareMethod)
 	}
-	v.SetDocCompareMethod(docCompareMethod)
 
 	partitioningScheme := cCtx.String(partitioningScheme)
 	if !slices.Contains(partitions.Schemes, partitioningScheme) {

--- a/main/migration_verifier.go
+++ b/main/migration_verifier.go
@@ -330,10 +330,6 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 		verifierSettings.ReadConcernSetting = verifier.ReadConcernIgnore
 	}
 
-	logPath := cCtx.String(logPath)
-
-	v := verifier.NewVerifier(verifierSettings, logPath)
-
 	missingStringArgs := lo.Filter(
 		mslices.Of(srcURI, dstURI),
 		func(setting string, _ int) bool {
@@ -342,8 +338,12 @@ func handleArgs(ctx context.Context, cCtx *cli.Context) (*verifier.Verifier, err
 	)
 
 	if len(missingStringArgs) > 0 {
-		return v, fmt.Errorf("missing required parameters: %#q", missingStringArgs)
+		return nil, fmt.Errorf("missing required parameters: %#q", missingStringArgs)
 	}
+
+	logPath := cCtx.String(logPath)
+
+	v := verifier.NewVerifier(verifierSettings, logPath)
 
 	logger := v.GetLogger()
 


### PR DESCRIPTION
Verifier has a guardrail to prevent users from trying to use hashed comparison with server versions that can’t support it. That guardrail, though, has been silently inactive in production due to an ordering bug in the argument validation. As a result, users could see nonsensical errors about, e.g., `$arrayToObject`.

This makes 3 changes:
- Fixes the argument validation so that the guardrail gives a friendlier error.
- Improves the guardrail to show the minimum server version that can support hashed comparison.
- Removes the suggestion to try hashed comparison. (Its performance profile is spotty: sometimes it yields a big improvement, and sometimes it doesn’t improve things at all.)