### PR TITLE
Fix direct-connect when the connection string has an argument.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 
 require (
 	github.com/ccoveille/go-safecast/v2 v2.0.1
-	github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877
+	github.com/mongodb-labs/migration-tools v0.0.0-20260724144220-d12b915e6a0f
 	github.com/samber/slog-zerolog/v2 v2.9.2
 	github.com/wI2L/jsondiff v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0 h1:rc
 github.com/mongodb-labs/migration-tools v0.0.0-20260522185419-3bb2cc4cdea0/go.mod h1:sBx9rr+6+EPgS9hEot8oLGXiBKoiwX6tQ46xKO2g5u4=
 github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877 h1:EZ0cmoqYznA2k/Ro+5cbC8EupnAMIpLbUsiblfsyKM4=
 github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877/go.mod h1:kr/kTzB30NlOUXeib9a/wmT5eysIog/fEpc1T0Ze++U=
+github.com/mongodb-labs/migration-tools v0.0.0-20260724144220-d12b915e6a0f h1:txCdZWZezn1kCtqKiRjx5EyCJNWfFmVW1v6qEQdhqTI=
+github.com/mongodb-labs/migration-tools v0.0.0-20260724144220-d12b915e6a0f/go.mod h1:kr/kTzB30NlOUXeib9a/wmT5eysIog/fEpc1T0Ze++U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -383,6 +383,10 @@ func (verifier *Verifier) SetMetaURI(ctx context.Context, uri string) error {
 		return err
 	}
 
+	if err := verifier.metaClient.Ping(ctx, readpref.Primary()); err != nil {
+		return errors.Wrapf(err, "connect to metadata server (%s)", uri)
+	}
+
 	verifier.logger.Debug().
 		Msg("Reading metadata’s cluster info.")
 

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -273,7 +273,11 @@ func (verifier *Verifier) SetDDLHandling(mode DDLHandling) {
 	verifier.ddlHandling = mode
 }
 
-func (verifier *Verifier) getClientOpts(uri string) *options.ClientOptions {
+func (verifier *Verifier) getClient(
+	ctx context.Context,
+	uri string,
+	rp *readpref.ReadPref,
+) (*mongo.Client, *options.ClientOptions, error) {
 	appName := buildvar.GetClientAppName()
 	opts := &options.ClientOptions{
 		AppName: &appName,
@@ -285,7 +289,20 @@ func (verifier *Verifier) getClientOpts(uri string) *options.ClientOptions {
 		opts.SetReadConcern(readconcern.Majority())
 	})
 
-	return opts
+	if rp != nil {
+		opts.SetReadPreference(rp)
+	}
+
+	client, err := mongo.Connect(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create connection: %w", err)
+	}
+
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return nil, nil, fmt.Errorf("ping: %w", err)
+	}
+
+	return client, opts, nil
 }
 
 func (verifier *Verifier) SetFailureDisplaySize(size int64) {
@@ -376,15 +393,10 @@ func (verifier *Verifier) GetLogger() *logger.Logger {
 }
 
 func (verifier *Verifier) SetMetaURI(ctx context.Context, uri string) error {
-	opts := verifier.getClientOpts(uri)
 	var err error
-	verifier.metaClient, err = mongo.Connect(opts)
+	verifier.metaClient, _, err = verifier.getClient(ctx, uri, readpref.Primary())
 	if err != nil {
-		return err
-	}
-
-	if err := verifier.metaClient.Ping(ctx, readpref.Primary()); err != nil {
-		return errors.Wrapf(err, "connect to metadata server (%s)", uri)
+		return errors.Wrapf(err, "connect to metadata")
 	}
 
 	verifier.logger.Debug().

--- a/internal/verifier/migration_verifier.go
+++ b/internal/verifier/migration_verifier.go
@@ -2,6 +2,7 @@ package verifier
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -298,7 +299,9 @@ func (verifier *Verifier) getClient(
 		return nil, nil, fmt.Errorf("create connection: %w", err)
 	}
 
-	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+	pingRP := cmp.Or(rp, readpref.Primary())
+
+	if err := client.Ping(ctx, pingRP); err != nil {
 		return nil, nil, fmt.Errorf("ping: %w", err)
 	}
 

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
@@ -112,9 +113,11 @@ func checkURIAgainstServerVersion(uri string, bi util.ClusterInfo) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse and validate connection string")
 	}
-	if cs == nil {
-		panic("parsed and validated connection string (" + uri + ") must not be nil")
-	}
+
+	lo.Assert(
+		cs != nil,
+		"parsed and validated connection string must not be nil",
+	)
 
 	// migration-verifier disallows SRV strings for pre-v5 clusters for the
 	// same reason as mongosync’s embedded verifier: mongoses can be added

--- a/internal/verifier/uri.go
+++ b/internal/verifier/uri.go
@@ -5,19 +5,16 @@ import (
 
 	"github.com/10gen/migration-verifier/internal/util"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
 func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
-	opts := verifier.getClientOpts(uri).SetReadPreference(
-		verifier.readPreference,
-	)
-	var err error
-	verifier.srcClient, err = mongo.Connect(opts)
+	client, clientOpts, err := verifier.getClient(ctx, uri, verifier.readPreference)
 	if err != nil {
-		return errors.Wrapf(err, "failed to connect to source %#q", uri)
+		return errors.Wrapf(err, "connect to source")
 	}
+
+	verifier.srcClient = client
 
 	verifier.srcURI = uri
 
@@ -39,7 +36,7 @@ func (verifier *Verifier) SetSrcURI(ctx context.Context, uri string) error {
 		err := RefreshSrcMongosInstances(
 			ctx,
 			verifier.logger,
-			opts,
+			clientOpts,
 		)
 
 		if err != nil {
@@ -62,12 +59,12 @@ func isVersionSupported(version []int) bool {
 }
 
 func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
-	opts := verifier.getClientOpts(uri)
-	var err error
-	verifier.dstClient, err = mongo.Connect(opts)
+	client, clientOpts, err := verifier.getClient(ctx, uri, verifier.readPreference)
 	if err != nil {
-		return errors.Wrapf(err, "failed to connect to destination %#q", uri)
+		return errors.Wrapf(err, "connect to destination")
 	}
+
+	verifier.dstClient = client
 
 	verifier.logger.Debug().
 		Msg("Reading destination’s cluster info.")
@@ -91,7 +88,7 @@ func (verifier *Verifier) SetDstURI(ctx context.Context, uri string) error {
 		err := RefreshDstMongosInstances(
 			ctx,
 			verifier.logger,
-			opts,
+			clientOpts,
 		)
 
 		if err != nil {

--- a/vendor/github.com/mongodb-labs/migration-tools/mongotools/connstring.go
+++ b/vendor/github.com/mongodb-labs/migration-tools/mongotools/connstring.go
@@ -40,7 +40,7 @@ func MaybeAddDirectConnection(in string) (bool, string, error) {
 	}
 
 	_, query, _ := strings.Cut(in, "?")
-	if strings.Contains(query, "&") && !strings.HasSuffix(query, "&") {
+	if len(query) > 0 && !strings.HasSuffix(query, "&") {
 		in += "&"
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.2
 ## explicit; go 1.12
 github.com/modern-go/reflect2
-# github.com/mongodb-labs/migration-tools v0.0.0-20260609163806-88dc31f0c877
+# github.com/mongodb-labs/migration-tools v0.0.0-20260724144220-d12b915e6a0f
 ## explicit; go 1.25.7
 github.com/mongodb-labs/migration-tools/bsontools
 github.com/mongodb-labs/migration-tools/future


### PR DESCRIPTION
Previously connection strings like `mongodb://example.com?authSource=admin` would have a mangled `directConnection` argument postfixed.

This fixes that and adds a preliminary ping to detect connection problems up-front.

It also redacts the connection string from existing connection errors and deduplicates some of the logic to connect to the clusters.